### PR TITLE
Extend Ethernet Network Functions

### DIFF
--- a/examples/ethernet_network.rb
+++ b/examples/ethernet_network.rb
@@ -3,15 +3,16 @@ require_relative '_client' # Gives access to @client
 # Example: Create an ethernet network
 # NOTE: This will create an ethernet network named 'OneViewSDK Test Vlan', then delete it.
 options = {
-  vlanId:  1001,
+  vlanId:  '1001',
   purpose:  'General',
   name:  'OneViewSDK Test Vlan',
   smartLink:  false,
   privateNetwork:  false,
-  connectionTemplateUri:  nil,
+  connectionTemplateUri: nil,
   type:  'ethernet-networkV3'
 }
 
+# Creating a ethernet network
 ethernet = OneviewSDK::EthernetNetwork.new(@client, options)
 ethernet.create
 puts "\nCreated ethernet-network '#{ethernet[:name]}' sucessfully.\n  uri = '#{ethernet[:uri]}'"
@@ -21,19 +22,33 @@ matches = OneviewSDK::EthernetNetwork.find_by(@client, name: ethernet[:name])
 ethernet2 = matches.first
 puts "\nFound ethernet-network by name: '#{ethernet[:name]}'.\n  uri = '#{ethernet2[:uri]}'"
 
+# Update purpose and smartLink settings from recently created network
+attributes = {
+  purpose: 'Management',
+  smartLink: true
+}
+ethernet2.update(attributes)
+puts "\nUpdated ethernet-network: '#{ethernet[:name]}'.\n  uri = '#{ethernet2[:uri]}'"
+puts "with attributes: #{attributes}"
+
+# Get associated profiles
+puts "\nSuccessfully retrieved associated profiles: #{ethernet2.get_associated_profiles}"
+
+# Get associated uplink groups
+puts "\nSuccessfully retrieved associated uplink groups: #{ethernet2.get_associated_uplink_groups}"
+
 # Retrieve recently created network
 ethernet3 = OneviewSDK::EthernetNetwork.new(@client, name: ethernet[:name])
 ethernet3.retrieve!
 puts "\nRetrieved ethernet-network data by name: '#{ethernet[:name]}'.\n  uri = '#{ethernet3[:uri]}'"
 
-# Delete this network
-ethernet2.delete
-puts "\nSucessfully deleted ethernet-network '#{ethernet[:name]}'."
-
-
 # Example: List all ethernet networks with certain attributes
-attributes = { purpose: 'General' }
+attributes = { purpose: 'Management' }
 puts "\n\nEthernet networks with #{attributes}"
 OneviewSDK::EthernetNetwork.find_by(@client, attributes).each do |network|
   puts "  #{network[:name]}"
 end
+
+# Delete this network
+ethernet2.delete
+puts "\nSucessfully deleted ethernet-network '#{ethernet[:name]}'."

--- a/lib/oneview-sdk-ruby/resource/ethernet_network.rb
+++ b/lib/oneview-sdk-ruby/resource/ethernet_network.rb
@@ -32,6 +32,20 @@ module OneviewSDK
       end
     end
 
+    # Get associatedProfiles
+    def get_associated_profiles
+      ensure_client && ensure_uri
+      response = @client.rest_get("#{@data['uri']}/associatedProfiles", @api_version)
+      response.body
+    end
+
+    # Get associatedUplinkGroups
+    def get_associated_uplink_groups
+      ensure_client && ensure_uri
+      response = @client.rest_get("#{@data['uri']}/associatedUplinkGroups", @api_version)
+      response.body
+    end
+
     # Validate ethernetNetworkType
     # @param [String] value Notapplicable, Tagged, Tunnel, Unknown, Untagged
     def validate_ethernetNetworkType(value)

--- a/spec/unit/resource/ethernet_network_spec.rb
+++ b/spec/unit/resource/ethernet_network_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe OneviewSDK::EthernetNetwork do
+  include_context 'shared context'
+
+  describe '#initialize' do
+    it 'sets the defaults correctly api_ver 120' do
+      item = OneviewSDK::EthernetNetwork.new(@client, {}, 120)
+      expect(item[:ethernetNetworkType]).to eq('Tagged')
+      expect(item[:type]).to eq('ethernet-networkV2')
+    end
+    it 'sets the defaults correctly api_ver 200' do
+      item = OneviewSDK::EthernetNetwork.new(@client, {}, 200)
+      expect(item[:ethernetNetworkType]).to eq('Tagged')
+      expect(item[:type]).to eq('ethernet-networkV3')
+    end
+  end
+
+  describe 'validations' do
+    it 'validates ethernetNetworkType' do
+      options = { ethernetNetworkType: 'FakeType' }
+      expect { OneviewSDK::EthernetNetwork.new(@client, options) }.to raise_error(/Invalid network type/)
+    end
+
+    it 'validates purpose' do
+      options = { purpose: 'Fake' }
+      expect { OneviewSDK::EthernetNetwork.new(@client, options) }.to raise_error(/Invalid ethernet purpose/)
+    end
+
+  end
+end


### PR DESCRIPTION
run examples/ethernet_network.rb
## QA Description
- [x] You should see 'OneViewSDK Test Vlan' ethernet network at OneView while running the script. 
- [x]  'OneViewSDK Test Vlan' ethernet network must disappear at OneView after the end of the script. 
### Script output

Connected to OneView appliance at https://<hostname or ip>

Created ethernet-network 'OneViewSDK Test Vlan' sucessfully.
  uri = '/rest/ethernet-networks/<id>'

Found ethernet-network by name: 'OneViewSDK Test Vlan'.
  uri = '/rest/ethernet-networks/<id>'

Updated ethernet-network: 'OneViewSDK Test Vlan'.
  uri = '/rest/ethernet-networks/<id>'
with attributes: {:purpose=>"Management", :smartLink=>true}

Successfully retrieved associated profiles: []

Successfully retrieved associated uplink groups: []

Retrieved ethernet-network data by name: 'OneViewSDK Test Vlan'.
  uri = '/rest/ethernet-networks/<id>'

Ethernet networks with {:purpose=>"Management"}
  <Network list with purpose = Management>
  OneViewSDK Test Vlan

Sucessfully deleted ethernet-network 'OneViewSDK Test Vlan'.
