### PR TITLE
find_by handles paginated results

### DIFF
--- a/lib/oneview-sdk-ruby/resource.rb
+++ b/lib/oneview-sdk-ruby/resource.rb
@@ -177,7 +177,7 @@ module OneviewSDK
     def self.find_by(client, attributes)
       results = []
       uri = self::BASE_URI
-      10.times do
+      loop do
         response = client.rest_get(uri)
         members = response['members']
         members.each do |member|


### PR DESCRIPTION
This allows the find_by method to go through a paginated list if additional resources match the query but could not be put into the first response. Right now it only loops through 10 times to prevent an infinite loop or huge amount of resources, but we can sure change that depending on what you guys think.

I couldn't find anywhere else we'd want to do this kind of logic, but if you think of any, I can sure add them.
