### PR TITLE
Fixed resource_named for Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,9 @@ Style/AccessorMethodName:
 Style/EmptyLines:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/IndentArray:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 rvm:
   - 2.1
+  - 2.2.5
+  - 2.3.1
+
+before_install: gem update bundler
 
 script:
   - rake build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### v2.0.1
+### v2.1.0
  - Fixed issue with the :resource_named method for OneViewSDK::Resource in Ruby 2.3
 
 # v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v2.0.1
+ - Fixed issue with the :resource_named method for OneViewSDK::Resource in Ruby 2.3
+
 # v2.0.0
 ### Notes
  This is the second version of the Ruby SDK for HPE OneView. It was given support to the major features of OneView, refactor in some of the already existing code, and also a full set of exceptions to make some common exceptions more explicit in the debugging process.

--- a/lib/oneview-sdk/cli.rb
+++ b/lib/oneview-sdk/cli.rb
@@ -333,8 +333,10 @@ module OneviewSDK
     # Get resource class from given string
     def parse_type(type)
       valid_classes = []
-      ObjectSpace.each_object(Class).select { |klass| klass < OneviewSDK::Resource }.each do |c|
-        valid_classes.push(c.name.split('::').last)
+      OneviewSDK.constants.each do |c|
+        klass = OneviewSDK.const_get(c)
+        next unless klass.is_a?(Class) && klass < OneviewSDK::Resource
+        valid_classes.push(klass.name.split('::').last)
       end
       OneviewSDK.resource_named(type) || fail_nice("Invalid resource type: '#{type}'.\n  Valid options are #{valid_classes}")
     end

--- a/lib/oneview-sdk/resource.rb
+++ b/lib/oneview-sdk/resource.rb
@@ -336,11 +336,13 @@ module OneviewSDK
   def self.resource_named(type)
     classes = {}
     orig_classes = []
-    ObjectSpace.each_object(Class).select { |klass| klass < OneviewSDK::Resource }.each do |c|
-      name = c.name.split('::').last
+    OneviewSDK.constants.each do |c|
+      klass = OneviewSDK.const_get(c)
+      next unless klass.is_a?(Class) && klass < OneviewSDK::Resource
+      name = klass.name.split('::').last
       orig_classes.push(name)
-      classes[name.downcase.delete('_').delete('-')] = c
-      classes["#{name.downcase.delete('_').delete('-')}s"] = c
+      classes[name.downcase.delete('_').delete('-')] = klass
+      classes["#{name.downcase.delete('_').delete('-')}s"] = klass
     end
     new_type = type.to_s.downcase.gsub(/[ -_]/, '')
     return classes[new_type] if classes.keys.include?(new_type)

--- a/lib/oneview-sdk/version.rb
+++ b/lib/oneview-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module OneviewSDK
-  VERSION = '2.0.1'.freeze
+  VERSION = '2.1.0'.freeze
 end

--- a/lib/oneview-sdk/version.rb
+++ b/lib/oneview-sdk/version.rb
@@ -1,7 +1,7 @@
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module OneviewSDK
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end


### PR DESCRIPTION
In Ruby 2.3, our methods to convert a string to a class name had issues. This fix should also be a lot faster; we're no longer looping through the entire ObjectSpace.

I recommend releasing after this fix.
cc @hdiomede , @tmiotto 