### PR TITLE
Split system tests for API 300

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,30 +58,102 @@ end
 
 desc 'Run System tests'
 RSpec::Core::RakeTask.new('spec:system') do |spec|
-  spec.pattern = 'spec/**/*_spec.rb'
+  spec.pattern = spec_pattern
   spec.rspec_opts = def_int_spec_options
   spec.rspec_opts << ' --tag system'
+end
+
+desc 'Run System tests for specified model & API. Defaults to model C7000 and API 300.'
+task 'spec:system:api_version_model', [:api, :model] do |_t, spec|
+  args = {}
+  args['model'] = spec['model'] || 'c7000'
+  args['api'] = spec['api'] || 300
+  spec_pattern = "spec/system/**/api#{args['api']}/#{args['model']}/*_spec.rb"
+  spec_pattern = 'spec/system/**/api200/*_spec.rb' if args['api'] == '200'
+  Rake::Task['spec:system'].invoke
+end
+
+desc 'Run System tests for specified API. Defaults to API 300.'
+task 'spec:system:api_version', [:api] do |_t, spec|
+  args = spec['api'] || 300
+  spec_pattern = "spec/system/**/api#{args}/**/*_spec.rb"
+  spec_pattern = 'spec/system/**/api200/*_spec.rb' if args == '200'
+  Rake::Task['spec:system'].invoke
 end
 
 desc 'Run System tests Light Profile'
 RSpec::Core::RakeTask.new('spec:system:light') do |spec|
-  spec.pattern = 'spec/system/light_profile/*_spec.rb'
+  spec.pattern = 'spec/system/light_profile/**/*_spec.rb'
   spec.rspec_opts = def_int_spec_options
   spec.rspec_opts << ' --tag system'
+end
+
+desc 'Run System tests Light Profile for specified model & API. Defaults to model C7000 and API 300.'
+task 'spec:system:light:api_version_model', [:api, :model] do |_t, spec|
+  args = {}
+  args['model'] = spec['model'] || 'c7000'
+  args['api'] = spec['api'] || 300
+  spec_pattern = "spec/system/light_profile/api#{args['api']}/#{args['model']}/*_spec.rb"
+  spec_pattern = 'spec/system/light_profile/api200/*_spec.rb' if args['api'] == '200'
+  Rake::Task['spec:system'].invoke
+end
+
+desc 'Run System tests Light Profile for specified API. Defaults to API 300.'
+task 'spec:system:light:api_version', [:api] do |_t, spec|
+  args = spec['api'] || 300
+  spec_pattern = "spec/system/light_profile/api#{args}/**/*_spec.rb"
+  spec_pattern = 'spec/system/light_profile/api200/*_spec.rb' if args == '200'
+  Rake::Task['spec:system'].invoke
 end
 
 desc 'Run System tests Medium Profile'
 RSpec::Core::RakeTask.new('spec:system:medium') do |spec|
-  spec.pattern = 'spec/system/medium_profile/*_spec.rb'
+  spec.pattern = 'spec/system/medium_profile/**/*_spec.rb'
   spec.rspec_opts = def_int_spec_options
   spec.rspec_opts << ' --tag system'
 end
 
+desc 'Run System tests Medium Profile for specified model & API. Defaults to model C7000 and API 300.'
+task 'spec:system:medium:api_version_model', [:api, :model] do |_t, spec|
+  args = {}
+  args['model'] = spec['model'] || 'c7000'
+  args['api'] = spec['api'] || 300
+  spec_pattern = "spec/system/medium_profile/api#{args['api']}/#{args['model']}/*_spec.rb"
+  spec_pattern = 'spec/system/medium_profile/api200/*_spec.rb' if args['api'] == '200'
+  Rake::Task['spec:system'].invoke
+end
+
+desc 'Run System tests Medium Profile for specified API. Defaults to API 300.'
+task 'spec:system:medium:api_version', [:api] do |_t, spec|
+  args = spec['api'] || 300
+  spec_pattern = "spec/system/medium_profile/api#{args}/**/*_spec.rb"
+  spec_pattern = 'spec/system/medium_profile/api200/*_spec.rb' if args == '200'
+  Rake::Task['spec:system'].invoke
+end
+
 desc 'Run System tests Heavy Profile'
 RSpec::Core::RakeTask.new('spec:system:heavy') do |spec|
-  spec.pattern = 'spec/system/heavy_profile/*_spec.rb'
+  spec.pattern = 'spec/system/heavy_profile/**/*_spec.rb'
   spec.rspec_opts = def_int_spec_options
   spec.rspec_opts << ' --tag system'
+end
+
+desc 'Run System tests Heavy Profile for specified model & API. Defaults to model C7000 and API 300.'
+task 'spec:system:heavy:api_version_model', [:api, :model] do |_t, spec|
+  args = {}
+  args['model'] = spec['model'] || 'c7000'
+  args['api'] = spec['api'] || 300
+  spec_pattern = "spec/system/heavy_profile/api#{args['api']}/#{args['model']}/*_spec.rb"
+  spec_pattern = 'spec/system/heavy_profile/api200/*_spec.rb' if args['api'] == '200'
+  Rake::Task['spec:system'].invoke
+end
+
+desc 'Run System tests Heavy Profile for specified API. Defaults to API 300.'
+task 'spec:system:heavy:api_version', [:api] do |_t, spec|
+  args = spec['api'] || 300
+  spec_pattern = "spec/system/heavy_profile/api#{args}/**/*_spec.rb"
+  spec_pattern = 'spec/system/heavy_profile/api200/*_spec.rb' if args == '200'
+  Rake::Task['spec:system'].invoke
 end
 
 RuboCop::RakeTask.new do |task|

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -47,27 +47,22 @@ end
 RSpec.shared_context 'system context', a: :b do
 
   before(:each) do
