### PR TITLE
Added a few rspec tests to client and resource classes

### DIFF
--- a/lib/oneview-sdk-ruby/resource.rb
+++ b/lib/oneview-sdk-ruby/resource.rb
@@ -20,8 +20,7 @@ module OneviewSDK
       @client = client
       @logger = @client.logger
       set_all(params)
-      api_ver ||= @client.api_version if @client
-      @api_version ||= api_ver || OneviewSDK::Client::DEFAULT_API_VERSION
+      @api_version = api_ver || @client.api_version
     end
 
     # Retrieve resource details based on this resource's name.

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -1,0 +1,8 @@
+RSpec.shared_context 'shared context', a: :b do
+
+  before :each do
+    options = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123' }
+    @client = OneviewSDK::Client.new(options)
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,17 @@ require 'simplecov'
 SimpleCov.start
 
 require 'oneview-sdk-ruby'
+require_relative 'shared_context'
 
 RSpec.configure do |config|
   config.before(:each) do
-    # TODO
+    allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(200)
+    allow_any_instance_of(OneviewSDK::Client).to receive(:login).and_return('secretToken')
+
+    # Clear environment variables
+    %w(ONEVIEWSDK_URL ONEVIEWSDK_USER ONEVIEWSDK_PASSWORD ONEVIEWSDK_TOKEN).each do |name|
+      ENV[name] = nil
+    end
   end
 
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -1,7 +1,112 @@
 require_relative './../spec_helper'
 
 RSpec.describe OneviewSDK::Client do
