### PR TITLE
gemspec update

### DIFF
--- a/oneview-sdk.gemspec
+++ b/oneview-sdk.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
   spec.homepage      = 'https://github.com/HewlettPackard/oneview-sdk-ruby'
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)/)
+  all_files = `git ls-files -z`.split("\x0")
+  spec.files         = all_files.reject { |f| f.match(%r{^(examples\/)|(spec\/)}) }
+  spec.executables   = all_files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # spec.add_runtime_dependency ''
+  spec.add_runtime_dependency 'thor'
   spec.add_runtime_dependency 'highline'
 
   spec.add_development_dependency 'bundler'
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'thor'
   spec.add_development_dependency 'pry'
 
 end


### PR DESCRIPTION
Our previous gemspec basically included ALL files in source control in the package that is built.  This probably wasn't a huge problem until I added the test .rpm file in PR #37 , which increased the size of the package from like 30 KB to 400 KB. In general, including the spec directory and examples directory in the packaged gem is pretty useless, as they are not used by the end-user. This saves them some bandwidth.

Also, the `spec.test_files` directive, from what I found, is a deprecated, useless directive that just adds things to the `spec.files` array. It doesn't run tests or do anything special with them, so I removed it.

Finally, I moved `thor` from a development dependency to a runtime dependency, because the cli requires thor to run.