-    default_config  = 'spec/system/one_view_config.json'
-    default_secrets = 'spec/system/one_view_secrets.json'
-
-    @config_path  ||= ENV['ONEVIEWSDK_SYSTEM_CONFIG']  || default_config
-    @secrets_path ||= ENV['ONEVIEWSDK_SYSTEM_SECRETS'] || default_secrets
-
-    unless File.file?(@config_path) && File.file?(@secrets_path)
-      STDERR.puts "\n\n"
-      STDERR.puts 'ERROR: System config file not found' unless File.file?(@config_path)
-      STDERR.puts 'ERROR: System secrets file not found' unless File.file?(@secrets_path)
-      STDERR.puts "\n\n"
-      exit!
-    end
-
-    $secrets ||= OneviewSDK::Config.load(@secrets_path) # Secrets for URIs, server/enclosure credentials, etc.
-
-    # Create client objects:
-    $config  ||= OneviewSDK::Config.load(@config_path)
+    system_context
     $client_120 ||= OneviewSDK::Client.new($config.merge(api_version: 120))
     $client     ||= OneviewSDK::Client.new($config.merge(api_version: 200))
+
+    allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_call_original
+    allow_any_instance_of(OneviewSDK::Client).to receive(:login).and_call_original
+  end
+
+end
+
+RSpec.shared_context 'system api300 context', a: :b do
+
+  before(:each) do
+    system_context
     $client_300 ||= OneviewSDK::Client.new($config.merge(api_version: 300))
+    $client_300_synergy ||= OneviewSDK::Client.new($config_synergy.merge(api_version: 300))
 
     allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_call_original
     allow_any_instance_of(OneviewSDK::Client).to receive(:login).and_call_original
@@ -120,4 +115,31 @@ def integration_context_debugging
       raise 'Skipped'
     end
   end
+end
+
+def system_context
+  default_config  = 'spec/system/one_view_config.json'
+  default_secrets = 'spec/system/one_view_secrets.json'
+  default_config_synergy  = 'spec/system/one_view_config_synergy.json'
+  default_secrets_synergy = 'spec/system/one_view_secrets_synergy.json'
+
+  @config_path  ||= ENV['ONEVIEWSDK_SYSTEM_CONFIG']  || default_config
+  @secrets_path ||= ENV['ONEVIEWSDK_SYSTEM_SECRETS'] || default_secrets
+  @config_path_synergy  ||= ENV['ONEVIEWSDK_SYSTEM_CONFIG_SYNERGY']  || default_config_synergy
+  @secrets_path_synergy ||= ENV['ONEVIEWSDK_SYSTEM_SECRETS_SYNERGY'] || default_secrets_synergy
+
+  unless File.file?(@config_path) && File.file?(@secrets_path)
+    STDERR.puts "\n\n"
+    STDERR.puts 'ERROR: System config file not found' unless File.file?(@config_path)
+    STDERR.puts 'ERROR: System secrets file not found' unless File.file?(@secrets_path)
+    STDERR.puts "\n\n"
+    exit!
+  end
+
+  $secrets ||= OneviewSDK::Config.load(@secrets_path) # Secrets for URIs, server/enclosure credentials, etc.
+  $secrets_synergy ||= OneviewSDK::Config.load(@secrets_path_synergy) # Secrets for URIs, server/enclosure credentials, etc.
+
+  # Create client objects:
+  $config ||= OneviewSDK::Config.load(@config_path)
+  $config_synergy ||= OneviewSDK::Config.load(@config_path_synergy)
 end

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -45,9 +45,11 @@ RSpec.shared_context 'integration api300 context', a: :b do
 end
 
 RSpec.shared_context 'system context', a: :b do
-
   before(:each) do
-    system_context
+    load_system_properties
+
+    # Create client objects:
+    $config ||= OneviewSDK::Config.load(@config_path)
     $client_120 ||= OneviewSDK::Client.new($config.merge(api_version: 120))
     $client     ||= OneviewSDK::Client.new($config.merge(api_version: 200))
 
@@ -58,9 +60,12 @@ RSpec.shared_context 'system context', a: :b do
 end
 
 RSpec.shared_context 'system api300 context', a: :b do
-
   before(:each) do
-    system_context
+    load_system_properties
+
+    # Create client objects:
+    $config ||= OneviewSDK::Config.load(@config_path)
+    $config_synergy ||= OneviewSDK::Config.load(@config_path_synergy)
     $client_300 ||= OneviewSDK::Client.new($config.merge(api_version: 300))
     $client_300_synergy ||= OneviewSDK::Client.new($config_synergy.merge(api_version: 300))
 
@@ -117,7 +122,17 @@ def integration_context_debugging
   end
 end
 
-def system_context
+# Must set the following environment variables:
+#   ENV['ONEVIEWSDK_SYSTEM_CONFIG'] = '/full/path/to/one_view/one_view_config.json'
+#   ENV['ONEVIEWSDK_SYSTEM_SECRETS'] = '/full/path/to/one_view/one_view_secrets.json'
+#   ENV['ONEVIEWSDK_SYSTEM_CONFIG_SYNERGY'] = '/full/path/to/one_view/one_view_config_synergy.json'
+#   ENV['ONEVIEWSDK_SYSTEM_SECRETS_SYNERGY'] = '/full/path/to/one_view/one_view_secrets_synergy.json'
+# Or use the default paths:
+#   spec/system/one_view_config.json
+#   spec/system/one_view_secrets.json
+#   spec/system/one_view_config_synergy.json
+#   spec/system/one_view_secrets_synergy.json
+def load_system_properties
   default_config  = 'spec/system/one_view_config.json'
   default_secrets = 'spec/system/one_view_secrets.json'
   default_config_synergy  = 'spec/system/one_view_config_synergy.json'
