### PR TITLE
#5 FC Networks

### DIFF
--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -1,14 +1,12 @@
 require_relative '_client' # Gives access to @client
 
 # Example: Create an fc network
-# NOTE: This will create an fc network named 'san01', then delete it.
+# NOTE: This will create an fc network named 'OneViewSDK Test FC Network', then delete it.
 options = {
-  name: 'san01',
+  name: 'OneViewSDK Test FC Network',
   connectionTemplateUri: nil,
-  linkStabilityTime: 30,
   autoLoginRedistribution: true,
-  fabricType: 'FabricAttach',
-  type: 'fc-networkV2'
+  fabricType: 'FabricAttach'
 }
 
 fc = OneviewSDK::FCNetwork.new(@client, options)

--- a/lib/oneview-sdk-ruby/resource/fc_network.rb
+++ b/lib/oneview-sdk-ruby/resource/fc_network.rb
@@ -8,7 +8,7 @@ module OneviewSDK
   #   description
   #   eTag
   #   fabricType (Required)
-  #   linkStabilityTime (Required)
+  #   linkStabilityTime (Required for FabricAttach)
   #   managedSunUri
   #   modified
   #   name (Required)
@@ -32,6 +32,7 @@ module OneviewSDK
     end
 
     def validate_linkStabilityTime(value)
+      return unless @data['fabricType'] && @data['fabricType'] == 'FabricAttach'
       fail 'Link stability time out of range 1..1800' unless value.between?(1, 1800)
     end
 

--- a/spec/unit/resource/fc_network_spec.rb
+++ b/spec/unit/resource/fc_network_spec.rb
@@ -20,8 +20,13 @@ RSpec.describe OneviewSDK::Client do
     end
 
     it 'validates linkStabilityTime' do
-      options = { linkStabilityTime: 0 }
+      options = { fabricType: 'FabricAttach', linkStabilityTime: 0 }
       expect { OneviewSDK::FCNetwork.new(@client, options) }.to raise_error(/Link stability time out of range/)
+    end
+
+    it 'does not validate linkStabilityTime for DirectAttach networks' do
+      options = { fabricType: 'DirectAttach', linkStabilityTime: 0 }
+      expect { OneviewSDK::FCNetwork.new(@client, options) }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
## QA Description

Fixes #5

Implement create, delete and retrieve fc networks for HP OneView
### Setup
- [x] Make a copy of examples/_client.rb.example
- [x] Rename it to _client.rb
- [x] Fill your HP OneView credentials
- [x] Make sure there isn't a network with the name **OneViewSDK Test FC Network**
### Running Example
- [x] Go to examples folder
- [x] Run `$ruby fc_network.rb`
### Expected Results
- [x] An fc network must be created with name **OneViewSDK Test FC Network**
- [x] This same network must be correctly retrieved from OneView
- [x] In the end this fc network must be successfully deleted
- [x] You must be able to see all other fc networks listed in HP OneView except from the one that was created
- [x] It must pass rubocop and rspec tests by running  rake test  
