### PR TITLE
Allow resources to retrieve by additional attributes

### DIFF
--- a/lib/oneview-sdk/resource.rb
+++ b/lib/oneview-sdk/resource.rb
@@ -16,6 +16,7 @@ module OneviewSDK
   # Resource base class that defines all common resource functionality.
   class Resource
     BASE_URI = '/rest'.freeze
+    UNIQUE_IDENTIFIERS = %w(name uri).freeze # Ordered list of unique attributes to search by
 
     attr_accessor \
       :client,
@@ -42,24 +43,30 @@ module OneviewSDK
     end
 
     # Retrieve resource details based on this resource's name or URI.
-    # @note Name or URI must be specified inside the resource
+    # @note one of the UNIQUE_IDENTIFIERS, e.g. name or uri, must be specified in the resource
     # @return [Boolean] Whether or not retrieve was successful
     def retrieve!
-      fail IncompleteResource, 'Must set resource name or uri before trying to retrieve!' unless @data['name'] || @data['uri']
-      results = self.class.find_by(@client, name: @data['name']) if @data['name']
-      results = self.class.find_by(@client, uri:  @data['uri'])  if @data['uri'] && (!results || results.empty?)
-      return false unless results.size == 1
-      set_all(results[0].data)
-      true
+      retrieval_keys = self.class::UNIQUE_IDENTIFIERS.select { |k| !@data[k].nil? }
+      fail IncompleteResource, "Must set resource #{self.class::UNIQUE_IDENTIFIERS.join(' or ')} before trying to retrieve!" if retrieval_keys.empty?
+      retrieval_keys.each do |k|
+        results = self.class.find_by(@client, k => @data[k])
+        next if results.size != 1
+        set_all(results[0].data)
+        return true
+      end
+      false
     end
 
     # Check if a resource exists
-    # @note name or uri must be specified inside resource
+    # @note one of the UNIQUE_IDENTIFIERS, e.g. name or uri, must be specified in the resource
     # @return [Boolean] Whether or not resource exists
     def exists?
-      fail IncompleteResource, 'Must set resource name or uri before trying to retrieve!' unless @data['name'] || @data['uri']
-      return true if @data['name'] && self.class.find_by(@client, name: @data['name']).size == 1
-      return true if @data['uri']  && self.class.find_by(@client, uri:  @data['uri']).size == 1
+      retrieval_keys = self.class::UNIQUE_IDENTIFIERS.select { |k| !@data[k].nil? }
+      fail IncompleteResource, "Must set resource #{self.class::UNIQUE_IDENTIFIERS.join(' or ')} before trying to retrieve!" if retrieval_keys.empty?
+      retrieval_keys.each do |k|
+        results = self.class.find_by(@client, k => @data[k])
+        return true if results.size == 1
+      end
       false
     end
 

--- a/lib/oneview-sdk/resource/enclosure.rb
+++ b/lib/oneview-sdk/resource/enclosure.rb
@@ -16,6 +16,7 @@ module OneviewSDK
   # Enclosure resource implementation
   class Enclosure < Resource
     BASE_URI = '/rest/enclosures'.freeze
+    UNIQUE_IDENTIFIERS = %w(name uri serialNumber activeOaPreferredIP standbyOaPreferredIP).freeze
 
     # Remove resource from OneView
     # @return [true] if resource was removed successfully

--- a/lib/oneview-sdk/resource/interconnect.rb
+++ b/lib/oneview-sdk/resource/interconnect.rb
@@ -14,6 +14,7 @@ module OneviewSDK
   class Interconnect < Resource
     BASE_URI = '/rest/interconnects'.freeze
     TYPE_URI = '/rest/interconnect-types'.freeze
+    UNIQUE_IDENTIFIERS = %w(name uri serialNumber interconnectIP).freeze
 
     # Create a resource object, associate it with a client, and set its properties.
     # @param [OneviewSDK::Client] client The client object for the OneView appliance

--- a/lib/oneview-sdk/resource/rack.rb
+++ b/lib/oneview-sdk/resource/rack.rb
@@ -13,6 +13,7 @@ module OneviewSDK
   # Rack resource implementation
   class Rack < Resource
     BASE_URI = '/rest/racks'.freeze
+    UNIQUE_IDENTIFIERS = %w(name uri serialNumber).freeze
 
     # Add the resource on OneView using the current data
     # @note Calls the refresh method to set additional data