@@ -136,10 +151,14 @@ def system_context
     exit!
   end
 
+  unless File.file?(@config_path_synergy) && File.file?(@secrets_path_synergy)
+    STDERR.puts "\n\n"
+    STDERR.puts 'ERROR: System config file for Synergy not found' unless File.file?(@config_path_synergy)
+    STDERR.puts 'ERROR: System secrets file for Synergy not found' unless File.file?(@secrets_path_synergy)
+    STDERR.puts "\n\n"
+    exit!
+  end
+
   $secrets ||= OneviewSDK::Config.load(@secrets_path) # Secrets for URIs, server/enclosure credentials, etc.
   $secrets_synergy ||= OneviewSDK::Config.load(@secrets_path_synergy) # Secrets for URIs, server/enclosure credentials, etc.
-
-  # Create client objects:
-  $config ||= OneviewSDK::Config.load(@config_path)
-  $config_synergy ||= OneviewSDK::Config.load(@config_path_synergy)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,8 +54,6 @@ require 'oneview-sdk'
 require_relative 'shared_context'
 require_relative 'support/fake_response'
 require_relative 'integration/sequence_and_naming'
-require_relative 'system/light_profile/resource_names'
-
 
 RSpec.configure do |config|
   # Sort integration and system tests

--- a/spec/system/README.md
+++ b/spec/system/README.md
@@ -10,33 +10,47 @@ First, there's some setup you'll need to do. Do EITHER of the following:
 
 1. **Use environment variables to specify config file locations:**
 
-  1. Copy the [one_view_config.json.example](one_view_config.json.example) and
-   [one_view_secrets.json.example](one_view_secrets.json.example) files to a secure location
+  1. Copy the [one_view_config.json.example](one_view_config.json.example), [one_view_secrets.json.example](one_view_secrets.json.example),
+   [one_view_config_synergy.json.example](one_view_config_synergy.json.example),
+   [one_view_secrets_synergy.json.example](one_view_secrets_synergy.json.example) files to a secure location
    **outside** this repo. When you do so, drop the `.example` part of the filename.
+
+   - [one_view_config.json.example](one_view_config.json.example): Tests for API v200 and API v300 C7000
+   - [one_view_secrets.json.example](one_view_secrets.json.example): Tests for API v200 and API v300 C7000
+   - [one_view_config_synergy.json.example](one_view_config_synergy.json.example): Tests for API v300 Synergy
+   - [one_view_secrets_synergy.json.example](one_view_secrets_synergy.json.example): Tests for API v300 Synergy
 
   2. Then set the following environment variables with the paths to the files you just created:
 
    ```bash
    export ONEVIEWSDK_SYSTEM_CONFIG='/path/to/one_view_config.json'
    export ONEVIEWSDK_SYSTEM_SECRETS='/path/to/one_view_secrets.json'
+   export ONEVIEWSDK_SYSTEM_CONFIG_SYNERGY='/path/to/one_view_config_synergy.json'
+   export ONEVIEWSDK_SYSTEM_SECRETS_SYNERGY='/path/to/one_view_secrets_synergy.json'
    ```
 
 2. **Use default config file locations**
 
-  1. Copy the [one_view_config.json.example](one_view_config.json.example) and
-   [one_view_secrets.json.example](one_view_secrets.json.example) files into the same directory (spec/integration) and drop the `.example` part of the filename on the new coppies. You should now have the following files:
+  1. Copy the [one_view_config.json.example](one_view_config.json.example), [one_view_secrets.json.example](one_view_secrets.json.example),
+   [one_view_config_synergy.json.example](one_view_config_synergy.json.example),
+   [one_view_secrets_synergy.json.example](one_view_secrets_synergy.json.example) files into the same directory (spec/integration)
+   and drop the `.example` part of the filename on the new coppies. You should now have the following files:
 
    ```bash
    spec/system/one_view_config.json
    spec/system/one_view_secrets.json
+   spec/system/one_view_config_synergy.json
+   spec/system/one_view_secrets_synergy.json
    ```
 
 
 These config files get loaded and create the following global variables:
- - `$secrets`: 
+ - `$secrets`:
  - `$config`: Config for connecting to OneView appliance
  - `$client_120`: Client object pinned to API v120
- - `$client`: Client object using latest API version supported by the appliance
+ - `$client`: Client object pinned to API v200
+ - `$client_300`: Client object using API v300 C7000
+ - `$client_300_synergy`: Client object using API v300 Synergy
 
 ## Running the tests
 The following command must run in your Ruby SDK root directory:
@@ -50,4 +64,12 @@ $ rake spec:system
 $ rake spec:system:light
 $ rake spec:system:medium
 $ rake spec:system:heavy
