### PR TITLE
support usage of undefined resources

### DIFF
--- a/lib/oneview-sdk-ruby/resource.rb
+++ b/lib/oneview-sdk-ruby/resource.rb
@@ -3,13 +3,14 @@ require_relative 'client'
 module OneviewSDK
   # Resource base class that defines all common resource functionality.
   class Resource
-    BASE_URI = '/rest'
+    BASE_URI = nil # Overridden in individual resource classes
 
     attr_accessor \
       :client,
       :data,
       :api_version,
-      :logger
+      :logger,
+      :base_uri # Use only for undefined resources (this class)
 
     # Create client object, establish connection, and set up logging and api version.
     # @param [Client] client The Client object with a connection to the OneView appliance
@@ -116,7 +117,7 @@ module OneviewSDK
     # @return [Resource] self
     def create
       ensure_client
-      response = @client.rest_post(self.class::BASE_URI, { 'body' => @data }, @api_version)
+      response = @client.rest_post(self.class::BASE_URI || @base_uri, { 'body' => @data }, @api_version)
       body = @client.response_handler(response)
       set_all(body)
       self
@@ -197,7 +198,7 @@ module OneviewSDK
     # @return [Array<Resource>] Results matching the search
     def self.find_by(client, attributes)
       results = []
-      uri = self::BASE_URI
+      uri = self::BASE_URI || @base_uri
       loop do
         response = JSON.parse(client.rest_get(uri).body)
         members = response['members']

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe OneviewSDK::Resource do
       expect(res[:name]).to eq('Test')
       expect(res['description']).to eq('None')
     end
+
+    it 'allows setting the base_uri for undefined classes' do
+      base_uri = '/rest/my-resource'
+      allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return(uri: "#{base_uri}/1")
+      res = OneviewSDK::Resource.new(@client)
+      res.base_uri = base_uri
+      expect(@client).to receive(:rest_post).with(base_uri, { 'body' => res.data }, res.api_version)
+      res.create
+      expect(res[:uri]).to eq("#{base_uri}/1")
+    end
   end
 
   describe '#like?' do


### PR DESCRIPTION
There's a lot of resources in OneView, and the goal is to get to all of them, but until we do, it may be useful to allow the `OneviewSDK::Resource` class to be flexible enough to handle those undefined resources in the best way it can.

I've added a `@base_uri` instance variable, which can be set and used like so:

``` ruby
r = OneviewSDK::Resource.new(@client, options)
r.base_uri = '/rest/my-resource'
r.create
r.delete
```

Granted, some resources don't support certain actions, or require special treatment, but this will at least support the ones that are semi-standard. For the most part, the find_by, retrieve!, and refresh methods should work for about anything.

This was just an idea I had, and it might be a bad one, so let me know if this is even something we'd want to do. If not, my feelings won't be hurt lol