--- a/lib/oneview-sdk/resource/server_profile.rb
+++ b/lib/oneview-sdk/resource/server_profile.rb
@@ -13,6 +13,7 @@ module OneviewSDK
   # Server profile resource implementation
   class ServerProfile < Resource
     BASE_URI = '/rest/server-profiles'.freeze
+    UNIQUE_IDENTIFIERS = %w(name uri associatedServer serialNumber serverHardwareUri).freeze
 
     def initialize(client, params = {}, api_ver = nil)
       super

--- a/lib/oneview-sdk/resource/switch.rb
+++ b/lib/oneview-sdk/resource/switch.rb
@@ -14,6 +14,7 @@ module OneviewSDK
   class Switch < Resource
     BASE_URI = '/rest/switches'.freeze
     TYPE_URI = '/rest/switch-types'.freeze
+    UNIQUE_IDENTIFIERS = %w(name uri serialNumber).freeze
 
     # Remove resource from OneView
     # @return [true] if resource was removed successfully

--- a/spec/unit/resource/enclosure_spec.rb
+++ b/spec/unit/resource/enclosure_spec.rb
@@ -13,6 +13,76 @@ RSpec.describe OneviewSDK::Enclosure do
     end
   end
 
+  describe '#retrieve!' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1', activeOaPreferredIP: 'aip1', standbyOaPreferredIP: 'sip1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2', activeOaPreferredIP: 'aip2', standbyOaPreferredIP: 'sip2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'retrieves by name' do
+      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by uri' do
+      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by activeOaPreferredIP' do
+      expect(described_class.new(@client, activeOaPreferredIP: 'aip1').retrieve!).to be true
+      expect(described_class.new(@client, activeOaPreferredIP: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by standbyOaPreferredIP' do
+      expect(described_class.new(@client, standbyOaPreferredIP: 'sip1').retrieve!).to be true
+      expect(described_class.new(@client, standbyOaPreferredIP: 'fake').retrieve!).to be false
+    end
+  end
+
+  describe '#exists?' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1', activeOaPreferredIP: 'aip1', standbyOaPreferredIP: 'sip1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2', activeOaPreferredIP: 'aip2', standbyOaPreferredIP: 'sip2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'finds it by name' do
+      expect(described_class.new(@client, name: 'name1').exists?).to be true
+      expect(described_class.new(@client, name: 'fake').exists?).to be false
+    end
+
+    it 'finds it by uri' do
+      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+    end
+
+    it 'finds it by activeOaPreferredIP' do
+      expect(described_class.new(@client, activeOaPreferredIP: 'aip1').exists?).to be true
+      expect(described_class.new(@client, activeOaPreferredIP: 'fake').exists?).to be false
+    end
+
+    it 'finds it by standbyOaPreferredIP' do
+      expect(described_class.new(@client, standbyOaPreferredIP: 'sip1').exists?).to be true
+      expect(described_class.new(@client, standbyOaPreferredIP: 'fake').exists?).to be false
+    end
+  end
+
   describe '#add' do
     context 'with valid data' do
       before :each do

--- a/spec/unit/resource/interconnect_spec.rb
+++ b/spec/unit/resource/interconnect_spec.rb
@@ -21,6 +21,67 @@ RSpec.describe OneviewSDK::Interconnect do
     end
   end
 
+  # name uri serialNumber interconnectIP
+  describe '#retrieve!' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1', interconnectIP: 'ip1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2', interconnectIP: 'ip2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'retrieves by name' do
+      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by uri' do
+      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by interconnectIP' do
+      expect(described_class.new(@client, interconnectIP: 'ip1').retrieve!).to be true
+      expect(described_class.new(@client, interconnectIP: 'fake').retrieve!).to be false
+    end
+  end
+
+  describe '#exists?' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1', interconnectIP: 'ip1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2', interconnectIP: 'ip2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'finds it by name' do
+      expect(described_class.new(@client, name: 'name1').exists?).to be true
+      expect(described_class.new(@client, name: 'fake').exists?).to be false
+    end
+
+    it 'finds it by uri' do
+      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+    end
+
+    it 'finds it by interconnectIP' do
+      expect(described_class.new(@client, interconnectIP: 'ip1').exists?).to be true
+      expect(described_class.new(@client, interconnectIP: 'fake').exists?).to be false
+    end
+  end
+
   describe 'statistics' do
     before :each do
       @item = OneviewSDK::Interconnect.new(@client, {})

--- a/spec/unit/resource/rack_spec.rb
+++ b/spec/unit/resource/rack_spec.rb
@@ -21,6 +21,56 @@ RSpec.describe OneviewSDK::Rack do
     end
   end
 
+  describe '#retrieve!' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'retrieves by name' do
+      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by uri' do
+      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+    end
+  end
+
+  describe '#exists?' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'finds it by name' do
+      expect(described_class.new(@client, name: 'name1').exists?).to be true
+      expect(described_class.new(@client, name: 'fake').exists?).to be false
+    end
+
+    it 'finds it by uri' do
+      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+    end
+  end
+
   describe '#add' do
     it 'Should support add' do
       rack = OneviewSDK::Rack.new(@client, uri: '/rest/racks')

--- a/spec/unit/resource/server_hardware_spec.rb
+++ b/spec/unit/resource/server_hardware_spec.rb
@@ -19,6 +19,90 @@ RSpec.describe OneviewSDK::ServerHardware do
     end
   end
 
+  describe '#retrieve!' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1', virtualSerialNumber: 'vsn1', serverProfileUri: 'sp1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2', virtualSerialNumber: 'vsn2', serverProfileUri: 'sp2' },
+        { name: 'name3', uri: 'uri2', mpHostInfo: { 'mpHostName' => 'h1' } }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'retrieves by name' do
+      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by uri' do
+      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by virtualSerialNumber' do
+      expect(described_class.new(@client, virtualSerialNumber: 'vsn1').retrieve!).to be true
+      expect(described_class.new(@client, virtualSerialNumber: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serverProfileUri' do
+      expect(described_class.new(@client, serverProfileUri: 'sp1').retrieve!).to be true
+      expect(described_class.new(@client, serverProfileUri: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by hostname' do
+      expect(described_class.new(@client, hostname: 'h1').retrieve!).to be true
+      expect(described_class.new(@client, mpHostInfo: { 'mpHostName' => 'h1' }).retrieve!).to be true
+      expect(described_class.new(@client, hostname: 'fake').retrieve!).to be false
+    end
+  end
+
+  describe '#exists?' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1', virtualSerialNumber: 'vsn1', serverProfileUri: 'sp1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2', virtualSerialNumber: 'vsn2', serverProfileUri: 'sp2' },
+        { name: 'name3', uri: 'uri2', mpHostInfo: { 'mpHostName' => 'h1' } }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'finds it by name' do
+      expect(described_class.new(@client, name: 'name1').exists?).to be true
+      expect(described_class.new(@client, name: 'fake').exists?).to be false
+    end
+
+    it 'finds it by uri' do
+      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+    end
+
+    it 'finds it by virtualSerialNumber' do
+      expect(described_class.new(@client, virtualSerialNumber: 'vsn1').exists?).to be true
+      expect(described_class.new(@client, virtualSerialNumber: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serverProfileUri' do
+      expect(described_class.new(@client, serverProfileUri: 'sp1').exists?).to be true
+      expect(described_class.new(@client, serverProfileUri: 'fake').exists?).to be false
+    end
+
+    it 'finds it by hostname' do
+      expect(described_class.new(@client, hostname: 'h1').exists?).to be true
+      expect(described_class.new(@client, mpHostInfo: { 'mpHostName' => 'h1' }).exists?).to be true
+      expect(described_class.new(@client, hostname: 'fake').exists?).to be false
+    end
+  end
+
   describe '#get_bios' do
     it '' do
       item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')

--- a/spec/unit/resource/server_profile_spec.rb
+++ b/spec/unit/resource/server_profile_spec.rb
@@ -14,6 +14,76 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
   end
 
+  describe '#retrieve!' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', associatedServer: 'as1', serialNumber: 'sn1', serverHardwareUri: 'sh1' },
+        { name: 'name2', uri: 'uri2', associatedServer: 'as2', serialNumber: 'sn2', serverHardwareUri: 'sh2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'retrieves by name' do
+      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by uri' do
+      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by associatedServer' do
+      expect(described_class.new(@client, associatedServer: 'as1').retrieve!).to be true
+      expect(described_class.new(@client, associatedServer: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serverHardwareUri' do
+      expect(described_class.new(@client, serverHardwareUri: 'sh1').retrieve!).to be true
+      expect(described_class.new(@client, serverHardwareUri: 'fake').retrieve!).to be false
+    end
+  end
+
+  describe '#exists?' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', associatedServer: 'as1', serialNumber: 'sn1', serverHardwareUri: 'sh1' },
+        { name: 'name2', uri: 'uri2', associatedServer: 'as2', serialNumber: 'sn2', serverHardwareUri: 'sh2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'finds it by name' do
+      expect(described_class.new(@client, name: 'name1').exists?).to be true
+      expect(described_class.new(@client, name: 'fake').exists?).to be false
+    end
+
+    it 'finds it by uri' do
+      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+    end
+
+    it 'finds it by associatedServer' do
+      expect(described_class.new(@client, associatedServer: 'as1').exists?).to be true
+      expect(described_class.new(@client, associatedServer: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serverHardwareUri' do
+      expect(described_class.new(@client, serverHardwareUri: 'sh1').exists?).to be true
+      expect(described_class.new(@client, serverHardwareUri: 'fake').exists?).to be false
+    end
+  end
+
   describe '#set_server_hardware' do
     before :each do
       @server_hardware = OneviewSDK::ServerHardware.new(@client, name: 'server_hardware')

--- a/spec/unit/resource/storage_system_spec.rb
+++ b/spec/unit/resource/storage_system_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OneviewSDK::StorageSystem do
   describe '#retrieve!' do
     it 'finds by name if it is set' do
       item = OneviewSDK::StorageSystem.new(@client, name: 'Fake')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, name: 'Fake').and_return([item])
+      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, 'name' => 'Fake').and_return([item])
       expect(item.retrieve!).to eq(true)
     end
 

--- a/spec/unit/resource/storage_system_spec.rb
+++ b/spec/unit/resource/storage_system_spec.rb
@@ -31,40 +31,80 @@ RSpec.describe OneviewSDK::StorageSystem do
   end
 
   describe '#retrieve!' do
-    it 'finds by name if it is set' do
-      item = OneviewSDK::StorageSystem.new(@client, name: 'Fake')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, 'name' => 'Fake').and_return([item])
-      expect(item.retrieve!).to eq(true)
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1', wwn: 'wwn1', credentials: { ip_hostname: 'ip1' } },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2', wwn: 'wwn2', credentials: { ip_hostname: 'ip2' } }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
-    it 'finds by credentials if the name is not set' do
-      item = OneviewSDK::StorageSystem.new(@client, credentials: { ip_hostname: 'a.com', username: 'admin', password: 'secret' })
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, credentials: { ip_hostname: item['credentials'][:ip_hostname] })
-        .and_return([item])
-      expect(item.retrieve!).to eq(true)
+    it 'retrieves by name' do
+      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
     end
 
-    it 'no parameter given' do
+    it 'retrieves by uri' do
+      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by wwn' do
+      expect(described_class.new(@client, wwn: 'wwn1').retrieve!).to be true
+      expect(described_class.new(@client, wwn: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by credentials' do
+      expect(described_class.new(@client, credentials: { ip_hostname: 'ip1' }).retrieve!).to be true
+      expect(described_class.new(@client, credentials: { ip_hostname: 'fake' }).retrieve!).to be false
+    end
+
+    it 'raises an exception if no identifiers are given' do
       item = OneviewSDK::StorageSystem.new(@client, {})
       expect { item.retrieve! }.to raise_error(OneviewSDK::IncompleteResource)
     end
   end
 
   describe '#exists?' do
-    it 'finds by name if it is set' do
-      item = OneviewSDK::StorageSystem.new(@client, name: 'Fake')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, name: 'Fake').and_return([item])
-      expect(item.exists?).to eq(true)
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1', wwn: 'wwn1', credentials: { ip_hostname: 'ip1' } },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2', wwn: 'wwn2', credentials: { ip_hostname: 'ip2' } }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
-    it 'finds by credentials if the name is not set' do
-      item = OneviewSDK::StorageSystem.new(@client, credentials: { ip_hostname: 'a.com', username: 'admin', password: 'secret' })
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, credentials: { ip_hostname: item['credentials'][:ip_hostname] })
-        .and_return([item])
-      expect(item.exists?).to eq(true)
+    it 'finds it by name' do
+      expect(described_class.new(@client, name: 'name1').exists?).to be true
+      expect(described_class.new(@client, name: 'fake').exists?).to be false
     end
 
-    it 'no parameter given' do
+    it 'finds it by uri' do
+      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+    end
+
+    it 'finds it by wwn' do
+      expect(described_class.new(@client, wwn: 'wwn1').exists?).to be true
+      expect(described_class.new(@client, wwn: 'fake').exists?).to be false
+    end
+
+    it 'finds it by credentials' do
+      expect(described_class.new(@client, credentials: { ip_hostname: 'ip1' }).exists?).to be true
+      expect(described_class.new(@client, credentials: { ip_hostname: 'fake' }).exists?).to be false
+    end
+
+    it 'raises an exception if no identifiers are given' do
       item = OneviewSDK::StorageSystem.new(@client, {})
       expect { item.exists? }.to raise_error(OneviewSDK::IncompleteResource)
     end

--- a/spec/unit/resource/switch_spec.rb
+++ b/spec/unit/resource/switch_spec.rb
@@ -3,6 +3,56 @@ require 'spec_helper'
 RSpec.describe OneviewSDK::Switch do
   include_context 'shared context'
 
+  describe '#retrieve!' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'retrieves by name' do
+      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by uri' do
+      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+    end
+
+    it 'retrieves by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+    end
+  end
+
+  describe '#exists?' do
+    before :each do
+      resp = FakeResponse.new(members: [
+        { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
+        { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
+      ])
+      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+    end
+
+    it 'finds it by name' do
+      expect(described_class.new(@client, name: 'name1').exists?).to be true
+      expect(described_class.new(@client, name: 'fake').exists?).to be false
+    end
+
+    it 'finds it by uri' do
+      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+    end
+
+    it 'finds it by serialNumber' do
+      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+    end
+  end
+
   describe '#remove' do
     it 'Should support remove' do
       switch = OneviewSDK::Switch.new(@client, uri: '/rest/switches/100')

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe OneviewSDK::Resource do
       res = OneviewSDK::Resource.new(@client, name: 'ResourceName')
       expect(res.retrieve!).to eq(false)
     end
+
+    it 'returns false when multiple resources match' do
+      allow(OneviewSDK::Resource).to receive(:find_by).and_return([
+        OneviewSDK::Resource.new(@client, name: 'ResourceName'),
+        OneviewSDK::Resource.new(@client, name: 'ResourceName')
+      ])
+      res = OneviewSDK::Resource.new(@client, name: 'ResourceName')
+      expect(res.retrieve!).to eq(false)
+    end
   end
 
   describe '#exists?' do
@@ -72,19 +81,19 @@ RSpec.describe OneviewSDK::Resource do
 
     it 'uses the uri attribute when the name is not set' do
       res = OneviewSDK::Resource.new(@client, uri: '/rest/fake')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, uri: res['uri']).and_return([])
+      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, 'uri' => res['uri']).and_return([])
       expect(res.exists?).to eq(false)
     end
 
     it 'returns true when the resource is found' do
       res = OneviewSDK::Resource.new(@client, name: 'ResourceName')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, name: res['name']).and_return([res])
+      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, 'name' => res['name']).and_return([res])
       expect(res.exists?).to eq(true)
     end
 
     it 'returns false when the resource is not found' do
       res = OneviewSDK::Resource.new(@client, uri: '/rest/fake')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, uri: res['uri']).and_return([])
+      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, 'uri' => res['uri']).and_return([])
       expect(res.exists?).to eq(false)
     end
   end


### PR DESCRIPTION
Fixes #91

This allows the ServerHardware resource and others to retrieve and check for existence based on additional attributes from the defaults, `name` and `uri`.

New attributes that are considered unique for search purposes:
 - [x] **ServerHardware:** serialNumber, virtualSerialNumber, serverProfileUri, hostname
 - [x] **Enclosure:** serialNumber, activeOaPreferredIP, standbyOaPreferredIP
 - [x] **StorageSystem:** credentials/ip_hostname, serialNumber, wwn
 - [x] **ServerProfile:** associatedServer, serialNumber, serverHardwareUri
 - [x] **Switch:** serialNumber
 - [x] **Interconnect:** interconnectIP, serialNumber
 - [x] **Rack:** serialNumber
 - :question: Other resources that need updated?

:warning: This PR isn't complete yet; we need to decide if this approach is good, and identify additional resources to be updated. So thoughts?