+$ rake spec:system:api_version[version] # spec:system:api_version[300]
+$ rake spec:system:api_version_model[version,model] # spec:system:api_version_model[300,c7000]
+$ rake spec:system:light:api_version[version]
+$ rake spec:system:light:api_version_model[version,model]
+$ rake spec:system:medium:api_version[version]
+$ rake spec:system:medium:api_version_model[version,model]
+$ rake spec:system:heavy:api_version[version]
+$ rake spec:system:heavy:api_version_model[version,model]
 ```

--- a/spec/system/light_profile/api200/resource_names.rb
+++ b/spec/system/light_profile/api200/resource_names.rb
@@ -1,0 +1,38 @@
+# Resources names shared among system test scenarios
+class ResourceNames
+  class << self
+    attr_accessor :ethernet_network
+    attr_accessor :bulk_ethernet_network
+    attr_accessor :fc_network
+    attr_accessor :fcoe_network
+    attr_accessor :logical_interconnect_group
+    attr_accessor :uplink_set
+    attr_accessor :enclosure_group
+    attr_accessor :enclosure
+    attr_accessor :logical_enclosure
+    attr_accessor :logical_interconnect
+    attr_accessor :interconnect
+    attr_accessor :storage_system
+    attr_accessor :storage_pool
+    attr_accessor :volume
+    attr_accessor :volume_template
+    attr_accessor :interconnect_type
+  end
+
+  self.ethernet_network = ['EthernetNetwork_01']
+  self.bulk_ethernet_network = ['BulkEthernetNetwork']
+  self.fc_network = ['FCNetwork_01']
+  self.fcoe_network = ['FCoENetwork_01']
+  self.logical_interconnect_group = ['LogicalInterconnectGroup_01']
+  self.uplink_set = %w(EthernetUplinkSet_01 FCUplinkSet_01)
+  self.enclosure_group = %w(EnclosureGroup_01 EnclosureGroup_02)
+  self.enclosure = ['Encl1']
+  self.logical_enclosure = ['Encl1']
+  self.logical_interconnect = ['Encl1-LogicalInterconnectGroup_01']
+  self.interconnect = ['Encl1, interconnect 1', 'Encl1, interconnect 3']
+  self.storage_system = ['ThreePAR7200-8810']
+  self.storage_pool = ['FST_CPG2']
+  self.volume = ['Volume_01']
+  self.volume_template = ['VolumeTemplate_01']
+  self.interconnect_type = ['HP VC FlexFabric-20/40 F8 Module', 'HP VC 16Gb 24-Port FC Module']
+end

--- a/spec/system/light_profile/api300/c7000/create_spec.rb
+++ b/spec/system/light_profile/api300/c7000/create_spec.rb
@@ -1,0 +1,241 @@
+# System test script
+# Light Profie
+
+require 'spec_helper'
+require_relative 'resource_names'
+
+RSpec.describe 'Spin up fluid resource pool API300 C7000', system: true, sequence: 1 do
+  include_context 'system api300 context'
+
+  it 'Ethernet Networks' do
+    options = {
+      name: ResourceNames.ethernet_network[0],
+      description: 'Ethernet network',
+      ethernetNetworkType: 'Tagged',
+      vlanId: 1001,
+      purpose: 'General',
+      smartLink: true,
+      privateNetwork: false
+    }
+    eth1 = OneviewSDK::API300::C7000::EthernetNetwork.new($client_300, options)
+    eth1.create
+    expect(eth1['uri']).not_to be_empty
+  end
+
+  it 'Bulk Ethernet Network' do
+    bulk_options = {
+      vlanIdRange: '2-6',
+      purpose: 'General',
+      namePrefix: ResourceNames.bulk_ethernet_network[0],
+      smartLink: false,
+      privateNetwork: false,
+      bandwidth: {
+        maximumBandwidth: 10_000,
+        typicalBandwidth: 2_000
+      }
+    }
+    OneviewSDK::API300::C7000::EthernetNetwork.bulk_create($client_300, bulk_options)
+  end
+
+  it 'FC Network' do
+    options = {
+      name: ResourceNames.fc_network[0],
+      connectionTemplateUri: nil,
+      autoLoginRedistribution: true,
+      fabricType: 'FabricAttach'
+    }
+    fc1 = OneviewSDK::API300::C7000::FCNetwork.new($client_300, options)
+    fc1.create
+    expect(fc1['uri']).not_to be_empty
+  end
+
+  it 'FCoE Network' do
+    options = {
+      name: ResourceNames.fcoe_network[0],
+      connectionTemplateUri: nil,
+      vlanId: 100
+    }
+    fcoe1 = OneviewSDK::API300::C7000::FCoENetwork.new($client_300, options)
+    fcoe1.create
+    expect(fcoe1['uri']).not_to be_empty
+  end
+
+  it 'Logical interconnect group' do
+    options = {
+      name: ResourceNames.logical_interconnect_group[0],
+      enclosureType: 'C7000'
+    }
+    lig1 = OneviewSDK::API300::C7000::LogicalInterconnectGroup.new($client_300, options)
+    lig1.add_interconnect(1, ResourceNames.interconnect_type[0])
+    lig1.add_interconnect(3, ResourceNames.interconnect_type[1])
+    lig1.create
+    expect(lig1['uri']).not_to be_empty
+  end
+
+  it 'Enclosure Group' do
+    lig = OneviewSDK::API300::C7000::LogicalInterconnectGroup.new($client_300, name: ResourceNames.logical_interconnect_group[0])
+    lig.retrieve!
+
+    options = {
+      name: ResourceNames.enclosure_group[0],
+      stackingMode: 'Enclosure',
+      interconnectBayMappingCount: 8
+    }
+
+    eg1 = OneviewSDK::API300::C7000::EnclosureGroup.new($client_300, options)
+    eg1.add_logical_interconnect_group(lig)
+    eg1.create
+    expect(eg1['uri']).not_to be_empty
+
+    options[:name] = ResourceNames.enclosure_group[1]
+    eg2 = OneviewSDK::API300::C7000::EnclosureGroup.new($client_300, options)
+    eg2.create
+    expect(eg2['uri']).not_to be_empty
+  end
+
+  it 'Enclosure' do
+    eg1 = OneviewSDK::API300::C7000::EnclosureGroup.new($client_300, name: ResourceNames.enclosure_group[0])
+    eg1.retrieve!
+    options = {
+      enclosureGroupUri: eg1['uri'],
+      hostname: $secrets['enclosure1_ip'],
+      username: $secrets['enclosure1_user'],
+      password: $secrets['enclosure1_password'],
+      licensingIntent: 'OneView'
+    }
+    enc = OneviewSDK::API300::C7000::Enclosure.new($client_300, options)
+    enc.add
+    expect(enc['uri']).not_to be_empty
+  end
+
+  it 'Storage System' do
+    options = {
+      credentials: {
+        ip_hostname: $secrets['storage_system1_ip'],
+        username: $secrets['storage_system1_user'],
+        password: $secrets['storage_system1_password']
+      },
+      managedDomain: 'TestDomain'
+    }
+    storage = OneviewSDK::API300::C7000::StorageSystem.new($client_300, options)
+    storage.add
+    expect(storage['uri']).not_to be_empty
+  end
+
+  it 'Storage Pool' do
+    storage_system = OneviewSDK::API300::C7000::StorageSystem.new($client_300, name: ResourceNames.storage_system[0])
+    storage_system.retrieve!
+    expect(storage_system['uri']).not_to be_empty
+    options = {
+      storageSystemUri: storage_system['uri'],
+      poolName: ResourceNames.storage_pool[0]
+    }
+    storage_pool = OneviewSDK::API300::C7000::StoragePool.new($client_300, options)
+    storage_pool.add
+    expect(storage_pool['uri']).not_to be_empty
+  end
+
+  it 'Volume' do
+    storage_system = OneviewSDK::API300::C7000::StorageSystem.new($client_300, name: ResourceNames.storage_system[0])
+    storage_system.retrieve!
+    expect(storage_system['uri']).not_to be_empty
+    pools = OneviewSDK::API300::C7000::StoragePool.find_by($client_300, storageSystemUri: storage_system[:uri])
+    storage_pool = pools.first
+    options = {
+      name: ResourceNames.volume[0],
+      description: 'Test volume with common creation: Storage System + Storage Pool',
+      provisioningParameters: {
+        provisionType: 'Full',
+        shareable: true,
+        storagePoolUri: storage_pool['uri'],
+        requestedCapacity: 512 * 1024 * 1024
+      }
+    }
+    volume = OneviewSDK::API300::C7000::Volume.new($client_300, options)
+    volume.create
+    expect(volume['uri']).not_to be_empty
+  end
+
+  it 'Volume Template' do
+    options = {
+      name: ResourceNames.volume_template[0],
+      description: 'Volume Template',
+      stateReason: 'None'
+    }
+    storage_pool = OneviewSDK::API300::C7000::StoragePool.find_by($client_300, {}).first
+    storage_system = OneviewSDK::API300::C7000::StorageSystem.find_by($client_300, {}).first
+    volume_template = OneviewSDK::API300::C7000::VolumeTemplate.new($client_300, options)
+    volume_template.set_provisioning(true, 'Thin', '10737418240', storage_pool)
+    volume_template.set_snapshot_pool(storage_pool)
+    volume_template.set_storage_system(storage_system)
+    volume_template.create
+    expect(volume_template['uri']).not_to be_empty
+  end
+
+  it 'Uplink set Ethernet' do
+    ethernet = OneviewSDK::API300::C7000::EthernetNetwork.new($client_300, name: ResourceNames.ethernet_network[0])
+    ethernet.retrieve!
+
+    enclosure = OneviewSDK::API300::C7000::Enclosure.new($client_300, name: ResourceNames.enclosure[0])
+    enclosure.retrieve!
+
+    li = OneviewSDK::API300::C7000::LogicalInterconnect.new($client_300, name: ResourceNames.logical_interconnect[0])
+    li.retrieve!
+
+    interconnect = OneviewSDK::API300::C7000::Interconnect.new($client_300, name: ResourceNames.interconnect[0])
+    interconnect.retrieve!
+
+    options = {
+      type: 'uplink-setV300',
+      connectionMode: 'Auto',
+      ethernetNetworkType: ethernet['ethernetNetworkType'],
+      logicalInterconnectUri: li['uri'],
+      manualLoginRedistributionState: 'NotSupported',
+      networkType: 'Ethernet',
+      name: ResourceNames.uplink_set[0],
+      networkUris: [ethernet['uri']]
+    }
+    uplink = OneviewSDK::API300::C7000::UplinkSet.new($client_300, options)
+    uplink.add_port_config(
+      "#{interconnect['uri']}:Q1.1",
+      'Auto',
+      [{ value: 1, type: 'Bay' }, { value: enclosure['uri'], type: 'Enclosure' }, { value: 'Q1.1', type: 'Port' }]
+    )
+    uplink.add_network(ethernet)
+    uplink.create
+  end
+
+  it 'Uplink set FC' do
+    fc = OneviewSDK::API300::C7000::FCNetwork.new($client_300, name: ResourceNames.fc_network[0])
+    fc.retrieve!
+
+    enclosure = OneviewSDK::API300::C7000::Enclosure.new($client_300, name: ResourceNames.enclosure[0])
+    enclosure.retrieve!
+
+    li = OneviewSDK::API300::C7000::LogicalInterconnect.new($client_300, name: ResourceNames.logical_interconnect[0])
+    li.retrieve!
+
+    interconnect = OneviewSDK::API300::C7000::Interconnect.new($client_300, name: ResourceNames.interconnect[1])
+    interconnect.retrieve!
+
+    options = {
+      type: 'uplink-setV300',
+      connectionMode: 'Auto',
+      ethernetNetworkType: 'Tagged',
+      logicalInterconnectUri: li['uri'],
+      manualLoginRedistributionState: 'Supported',
+      networkType: 'FibreChannel',
+      name: ResourceNames.uplink_set[1],
+      fcNetworkUris: [fc['uri']]
+    }
+    uplink = OneviewSDK::API300::C7000::UplinkSet.new($client_300, options)
+    uplink.add_port_config(
+      "#{interconnect['uri']}:1",
+      'Auto',
+      [{ value: 3, type: 'Bay' }, { value: enclosure['uri'], type: 'Enclosure' }, { value: '1', type: 'Port' }]
+    )
+    uplink.add_fcnetwork(fc)
+    uplink.create
+  end
+
+end

--- a/spec/system/light_profile/api300/c7000/resource_names.rb
+++ b/spec/system/light_profile/api300/c7000/resource_names.rb
@@ -1,0 +1,39 @@
+# Resources names shared among system test scenarios
+class ResourceNames
+  class << self
+    attr_accessor :ethernet_network
+    attr_accessor :bulk_ethernet_network
+    attr_accessor :fc_network
+    attr_accessor :fcoe_network
+    attr_accessor :logical_interconnect_group
+    attr_accessor :uplink_set
+    attr_accessor :enclosure_group
+    attr_accessor :enclosure
+    attr_accessor :logical_enclosure
+    attr_accessor :logical_interconnect
+    attr_accessor :interconnect
+    attr_accessor :storage_system
+    attr_accessor :storage_pool
+    attr_accessor :volume
+    attr_accessor :volume_template
+    attr_accessor :interconnect_type
+  end
+
+  self.ethernet_network = ['EthernetNetwork_01']
+  self.bulk_ethernet_network = ['BulkEthernetNetwork']
+  self.fc_network = ['FCNetwork_01']
+  self.fcoe_network = ['FCoENetwork_01']
+  self.logical_interconnect_group = ['LogicalInterconnectGroup_01']
+  self.uplink_set = %w(EthernetUplinkSet_01 FCUplinkSet_01)
+  self.enclosure_group = %w(EnclosureGroup_01 EnclosureGroup_02)
+  self.enclosure = ['Encl1']
+  self.logical_enclosure = ['Encl1']
+  self.logical_interconnect = ['Encl1-LogicalInterconnectGroup_01']
+  self.interconnect = ['Encl1, interconnect 1', 'Encl1, interconnect 3']
+  self.storage_system = ['ThreePAR7200-8810']
+  self.storage_pool = ['FST_CPG2']
+  self.volume = ['Volume_01']
+  self.volume_template = ['VolumeTemplate_01']
+  self.interconnect_type = ['HP VC FlexFabric-20/40 F8 Module', 'HP VC 16Gb 24-Port FC Module']
+
+end

--- a/spec/system/light_profile/api300/synergy/create_spec.rb
+++ b/spec/system/light_profile/api300/synergy/create_spec.rb
@@ -1,0 +1,260 @@
+# System test script
+# Light Profie
+
+require 'spec_helper'
+require_relative 'resource_names'
+
+RSpec.describe 'Spin up fluid resource pool API300 Synergy', system: true, sequence: 1 do
+  include_context 'system api300 context'
+
+  it 'Ethernet Networks' do
+    options = {
+      name: ResourceNames.ethernet_network[0],
+      description: 'Ethernet network',
+      ethernetNetworkType: 'Tagged',
+      vlanId: 1001,
+      purpose: 'General',
+      smartLink: true,
+      privateNetwork: false
+    }
+    eth1 = OneviewSDK::API300::Synergy::EthernetNetwork.new($client_300_synergy, options)
+    eth1.create
+    expect(eth1['uri']).not_to be_empty
+  end
+
+  it 'Bulk Ethernet Network' do
+    bulk_options = {
+      vlanIdRange: '2-6',
+      purpose: 'General',
+      namePrefix: ResourceNames.bulk_ethernet_network[0],
+      smartLink: false,
+      privateNetwork: false,
+      bandwidth: {
+        maximumBandwidth: 10_000,
+        typicalBandwidth: 2_000
+      }
+    }
+    OneviewSDK::API300::Synergy::EthernetNetwork.bulk_create($client_300_synergy, bulk_options)
+  end
+
+  it 'FC Network' do
+    options = {
+      name: ResourceNames.fc_network[0],
+      connectionTemplateUri: nil,
+      autoLoginRedistribution: true,
+      fabricType: 'FabricAttach'
+    }
+    fc1 = OneviewSDK::API300::Synergy::FCNetwork.new($client_300_synergy, options)
+    fc1.create
+    expect(fc1['uri']).not_to be_empty
+  end
+
+  it 'FCoE Network' do
+    options = {
+      name: ResourceNames.fcoe_network[0],
+      connectionTemplateUri: nil,
+      vlanId: 100
+    }
+    fcoe1 = OneviewSDK::API300::Synergy::FCoENetwork.new($client_300_synergy, options)
+    fcoe1.create
+    expect(fcoe1['uri']).not_to be_empty
+  end
+
+  it 'Logical interconnect group' do
+    options = {
+      name: ResourceNames.logical_interconnect_group[0],
+      redundancyType: 'Redundant',
+      interconnectBaySet: 2,
+      enclosureIndexes: [-1]
+    }
+    lig = OneviewSDK::API300::Synergy::LogicalInterconnectGroup.new($client_300_synergy, options)
+    lig.add_interconnect(2, ResourceNames.interconnect_type[0])
+    lig.add_interconnect(5, ResourceNames.interconnect_type[0])
+    lig['interconnectMapTemplate']['interconnectMapEntryTemplates'].each { |i| i['enclosureIndex'] = -1 }
+    lig.create
+    expect(lig['uri']).not_to be_empty
+  end
+
+  it 'Enclosure Group' do
+    lig_options = {
+      name: ResourceNames.logical_interconnect_group[0]
+    }
+
+    lig = OneviewSDK::API300::Synergy::LogicalInterconnectGroup.new($client_300_synergy, lig_options)
+    lig.retrieve!
+
+    options = {
+      'name' => ResourceNames.enclosure_group[0],
+      'stackingMode' => 'Enclosure',
+      'ipAddressingMode' => 'DHCP',
+      'type' => 'EnclosureGroupV300',
+      'enclosureCount' => 3,
+      'interconnectBayMappings' =>
+      [
+        {
+          'enclosureIndex' => 1,
+          'interconnectBay' => 2,
+          'logicalInterconnectGroupUri' => ''
+        },
+        {
+          'enclosureIndex' => 1,
+          'interconnectBay' => 5,
+          'logicalInterconnectGroupUri' => ''
+        },
+        {
+          'enclosureIndex' => 3,
+          'interconnectBay' => 2,
+          'logicalInterconnectGroupUri' => ''
+        },
+        {
+          'enclosureIndex' => 3,
+          'interconnectBay' => 5,
+          'logicalInterconnectGroupUri' => ''
+        }
+      ]
+    }
+
+    eg1 = OneviewSDK::API300::Synergy::EnclosureGroup.new($client_300_synergy, options)
+    eg1['interconnectBayMappings'].each do |bay|
+      bay['logicalInterconnectGroupUri'] = lig['uri']
+    end
+    eg1.add_logical_interconnect_group(lig)
+    eg1.create
+    expect(eg1['uri']).not_to be_empty
+    eg1['interconnectBayMappings'].each do |bay|
+      if bay['interconnectBay'] == 2 || bay['interconnectBay'] == 5
+        expect(bay['logicalInterconnectGroupUri']).to eq(lig['uri'])
+      else
+        expect(bay['logicalInterconnectGroupUri']).to_not be
+      end
+    end
+
+    options[:name] = ResourceNames.enclosure_group[1]
+    eg2 = OneviewSDK::API300::Synergy::EnclosureGroup.new($client_300_synergy, options)
+    eg2.create
+    expect(eg2['uri']).not_to be_empty
+  end
+
+  it 'Logical Enclosure' do
+    eg1 = OneviewSDK::API300::Synergy::EnclosureGroup.new($client_300_synergy, name: ResourceNames.enclosure_group[0])
+    eg1.retrieve!
+    enc1 = OneviewSDK::API300::Synergy::Enclosure.find_by($client_300_synergy, name: ResourceNames.enclosure[0]).first
+    enc2 = OneviewSDK::API300::Synergy::Enclosure.find_by($client_300_synergy, name: ResourceNames.enclosure[1]).first
+    enc3 = OneviewSDK::API300::Synergy::Enclosure.find_by($client_300_synergy, name: ResourceNames.enclosure[2]).first
+
+    le = OneviewSDK::API300::Synergy::LogicalEnclosure.new($client_300_synergy, name: ResourceNames.logical_enclosure[0])
+    le.set_enclosure_group(eg1)
+    le.set_enclosures([enc1, enc2, enc3])
+    le.create
+    result = OneviewSDK::API300::Synergy::LogicalEnclosure.find_by($client_300_synergy, name: ResourceNames.logical_enclosure[0]).first
+    expect(result['uri']).to be_truthy
+    expect(result['enclosureGroupUri']).to eq(le['enclosureGroupUri'])
+    expect(result['enclosureUris']).to eq(le['enclosureUris'])
+    expect(result['enclosures'].size).to eq(3)
+    expect(result['enclosures'].key?(le['enclosureUris'].first)).to be true
+  end
+
+  it 'Storage System' do
+    options = {
+      credentials: {
+        ip_hostname: $secrets_synergy['storage_system1_ip'],
+        username: $secrets_synergy['storage_system1_user'],
+        password: $secrets_synergy['storage_system1_password']
+      },
+      managedDomain: 'TestDomain'
+    }
+    storage = OneviewSDK::API300::Synergy::StorageSystem.new($client_300_synergy, options)
+    storage.add
+    expect(storage['uri']).not_to be_empty
+  end
+
+  it 'Storage Pool' do
+    storage_system = OneviewSDK::API300::Synergy::StorageSystem.new($client_300_synergy, name: ResourceNames.storage_system[0])
+    storage_system.retrieve!
+    expect(storage_system['uri']).not_to be_empty
+    options = {
+      storageSystemUri: storage_system['uri'],
+      poolName: ResourceNames.storage_pool[0]
+    }
+    storage_pool = OneviewSDK::API300::Synergy::StoragePool.new($client_300_synergy, options)
+    storage_pool.add
+    expect(storage_pool['uri']).not_to be_empty
+  end
+
+  it 'Volume' do
+    storage_system = OneviewSDK::API300::Synergy::StorageSystem.new($client_300_synergy, name: ResourceNames.storage_system[0])
+    storage_system.retrieve!
+    expect(storage_system['uri']).not_to be_empty
+    pools = OneviewSDK::API300::Synergy::StoragePool.find_by($client_300_synergy, storageSystemUri: storage_system[:uri])
+    storage_pool = pools.first
+    options = {
+      name: ResourceNames.volume[0],
+      description: 'Test volume with common creation: Storage System + Storage Pool',
+      provisioningParameters: {
+        provisionType: 'Full',
+        shareable: true,
+        storagePoolUri: storage_pool['uri'],
+        requestedCapacity: 512 * 1024 * 1024
+      }
+    }
+    volume = OneviewSDK::API300::Synergy::Volume.new($client_300_synergy, options)
+    volume.create
+    expect(volume['uri']).not_to be_empty
+  end
+
+  it 'Volume Template' do
+    options = {
+      name: ResourceNames.volume_template[0],
+      description: 'Volume Template',
+      stateReason: 'None'
+    }
+
+    storage_system = OneviewSDK::API300::Synergy::StorageSystem.new($client_300_synergy, name: ResourceNames.storage_system[0])
+    storage_system.retrieve!
+    sp_options = {
+      name: ResourceNames.storage_pool[0],
+      storageSystemUri: storage_system['uri']
+    }
+    storage_pool = OneviewSDK::API300::Synergy::StoragePool.new($client_300_synergy, sp_options)
+    storage_pool.retrieve!
+    volume_template = OneviewSDK::API300::Synergy::VolumeTemplate.new($client_300_synergy, options)
+    volume_template.set_provisioning(true, 'Thin', '10737418240', storage_pool)
+    volume_template.set_snapshot_pool(storage_pool)
+    volume_template.set_storage_system(storage_system)
+    volume_template.create
+    expect(volume_template['uri']).not_to be_empty
+  end
+
+  it 'Uplink set FC' do
+    fc = OneviewSDK::API300::Synergy::FCNetwork.new($client_300_synergy, name: ResourceNames.fc_network[0])
+    fc.retrieve!
+
+    enclosure = OneviewSDK::API300::Synergy::Enclosure.new($client_300_synergy, name: ResourceNames.enclosure[0])
+    enclosure.retrieve!
+
+    li = OneviewSDK::API300::Synergy::LogicalInterconnect.new($client_300_synergy, name: ResourceNames.logical_interconnect[0])
+    li.retrieve!
+
+    interconnect = OneviewSDK::API300::Synergy::Interconnect.new($client_300_synergy, name: ResourceNames.interconnect[1])
+    interconnect.retrieve!
+
+    options = {
+      type: 'uplink-setV300',
+      connectionMode: 'Auto',
+      ethernetNetworkType: 'Tagged',
+      logicalInterconnectUri: li['uri'],
+      manualLoginRedistributionState: 'Supported',
+      networkType: 'FibreChannel',
+      name: ResourceNames.uplink_set[1],
+      fcNetworkUris: [fc['uri']]
+    }
+    uplink = OneviewSDK::API300::Synergy::UplinkSet.new($client_300_synergy, options)
+    uplink.add_port_config(
+      "#{interconnect['uri']}:1",
+      'Auto',
+      [{ value: 2, type: 'Bay' }, { value: enclosure['uri'], type: 'Enclosure' }, { value: '1', type: 'Port' }]
+    )
+    uplink.add_fcnetwork(fc)
+    uplink.create
+  end
+end

--- a/spec/system/light_profile/api300/synergy/resource_names.rb
+++ b/spec/system/light_profile/api300/synergy/resource_names.rb
@@ -16,6 +16,7 @@ class ResourceNames
     attr_accessor :storage_pool
     attr_accessor :volume
     attr_accessor :volume_template
+    attr_accessor :interconnect_type
   end
 
   self.ethernet_network = ['EthernetNetwork_01']
@@ -25,13 +26,12 @@ class ResourceNames
   self.logical_interconnect_group = ['LogicalInterconnectGroup_01']
   self.uplink_set = %w(EthernetUplinkSet_01 FCUplinkSet_01)
   self.enclosure_group = %w(EnclosureGroup_01 EnclosureGroup_02)
-  self.enclosure = ['Encl1']
-  self.logical_enclosure = ['Encl1']
-  self.logical_interconnect = ['Encl1-LogicalInterconnectGroup_01']
-  self.interconnect = ['Encl1, interconnect 1', 'Encl1, interconnect 2']
-  self.storage_system = ['ThreePAR7200-2027']
-  self.storage_pool = ['CPG-SSD-AO']
+  self.enclosure = %w(0000A66101 0000A66102 0000A66103)
+  self.logical_enclosure = ['LogicalEnclosure_1']
+  self.logical_interconnect = ['LogicalEnclosure_1-LogicalInterconnectGroup_01-1']
+  self.interconnect = ['0000A66101, interconnect 2', '0000A66101, interconnect 5']
+  self.storage_system = ['ThreePAR7200-6710']
+  self.storage_pool = ['FST_CPG2']
   self.volume = ['Volume_01']
-  self.volume_template = ['VolumeTemplate_01']
-
+  self.interconnect_type = ['Virtual Connect SE 16Gb FC Module for Synergy']
 end

--- a/spec/system/one_view_config_synergy.json.example
+++ b/spec/system/one_view_config_synergy.json.example
@@ -1,0 +1,6 @@
+{
+  "url"         : "https://oneview.example.com",
+  "user"        : "Administrator",
+  "password"    : "secret123",
+  "ssl_enabled" : false
+}

--- a/spec/system/one_view_secrets_synergy.json.example
+++ b/spec/system/one_view_secrets_synergy.json.example
@@ -1,0 +1,8 @@
+{
+  "enclosure1_ip": "172.18.1.11",
+  "enclosure1_user": "dcs",
+  "enclosure1_password": "dcs",
+  "storage_system1_ip": "172.18.11.11",
+  "storage_system1_user": "dcs",
+  "storage_system1_password": "dcs"
+}


### PR DESCRIPTION
### Description
System tests are suitable for the API 300. Test strategy to run tests for different schemas. Please read the README.md file from the spec/system/README.md file for instructions.

### Issues Resolved
#109 

### Check List
- [ ] New functionality includes testing.
  - [] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
