### PR TITLE
updated cli search and recursive_like

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,43 @@ Resources can be saved to files and loaded again very easily using the built-in 
 
 For more examples and test-scripts, see the [examples](examples/) directory and [rubydoc.info](http://www.rubydoc.info/gems/oneview-sdk-ruby) documentation.
 
+## CLI
+This gem also comes with a command-line interface to make interracting with OneView possible without the need to create a Ruby program or script.
+
+To get started, run `$ ruby-sdk-ruby --help`.
+
+To communicate with an appliace, you'll need to set up a few environment variables so it knows how to communicate. Run `$ ruby-sdk-ruby env` to see the available environment variables.
+
+The CLI doesn't expose everything in the sdk, but it is great for doing simple tasks such as creating or deleting resources from files, listing resources, and searching. Here's a few examples:
+
+ - List ServerProfiles: 
+ ```bash
+ oneview-sdk-ruby list ServerProfiles
+ # Or to show in yaml format (json is also supported):
+ oneview-sdk-ruby list ServerProfiles -f yaml
+ ```
+ 
+ - Show details for a specific resource:
+ ```bash
+ oneview-sdk-ruby show ServerProfile profile-1
+ # Or to show specific attributes only:
+ oneview-sdk-ruby show ServerProfile profile-1 -a name,uri,enclosureBay
+ ```
+ 
+ - Search by an attribute:
+ ```bash
+ oneview-sdk-ruby search ServerProfiles --filter state:Normal affinity:Bay
+ # Again, you can show only certain attributes by using the -a option
+ # You can also chain keys together to search in nested hashes:
+ oneview-sdk-ruby search ServerProfiles --filter state:Normal boot.manageBoot:true
+ ```
+ 
+ - Create or delete resource by file:
+ ```bash
+ oneview-sdk-ruby create_from_file /my-server-profile.json
+ oneview-sdk-ruby delete_from_file /my-server-profile.json
+ ```
+
 ## Contributing
 You know the drill. Fork it, branch it, change it, commit it, and pull-request it. We're passionate about improving this project, and glad to accept help to make it better.
 

--- a/lib/oneview-sdk-ruby/resource.rb
+++ b/lib/oneview-sdk-ruby/resource.rb
@@ -221,7 +221,7 @@ module OneviewSDK
       other.each do |key, val|
         return false unless data && data.respond_to?(:[])
         if val.is_a?(Hash)
-          return false unless recursive_like?(val, data[key.to_s])
+          return false unless data.class == Hash && recursive_like?(val, data[key.to_s])
         else
           return false if val != data[key.to_s]
         end

--- a/spec/unit/cli/search_spec.rb
+++ b/spec/unit/cli/search_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe OneviewSDK::Cli do
         expect { OneviewSDK::Cli.start(%w(search ServerProfile -f yaml --filter description:Blah -a uri)) }
           .to output(out.to_yaml).to_stdout_from_any_process
       end
+
+      it 'allows attribute chaining' do
+        expect(OneviewSDK::Resource).to receive(:find_by).with(OneviewSDK::Client, 'key1' => { 'key2' => { 'key3' => 'Blah' } })
+        out = [@resource_data.merge('type' => 'ServerProfileV5'), @resource_data2.merge('type' => 'ServerProfileV5')]
+        expect { OneviewSDK::Cli.start(%w(search ServerProfile -f yaml --filter key1.key2.key3:Blah)) }
+          .to output(out.to_yaml).to_stdout_from_any_process
+      end
     end
 
   end


### PR DESCRIPTION
This allows chaining for the cli search and fixes a bug in the recursive_like? method. There was a problem when an array existed where a hash was given as search data. The functionality still isn't super awesome, because if you want to compare a resource value inside an array, you must give the entire array.
