### PR TITLE
Added rest and update CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v2.2.0
+ - Added the 'rest' and 'update' commands to the CLI
+ - Removed the --force option from the create_from_file CLI command
+
 ### v2.1.0
  - Fixed issue with the :resource_named method for OneViewSDK::Resource in Ruby 2.3
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Each OneView resource is exposed for usage with CRUD-like functionality.
 
 For example, once you instantiate a resource object, you can call intuitive methods such as `resource.create`, `resource.udpate` and `resource.delete`. In addition, resources respond to helpful methods such as `.each`, `.eql?(other_resource)`, `.like(other_resource)`, `.retrieve!`, and many others.
 
-Please see the [rubydoc.info](http://www.rubydoc.info/gems/oneview-sdk) documentation for the complete list and usage details, but here are a few examples to get you started:
+Please see the [rubydoc.info](http://www.rubydoc.info/gems/oneview-sdk) documentation for complete usage details and the [examples](examples/) directory for more examples and test-scripts, but here are a few examples to get you started:
 
 ##### Create a resource
 
@@ -262,6 +262,13 @@ $ oneview-sdk-ruby search ServerProfiles --filter state:Normal boot.manageBoot:t
 ```bash
 $ oneview-sdk-ruby create_from_file /my-server-profile.json
 $ oneview-sdk-ruby delete_from_file /my-server-profile.json
+```
+
+##### Update a resource by name:
+
+```bash
+$ oneview-sdk-ruby update FCNetwork FC1 -h linkStabilityTime:20  # Using hash format
+$ oneview-sdk-ruby update Volume VOL_01 -j '{"shareable": true}' # Using json format
 ```
 
 ##### Start an interactive console session with a OneView connection:

--- a/README.md
+++ b/README.md
@@ -264,11 +264,18 @@ $ oneview-sdk-ruby create_from_file /my-server-profile.json
 $ oneview-sdk-ruby delete_from_file /my-server-profile.json
 ```
 
-##### Update a resource by name:
+##### Update resources by name:
 
 ```bash
 $ oneview-sdk-ruby update FCNetwork FC1 -h linkStabilityTime:20  # Using hash format
 $ oneview-sdk-ruby update Volume VOL_01 -j '{"shareable": true}' # Using json format
+```
+
+##### Make REST calls:
+
+```bash
+$ oneview-sdk-ruby rest get rest/fc-networks
+$ oneview-sdk-ruby rest PUT rest/enclosures/<id>/configuration
 ```
 
 ##### Start an interactive console session with a OneView connection:

--- a/lib/oneview-sdk/rest.rb
+++ b/lib/oneview-sdk/rest.rb
@@ -180,7 +180,7 @@ module OneviewSDK
       when :delete
         request = Net::HTTP::Delete.new(uri.request_uri)
       else
-        fail InvalidRequest, "Invalid rest call: #{type}"
+        fail InvalidRequest, "Invalid rest method: #{type}. Valid methods are: get, post, put, patch, delete"
       end
 
       options['X-API-Version'] ||= api_ver

--- a/lib/oneview-sdk/version.rb
+++ b/lib/oneview-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module OneviewSDK
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.2.0'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ SimpleCov.profiles.define 'unit' do
   add_group 'Client', client_files
   add_group 'Resources', resource_path
   add_group 'CLI', 'cli.rb'
-  minimum_coverage 92 # TODO: bump up as we increase coverage. Goal: 95%
+  minimum_coverage 90 # TODO: bump up as we increase coverage. Goal: 95%
   minimum_coverage_by_file 60 # TODO: bump up as we increase coverage. Goal: 70%
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ SimpleCov.profiles.define 'unit' do
   add_group 'Client', client_files
   add_group 'Resources', resource_path
   add_group 'CLI', 'cli.rb'
-  minimum_coverage 90 # TODO: bump up as we increase coverage. Goal: 95%
+  minimum_coverage 92 # TODO: bump up as we increase coverage. Goal: 95%
   minimum_coverage_by_file 60 # TODO: bump up as we increase coverage. Goal: 70%
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,8 @@ SimpleCov.profiles.define 'unit' do
   add_group 'Client', client_files
   add_group 'Resources', resource_path
   add_group 'CLI', 'cli.rb'
-  minimum_coverage 90 # TODO: bump up as we increase coverage. Goal: 95%
-  minimum_coverage_by_file 50 # TODO: bump up as we increase coverage. Goal: 70%
+  minimum_coverage 92 # TODO: bump up as we increase coverage. Goal: 95%
+  minimum_coverage_by_file 60 # TODO: bump up as we increase coverage. Goal: 70%
 end
 
 SimpleCov.profiles.define 'integration' do

--- a/spec/unit/cli/create_from_file_spec.rb
+++ b/spec/unit/cli/create_from_file_spec.rb
@@ -13,12 +13,6 @@ RSpec.describe OneviewSDK::Cli do
         expect { OneviewSDK::Cli.start(['create_from_file']) }
           .to output(/was called with no arguments*\sUsage:/).to_stderr_from_any_process
       end
-
-      it 'does not allow both the if_missing and force options' do
-        expect(STDOUT).to receive(:puts).with(/flags at the same time/)
-        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file, '-f', '-i']) }
-          .to raise_error SystemExit
-      end
     end
 
     context 'with valid options' do
@@ -36,24 +30,13 @@ RSpec.describe OneviewSDK::Cli do
           .to output(/Created Successfully!/).to_stdout_from_any_process
       end
 
-      it 'respects the force option for overrides' do
-        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file, '-f']) }
-          .to output(/Updated Successfully!/).to_stdout_from_any_process
-      end
-
       it 'respects the if_missing option' do
         expect { OneviewSDK::Cli.start(['create_from_file', yaml_file, '-i']) }
           .to output(/Skipped/).to_stdout_from_any_process
       end
 
-      it 'fails if the resource already exists' do
-        expect(STDOUT).to receive(:puts).with(/already exists/)
-        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file]) }
-          .to raise_error SystemExit
-      end
-
       it 'fails if the file does not exist' do
-        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file + '.yml', '-f']) }
+        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file + '.yml']) }
           .to raise_error(/No such file or directory/)
       end
 
@@ -61,7 +44,7 @@ RSpec.describe OneviewSDK::Cli do
         resource = OneviewSDK::Resource.new(@client)
         allow(OneviewSDK::Resource).to receive(:from_file).and_return(resource)
         expect(STDOUT).to receive(:puts).with(/must specify a resource name/)
-        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file, '-f']) }
+        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file]) }
           .to raise_error SystemExit
       end
 
@@ -76,7 +59,7 @@ RSpec.describe OneviewSDK::Cli do
       it 'shows the resource update error message on failure' do
         allow_any_instance_of(OneviewSDK::Resource).to receive(:update).and_raise('Explanation')
         expect(STDOUT).to receive(:puts).with(/Failed to update.*Explanation/)
-        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file, '-f']) }
+        expect { OneviewSDK::Cli.start(['create_from_file', yaml_file]) }
           .to raise_error SystemExit
       end
     end

--- a/spec/unit/cli/rest_spec.rb
+++ b/spec/unit/cli/rest_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+RSpec.describe OneviewSDK::Cli do
+  include_context 'cli context'
+
+  let(:data) { { 'key1' => 'val1', 'key2' => 'val2' } }
+  let(:response) { { 'key1' => 'val1', 'key2' => 'val2', 'key3' => { 'key4' => 'val4' } } }
+
+  describe '#rest get' do
+    it 'requires a URI' do
+      expect($stderr).to receive(:puts).with(/ERROR.*arguments/)
+      described_class.start(%w(rest get))
+    end
+
+    it 'sends any data that is passed in' do
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+        .with('get', '/rest/fake', body: data).and_return FakeResponse.new(response)
+      expect { described_class.start(['rest', 'get', 'rest/fake', '-d', data.to_json]) }
+        .to output(JSON.pretty_generate(response) + "\n").to_stdout_from_any_process
+    end
+
+    context 'output formats' do
+      before :each do
+        expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+          .with('get', '/rest/fake', {}).and_return FakeResponse.new(response)
+      end
+
+      it 'makes a GET call to the URI and outputs the response in json format' do
+        expect { described_class.start(%w(rest get rest/fake)) }
+          .to output(JSON.pretty_generate(response) + "\n").to_stdout_from_any_process
+      end
+
+      it 'can output the response in raw format' do
+        expect { described_class.start(%w(rest get rest/fake -f raw)) }
+          .to output(response.to_json + "\n").to_stdout_from_any_process
+      end
+
+      it 'can output the response in yaml format' do
+        expect { described_class.start(%w(rest get rest/fake -f yaml)) }
+          .to output(response.to_yaml).to_stdout_from_any_process
+      end
+    end
+
+    context 'bad requests' do
+      it 'fails if the data cannot be parsed as json' do
+        expect($stdout).to receive(:puts).with(/Failed to parse data as JSON/)
+        expect { described_class.start(%w(rest get rest/ -d fake_json)) }
+          .to raise_error SystemExit
+      end
+
+      it 'fails if the request method is invalid' do
+        expect($stdout).to receive(:puts).with(/Invalid rest method/)
+        expect { described_class.start(%w(rest blah rest/)) }
+          .to raise_error SystemExit
+      end
+
+      it 'fails if the response code is 3XX' do
+        headers = { 'location' => ['rest/Systems/1/'] }
+        body = {}
+        expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+          .with('get', '/rest', {}).and_return FakeResponse.new(body, 308, headers)
+        expect($stdout).to receive(:puts).with(/308.*location/m)
+        expect { described_class.start(%w(rest get rest)) }
+          .to raise_error SystemExit
+      end
+
+      it 'fails if the response code is 4XX' do
+        headers = { 'content-type' => ['text/plain'] }
+        body = { 'Message' => 'Not found!' }
+        expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+          .with('get', '/rest', {}).and_return FakeResponse.new(body, 404, headers)
+        expect($stdout).to receive(:puts).with(/404.*content-type.*Not found/m)
+        expect { described_class.start(%w(rest get rest)) }
+          .to raise_error SystemExit
+      end
+
+      it 'fails if the response code is 4XX' do
+        headers = { 'content-type' => ['text/plain'] }
+        body = { 'Message' => 'Server error!' }
+        expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+          .with('get', '/rest', {}).and_return FakeResponse.new(body, 500, headers)
+        expect($stdout).to receive(:puts).with(/500.*content-type.*Server error/m)
+        expect { described_class.start(%w(rest get rest)) }
+          .to raise_error SystemExit
+      end
+    end
+  end
+
+  describe '#rest post' do
+    it 'makes a rest call with any data that is passed in' do
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+        .with('post', '/rest/fake', body: data).and_return FakeResponse.new(response)
+      expect { described_class.start(['rest', 'post', 'rest/fake', '-d', data.to_json]) }
+        .to output(JSON.pretty_generate(response) + "\n").to_stdout_from_any_process
+    end
+  end
+
+  describe '#rest put' do
+    it 'makes a rest call with any data that is passed in' do
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+        .with('put', '/rest/fake', body: data).and_return FakeResponse.new(response)
+      expect { described_class.start(['rest', 'put', 'rest/fake', '-d', data.to_json]) }
+        .to output(JSON.pretty_generate(response) + "\n").to_stdout_from_any_process
+    end
+  end
+
+  describe '#rest patch' do
+    it 'makes a rest call with any data that is passed in' do
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+        .with('patch', '/rest/fake', body: data).and_return FakeResponse.new(response)
+      expect { described_class.start(['rest', 'patch', 'rest/fake', '-d', data.to_json]) }
+        .to output(JSON.pretty_generate(response) + "\n").to_stdout_from_any_process
+    end
+  end
+
+  describe '#rest delete' do
+    it 'makes a rest call with any data that is passed in' do
+      expect_any_instance_of(OneviewSDK::Client).to receive(:rest_api)
+        .with('delete', '/rest/fake', body: data).and_return FakeResponse.new(response)
+      expect { described_class.start(['rest', 'delete', 'rest/fake', '-d', data.to_json]) }
+        .to output(JSON.pretty_generate(response) + "\n").to_stdout_from_any_process
+    end
+  end
+end

--- a/spec/unit/cli/update_spec.rb
+++ b/spec/unit/cli/update_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+RSpec.describe OneviewSDK::Cli do
+  include_context 'cli context'
+  include_context 'shared context'
+
+  describe '#update' do
+
+    let(:data) do
+      { 'name' => 'SP_1', 'description' => 'NewBlah' }
+    end
+
+    let(:resource_data) do
+      { 'name' => 'SP1', 'uri' => '/rest/fake', 'description' => 'Blah' }
+    end
+
+    let(:sp1) do
+      OneviewSDK::ServerProfile.new(@client, resource_data)
+    end
+
+    let(:sp_list) do
+      [sp1]
+    end
+
+    context 'with invalid options' do
+      it 'requires a type' do
+        expect { described_class.start(%w(update)) }
+          .to output(/called with no arguments/).to_stderr_from_any_process
+      end
+
+      it 'requires a valid type' do
+        expect(STDOUT).to receive(:puts).with(/Invalid resource type/)
+        expect { described_class.start(%w(update InvalidType Name)) }.to raise_error SystemExit
+      end
+
+      it 'requires a name' do
+        expect { described_class.start(%w(update ServerProfile)) }
+          .to output(/called with arguments/).to_stderr_from_any_process
+      end
+
+      it 'requires the hash or json option' do
+        expect($stdout).to receive(:puts).with(/Must set the hash or json option/)
+        expect { described_class.start(%w(update ServerProfile SP1)) }
+          .to raise_error SystemExit
+      end
+
+      it 'requires the json to be valid' do
+        expect($stdout).to receive(:puts).with(/Failed to parse json/)
+        expect { described_class.start(%w(update ServerProfile SP1 -j invalid_json)) }
+          .to raise_error SystemExit
+      end
+    end
+
+    it 'fails if no match is found' do
+      expect(OneviewSDK::ServerProfile).to receive(:find_by).with(instance_of(OneviewSDK::Client), name: 'SP_2')
+        .and_return []
+      expect($stdout).to receive(:puts).with(/Not Found/)
+      expect { described_class.start(%w(update ServerProfile SP_2 -h name:SP2)) }
+        .to raise_error SystemExit
+    end
+
+    it 'parses hash data' do
+      expect(OneviewSDK::ServerProfile).to receive(:find_by).with(instance_of(OneviewSDK::Client), name: sp1['name'])
+        .and_return sp_list
+      expect(sp1).to receive(:update).with(data).and_return true
+      expect { described_class.start(%w(update ServerProfile SP1 -h name:SP_1 description:NewBlah)) }
+        .to output(/Successfully/).to_stdout_from_any_process
+    end
+
+    it 'parses json data' do
+      expect(OneviewSDK::ServerProfile).to receive(:find_by).with(instance_of(OneviewSDK::Client), name: sp1['name'])
+        .and_return sp_list
+      expect(sp1).to receive(:update).with(data).and_return true
+      expect { described_class.start(['update', 'ServerProfile', 'SP1', '-j', data.to_json]) }
+        .to output(/Successfully/).to_stdout_from_any_process
+    end
+
+    it 'prints out error messages' do
+      expect(OneviewSDK::ServerProfile).to receive(:find_by).with(instance_of(OneviewSDK::Client), name: sp1['name'])
+        .and_return sp_list
+      expect(sp1).to receive(:update).with(data).and_raise(OneviewSDK::BadRequest, 'Reason')
+      expect($stdout).to receive(:puts).with(/Reason/)
+      expect { described_class.start(['update', 'ServerProfile', 'SP1', '-j', data.to_json]) }
+        .to raise_error SystemExit
+    end
+  end
+end

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe OneviewSDK::Client do
     end
 
     it 'fails when an invalid request type is given' do
-      expect { @client.send(:build_request, :fake, @uri, {}, @client.api_version) }.to raise_error(OneviewSDK::InvalidRequest, /Invalid rest call/)
+      expect { @client.send(:build_request, :fake, @uri, {}, @client.api_version) }.to raise_error(OneviewSDK::InvalidRequest, /Invalid rest method/)
     end
 
     context 'default header values' do


### PR DESCRIPTION
This adds the 'rest' and 'update' commands to the CLI, and removes the `--force' option from the create_from_file command (if you don't want to update it, just pass the 'if_missing' flag).