### PR TITLE
Bug fix in API300 C7000 Managed SAN method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
 - SAS Logical JBODs
 - Unmanaged devices
 
+2. Bug fixes:
+- Fixed issue #124 Missing argument in API300 C7000 Managed SAN method.
+
 # v3.0.0
 ### Notes
  This is the Third major version of the Ruby SDK for HPE OneView. It features a split in the API support, allowing for C7000 and Synergy hardware variants to be used, while maintaining compatibility to older versions. There are some code improvements applied throughout the release, as well as additional endpoints support.

--- a/lib/oneview-sdk/resource/api300/c7000/managed_san.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/managed_san.rb
@@ -27,7 +27,7 @@ module OneviewSDK
 
         # Method is not available
         # @raise [OneviewSDK::MethodUnavailable] method is not available
-        def set_public_attributes
+        def set_public_attributes(_attributes)
           unavailable_method
         end
       end

--- a/spec/integration/resource/api300/c7000/managed_san/update_spec.rb
+++ b/spec/integration/resource/api300/c7000/managed_san/update_spec.rb
@@ -42,25 +42,9 @@ RSpec.describe klass, integration: true, type: UPDATE do
   end
 
   describe '#set_public_attributes' do
-
-    it 'is a pending test'
-    # NOTE: Disabled for now as the endpoint is not showing on documentation and
-    # it does not seem to be working. Following up on this with a oneview bug to
-    # track it, and may remove or uncomment it later on.
-    # it 'Update public attributes' do
-    #   attributes = [
-    #     {
-    #       'name' => 'MetaSan',
-    #       'value' => 'Neon SAN',
-    #       'valueType' => 'String',
-    #       'valueFormat' => 'None',
-    #       'displayName' => nil,
-    #       'required' => false
-    #     }
-    #   ]
-    #   expect { @item.set_public_attributes(attributes) }.not_to raise_error
-    #   expect(@item['publicAttributes']).to eq(attributes)
-    # end
+    it 'Update public attributes' do
+      expect { @item.set_public_attributes(name: 'MetaSan') }.to raise_error(/The method #set_public_attributes is unavailable for this resource/)
+    end
   end
 
   describe '#set_san_policy' do

--- a/spec/integration/resource/api300/synergy/managed_san/update_spec.rb
+++ b/spec/integration/resource/api300/synergy/managed_san/update_spec.rb
@@ -42,25 +42,9 @@ RSpec.describe klass, integration: true, type: UPDATE do
   end
 
   describe '#set_public_attributes' do
-
-    it 'is a pending test'
-    # NOTE: Disabled for now as the endpoint is not showing on documentation and
-    # it does not seem to be working. Following up on this with a oneview bug to
-    # track it, and may remove or uncomment it later on.
-    # it 'Update public attributes' do
-    #   attributes = [
-    #     {
-    #       'name' => 'MetaSan',
-    #       'value' => 'Neon SAN',
-    #       'valueType' => 'String',
-    #       'valueFormat' => 'None',
-    #       'displayName' => nil,
-    #       'required' => false
-    #     }
-    #   ]
-    #   expect { @item.set_public_attributes(attributes) }.not_to raise_error
-    #   expect(@item['publicAttributes']).to eq(attributes)
-    # end
+    it 'Update public attributes' do
+      expect { @item.set_public_attributes(name: 'MetaSan') }.to raise_error(/The method #set_public_attributes is unavailable for this resource/)
+    end
   end
 
   describe '#set_san_policy' do

--- a/spec/unit/resource/api300/c7000/managed_san_spec.rb
+++ b/spec/unit/resource/api300/c7000/managed_san_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe klass do
   describe '#set_public_attributes' do
     it 'is unavailable' do
       san = klass.new(@client_300)
-      expect { san.set_public_attributes }.to raise_error(/The method #set_public_attributes is unavailable for this resource/)
+      expect { san.set_public_attributes(name: 'MetaSan') }.to raise_error(/The method #set_public_attributes is unavailable for this resource/)
     end
 
     # NOTE: This is disabled while waiting on a defect reply from the oneview team

--- a/spec/unit/resource/api300/synergy/managed_san_spec.rb
+++ b/spec/unit/resource/api300/synergy/managed_san_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe klass do
   describe '#set_public_attributes' do
     it 'is unavailable' do
       san = klass.new(@client_300)
-      expect { san.set_public_attributes }.to raise_error(/The method #set_public_attributes is unavailable for this resource/)
+      expect { san.set_public_attributes(name: 'MetaSan') }.to raise_error(/The method #set_public_attributes is unavailable for this resource/)
     end
 
     # NOTE: This is disabled while waiting on a defect reply from the oneview team


### PR DESCRIPTION
### Description
Missing argument in the signature of the unavailable method on Managed San.

### Issues Resolved
#124 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
