### PR TITLE
Added schema for resources

### DIFF
--- a/lib/oneview-sdk-ruby/resource.rb
+++ b/lib/oneview-sdk-ruby/resource.rb
@@ -194,6 +194,23 @@ module OneviewSDK
       true
     end
 
+    # Get resource schema
+    # @return [Hash] Schema
+    def schema
+      self.class.schema(@client)
+    end
+
+    # Get resource schema
+    # @param [Client] client
+    # @return [Hash] Schema
+    def self.schema(client)
+      response = client.rest_get("#{self::BASE_URI}/schema", client.api_version)
+      client.response_handler(response)
+    rescue StandardError => e
+      client.logger.error('This resource does not implement the schema endpoint!') if e.message.match(/404 NOT FOUND/)
+      raise e
+    end
+
     # Load resource from .json or .yaml file
     # @param [Client] client The client object to associate this resource with
     # @param [String] file_path The full path to the file


### PR DESCRIPTION
This adds the schema endpoint for resources that implement it. If the resource doesn't implement it, it will raise a 404 error.

Depending on what future versions of OneView will do, we may or may not want to merge this. I think there's an understanding that it needs to be consistent, but if that means they'll remove it for all resources, we can scrub this PR.

Where did we end up on the schema discussion?