-  describe '#method_name' do
-    it 'is a pending example'
+
+  describe '#initialize' do
+    it 'creates a client with valid credentials' do
+      options = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123' }
+      client = OneviewSDK::Client.new(options)
+      expect(client.token).to_not be_nil
+    end
+
+    it 'creates a client with a token' do
+      options = { url: 'https://oneview.example.com', token: 'token123' }
+      client = OneviewSDK::Client.new(options)
+      expect(client.token).to eq('token123')
+    end
+
+    it 'requires a token or user-password pair' do
+      options = { url: 'https://oneview.example.com', user: 'Administrator' }
+      expect { OneviewSDK::Client.new(options) }.to raise_error(/Must set user & password options or token/)
+    end
+
+    it 'requires the url attribute to be set' do
+      expect { OneviewSDK::Client.new({}) }.to raise_error(/Must set the url option/)
+    end
+
+    it 'sets the username to "Administrator" by default' do
+      options = { url: 'https://oneview.example.com', password: 'secret123' }
+      client = nil
+      expect { client = OneviewSDK::Client.new(options) }.to output(/User option not set. Using default/).to_stdout_from_any_process
+      expect(client.user).to eq('Administrator')
+    end
+
+    it 'respects credential environment variables' do
+      ENV['ONEVIEWSDK_USER'] = 'Admin'
+      ENV['ONEVIEWSDK_PASSWORD'] = 'secret456'
+      client = OneviewSDK::Client.new(url: 'https://oneview.example.com')
+      expect(client.user).to eq('Admin')
+      expect(client.password).to eq('secret456')
+    end
+
+    it 'respects the token environment variable' do
+      ENV['ONEVIEWSDK_TOKEN'] = 'secret456'
+      client = OneviewSDK::Client.new(url: 'https://oneview.example.com')
+      expect(client.token).to eq('secret456')
+    end
+
+    it 'sets the log level' do
+      options = { url: 'https://oneview.example.com', password: 'secret123', log_level: :error }
+      client = OneviewSDK::Client.new(options)
+      expect(client.log_level).to eq(:error)
+      expect(client.logger.level).to eq(3)
+    end
+
+    it 'picks the lower of the default api version and appliance api version' do
+      allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(120)
+      options = { url: 'https://oneview.example.com', token: 'token123' }
+      client = OneviewSDK::Client.new(options)
+      expect(client.api_version).to eq(120)
+    end
+
+    it 'warns if the api level is greater than the appliance api version' do
+      options = { url: 'https://oneview.example.com', token: 'token123', api_version: 300 }
+      client = nil
+      expect { client = OneviewSDK::Client.new(options) }.to output(/is greater than the appliance API version/).to_stdout_from_any_process
+      expect(client.api_version).to eq(300)
+    end
+  end
+
+  describe '#appliance_api_version' do
+    before :each do
+      allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_call_original
+    end
+
+    it 'gets the api version from the appliance' do
+      allow_any_instance_of(OneviewSDK::Client).to receive(:rest_api).and_return('currentVersion' => '120')
+      options = { url: 'https://oneview.example.com', token: 'token123' }
+      client = OneviewSDK::Client.new(options)
+      expect(client.api_version).to eq(120)
+    end
+
+    it 'sets a default api version value when it cannot be obtained from the appliance' do
+      allow_any_instance_of(OneviewSDK::Client).to receive(:rest_api).and_return({})
+      options = { url: 'https://oneview.example.com', token: 'token123' }
+      client = nil
+      expect { client = OneviewSDK::Client.new(options) }.to output(
+        /Failed to get OneView max api version. Setting to default/).to_stdout_from_any_process
+      expect(client.api_version).to eq(200)
+    end
+  end
+
+  describe '#login' do
+    before :each do
+      allow_any_instance_of(OneviewSDK::Client).to receive(:login).and_call_original
+    end
+
+    it 'gets a token from the appliance' do
+      allow_any_instance_of(OneviewSDK::Client).to receive(:rest_api).and_return('sessionID' => 'secret789')
+      options = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123' }
+      client = OneviewSDK::Client.new(options)
+      expect(client.token).to eq('secret789')
+    end
+
+    it 'tries twice to get a token from the appliance' do
+      allow_any_instance_of(OneviewSDK::Client).to receive(:rest_api).and_return({})
+      options = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123', log_level: :debug }
+      expect { OneviewSDK::Client.new(options) rescue nil }.to output(/Retrying.../).to_stdout_from_any_process
+      options.delete(:log_level)
+      expect { OneviewSDK::Client.new(options) }.to raise_error(/Couldn't log into OneView server/)
+    end
   end
 end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1,0 +1,40 @@
+require_relative './../spec_helper'
+
+RSpec.describe OneviewSDK::Client do
+  include_context 'shared context'
+
+  describe '#initialize' do
+    it 'uses the client\'s logger' do
+      res = OneviewSDK::Resource.new(@client)
+      expect(res.logger).to eq(@client.logger)
+    end
+
+    it 'uses the client\'s api version' do
+      res = OneviewSDK::Resource.new(@client)
+      expect(res.api_version).to eq(@client.api_version)
+    end
+
+    it 'can override the client\'s api version' do
+      res = OneviewSDK::Resource.new(@client, {}, 120)
+      expect(res.api_version).to_not eq(@client.api_version)
+      expect(res.api_version).to eq(120)
+    end
+
+    it 'has a base subset of attributes' do
+      res = OneviewSDK::Resource.new(@client)
+      expect(res.uri).to be_nil
+    end
+
+    it 'sets the provided attributes' do
+      res = OneviewSDK::Resource.new(@client, name: 'Test', description: 'None')
+      expect(res.name).to eq('Test')
+      expect(res.description).to eq('None')
+    end
+
+    it 'does not allow reserved method names to be used as attribute names' do
+      res = nil
+      expect { res = OneviewSDK::Resource.new(@client, to_hash: 'Val') }.to output(/that's a reserved method/).to_stdout_from_any_process
+      expect(res.to_hash).to_not eq('Val')
+    end
+  end
+end


### PR DESCRIPTION
This is a very small start to testing, but (hopefully) a good one nonetheless. Tests client and resource initializers. Now we should be running `rake test` at the minimum before uploading code or creating a PR.
