### PR TITLE
Bugfix for storage system method like?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### v2.2.2
+ - Fixed issue #92 (storage system like?). Excluding comparison of credentials
+
 #### v2.2.1
  - Fixed issue #88 (firmware bundle file size). Uses multipart-post now
 

--- a/lib/oneview-sdk/resource/storage_system.rb
+++ b/lib/oneview-sdk/resource/storage_system.rb
@@ -84,6 +84,20 @@ module OneviewSDK
       true
     end
 
+    # Check the equality of the data for the other resource with this resource.
+    # @note Does not check the client, logger, or api_version if another resource is passed in
+    # @param [Hash, Resource] other resource or hash to compare the key-value pairs with
+    # @example Compare to hash
+    #   myResource = OneviewSDK::Resource.new(client, { name: 'res1', description: 'example'}, 200)
+    #   myResource.like?(description: '') # returns false
+    #   myResource.like?(name: 'res1') # returns true
+    # @return [Boolean] Whether or not the two objects are alike
+    def like?(other)
+      other.delete('credentials') if other['credentials']
+      other.delete(:credentials) if other[:credentials]
+      super
+    end
+
     # Gets the host types for the storage system resource
     # @param [OneviewSDK::Client] client The client object for the OneView appliance
     # @return [String] response body

--- a/spec/unit/resource/storage_system_spec.rb
+++ b/spec/unit/resource/storage_system_spec.rb
@@ -70,6 +70,30 @@ RSpec.describe OneviewSDK::StorageSystem do
     end
   end
 
+  describe '#like?' do
+    it 'must not compare storage system credentials' do
+      options = {
+        name: 'StorageSystemName',
+        credentials: {
+          'ip_hostname' => '127.0.0.1',
+          'username' => 'user',
+          'password' => 'pass'
+        },
+        state: 'Configured'
+      }
+      item = OneviewSDK::StorageSystem.new(
+        @client,
+        name: 'StorageSystemName',
+        credentials: {
+          'ip_hostname' => '127.0.0.1',
+          'username' => 'user'
+        },
+        state: 'Configured'
+      )
+      expect(item.like?(options)).to eq(true)
+    end
+  end
+
   describe '#get_managed_ports' do
     it 'No port given' do
       item = OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake')


### PR DESCRIPTION
Fixes #92 

The method `:like?` should not compare credentials since oneview does not return password.
