### PR TITLE
full fc network implementation

### DIFF
--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -36,9 +36,6 @@ OneviewSDK::FCNetwork.find_by(@client, attributes).each do |network|
   puts "  #{network[:name]}"
 end
 
-# Get the fc networks schema
-puts "\nSuccessfully retrieved fc-networks schema: #{fc2.get_schema}"
-
 # Delete this network
 fc3.delete
 puts "\nSucessfully deleted fc-network '#{fc3[:name]}'."

--- a/lib/oneview-sdk-ruby/resource/fc_network.rb
+++ b/lib/oneview-sdk-ruby/resource/fc_network.rb
@@ -27,13 +27,6 @@ module OneviewSDK
       @data['fabricType'] ||= 'FabricAttach'
     end
 
-    # Get fc networks schema
-    def get_schema
-      ensure_client && ensure_uri
-      response = @client.rest_get("#{@data['uri']}/schema", @api_version)
-      response.body
-    end
-
     def validate_fabricType(value)
       fail 'Invalid fabric type' unless %w(DirectAttach FabricAttach).include?(value)
     end


### PR DESCRIPTION
run examples/fc_network.rb
## QA Description
- [x] You should see 'OneViewSDK Test FC Network' fc network at OneView while running the script. 
- [x]  'OneViewSDK Test FC Network' fc network must disappear at OneView after the end of the script. 
### Script output

Connected to OneView appliance at https://`<hostname>`

Created fc-network 'OneViewSDK Test FC Network' sucessfully.
  uri = '/rest/fc-networks/`<id>`'

Found fc-network by name: 'OneViewSDK Test FC Network'.
  uri = '/rest/fc-networks/`<id>`'

Retrieved fc-network data by name: 'OneViewSDK Test FC Network'.
  uri = '/rest/fc-networks/`<id>`'

Updated fc-network: 'OneViewSDK Test FC Network'.
  uri = '/rest/fc-networks/`<id>`'
with attribute: {:autoLoginRedistribution=>false}

FC networks with {:fabricType=>"FabricAttach"}
`<Network list with fabricType = FabricAttach>`
  OneViewSDK Test FC Network

Sucessfully deleted fc-network 'OneViewSDK Test FC Network'.
