### PR TITLE
Fixes #132: get_default_settings in API200 is currently an instance method, but it should be a class method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Suggested release: v4.0.0
 
-#### Breaking changes:
+#### Bug fixes
 - Fixed issue #132 get_default_settings in API200 is currently an instance method, but it should be a class method
+
+#### Breaking changes:
 - Fixed issue #93 Logical Switch refresh conflict
 
 #### Design changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased Changes
 
-## Unreleased: v4.0.0
+## Suggested release: v4.0.0
 
-#### Bug fixes:
+#### Breaking changes:
 - Fixed issue #132 get_default_settings in API200 is currently an instance method, but it should be a class method
 
 #### Design changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Unreleased Changes
+
+## Unreleased: v4.0.0
+
+#### Bug fixes:
+- Fixed issue #132 get_default_settings in API200 is currently an instance method, but it should be a class method
+
 #### Design changes:
    - Architecture for future Image Streamer support. **Unimplemented** features to support in the future:
      - Artifacts Bundle

--- a/examples/api200/logical_interconnect_group.rb
+++ b/examples/api200/logical_interconnect_group.rb
@@ -111,7 +111,7 @@ OneviewSDK::LogicalInterconnectGroup.find_by(@client, {}).each do |r|
 end
 
 puts '## Listing default settings ##'
-puts lig.get_default_settings
+puts OneviewSDK::LogicalInterconnectGroup.get_default_settings(@client)
 
 puts '## Listing this LIG settings ##'
 puts lig.get_settings

--- a/examples/api300/c7000/logical_interconnect_group.rb
+++ b/examples/api300/c7000/logical_interconnect_group.rb
@@ -18,7 +18,7 @@ type = 'Logical Interconnect Group'
 options = {
   name: 'ONEVIEW_SDK_TEST_LIG',
   enclosureType: 'C7000',
-  type: 'logical-interconnect-groupV3'
+  type: 'logical-interconnect-groupV300'
 }
 
 HP_VC_FF_24_MODEL = 'HP VC FlexFabric 10Gb/24-Port Module'.freeze
@@ -37,7 +37,7 @@ eth1_options = {
   smartLink:  false,
   privateNetwork:  false,
   connectionTemplateUri:  nil,
-  type:  'ethernet-networkV3'
+  type:  'ethernet-networkV300'
 }
 
 eth2_options = {
@@ -47,7 +47,7 @@ eth2_options = {
   smartLink:  false,
   privateNetwork:  false,
   connectionTemplateUri:  nil,
-  type:  'ethernet-networkV3'
+  type:  'ethernet-networkV300'
 }
 
 eth01 = OneviewSDK::API300::C7000::EthernetNetwork.new(@client, eth1_options)
@@ -111,7 +111,7 @@ OneviewSDK::API300::C7000::LogicalInterconnectGroup.find_by(@client, {}).each do
 end
 
 puts '## Listing default settings ##'
-puts lig.get_default_settings
+puts OneviewSDK::API300::C7000::LogicalInterconnectGroup.get_default_settings(@client)
 
 puts '## Listing this LIG settings ##'
 puts lig.get_settings

--- a/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
@@ -40,6 +40,14 @@ module OneviewSDK
         parse_interconnect_map_template if @data['interconnectMapTemplate']['interconnectMapEntryTemplates'] == []
       end
 
+      # Get the logical interconnect group default settings
+      # @param [OneviewSDK::Client] client The client object for the OneView appliance
+      # @return [Hash] The logical interconnect group settings
+      def self.get_default_settings(client)
+        response = client.rest_get(BASE_URI + '/defaultSettings', client.api_version)
+        client.response_handler(response)
+      end
+
       # Adds an interconnect
       # @param [Fixnum] bay Bay number
       # @param [String] type Interconnect type
@@ -61,14 +69,6 @@ module OneviewSDK
       # @param [OneviewSDK::LIGUplinkSet] uplink_set
       def add_uplink_set(uplink_set)
         @data['uplinkSets'] << uplink_set.data
-      end
-
-      # Get the logical interconnect group default settings
-      # @return [Hash] The logical interconnect group settings
-      def get_default_settings
-        get_uri = self.class::BASE_URI + '/defaultSettings'
-        response = @client.rest_get(get_uri, @api_version)
-        @client.response_handler(response)
       end
 
       # Gets the logical interconnect group settings

--- a/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
@@ -71,6 +71,15 @@ module OneviewSDK
         @data['uplinkSets'] << uplink_set.data
       end
 
+      # Get the logical interconnect group default settings
+      # @deprecated Use {::get_default_settings} instead. This method will be removed in the next major release.
+      # @return [Hash] The logical interconnect group settings
+      def get_default_settings
+        get_uri = self.class::BASE_URI + '/defaultSettings'
+        response = @client.rest_get(get_uri, @api_version)
+        @client.response_handler(response)
+      end
+
       # Gets the logical interconnect group settings
       # @return [Hash] The logical interconnect group settings
       def get_settings

--- a/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
     end
 
     it 'default settings' do
-      default_settings = @item.get_default_settings
+      default_settings = OneviewSDK::LogicalInterconnectGroup.get_default_settings($client)
       expect(default_settings).to be
       expect(default_settings['type']).to eq('InterconnectSettingsV3')
       expect(default_settings['uri']).to_not be

--- a/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
     end
 
+    it 'default settings from the lig instance' do
+      default_settings = @item.get_default_settings
+      expect(default_settings).to be
+      expect(default_settings['type']).to eq('InterconnectSettingsV3')
+      expect(default_settings['uri']).to_not be
+      expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
+    end
+
     it 'current settings' do
       default_settings = @item.get_settings
       expect(default_settings).to be

--- a/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
     end
 
+    it 'default settings from the lig instance' do
+      default_settings = @item.get_default_settings
+      expect(default_settings).to be
+      expect(default_settings['type']).to eq('InterconnectSettingsV201')
+      expect(default_settings['uri']).to_not be
+      expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
+    end
+
     it 'current settings' do
       default_settings = @item.get_settings
       expect(default_settings).to be

--- a/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
     end
 
     it 'default settings' do
-      default_settings = @item.get_default_settings
+      default_settings = OneviewSDK::API300::C7000::LogicalInterconnectGroup.get_default_settings($client_300)
       expect(default_settings).to be
       expect(default_settings['type']).to eq('InterconnectSettingsV201')
       expect(default_settings['uri']).to_not be

--- a/spec/unit/resource/api200/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api200/logical_interconnect_group_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
     end
   end
 
+  describe '::get_default_settings' do
+    it 'should get the default settings' do
+      expect(@client).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings', @client.api_version)
+        .and_return(FakeResponse.new)
+      expect(OneviewSDK::LogicalInterconnectGroup.get_default_settings(@client)).to be
+    end
+  end
+
   describe '#add_interconnect' do
     before :each do
       @item = OneviewSDK::LogicalInterconnectGroup.new(@client)
@@ -45,15 +53,6 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
       item.add_uplink_set(uplink)
       expect(item['uplinkSets'].size).to eq(1)
       expect(item['uplinkSets'].first).to eq(uplink.data)
-    end
-  end
-
-  describe '#get_default_settings' do
-    it 'should get the default settings' do
-      item = OneviewSDK::LogicalInterconnectGroup.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings', item.api_version)
-        .and_return(FakeResponse.new)
-      expect(item.get_default_settings).to be
     end
   end
 

--- a/spec/unit/resource/api200/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api200/logical_interconnect_group_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
     end
   end
 
+  describe '#get_default_settings' do
+    it 'should get the default settings' do
+      item = OneviewSDK::LogicalInterconnectGroup.new(@client, uri: '/rest/fake')
+      expect(@client).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings', item.api_version)
+        .and_return(FakeResponse.new)
+      expect(item.get_default_settings).to be
+    end
+  end
+
   describe '#get_settings' do
     it 'should get the settings' do
       item = OneviewSDK::LogicalInterconnectGroup.new(@client, uri: '/rest/fake')

--- a/spec/unit/resource/api300/c7000/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api300/c7000/logical_interconnect_group_spec.rb
@@ -51,4 +51,12 @@ RSpec.describe OneviewSDK::API300::C7000::LogicalInterconnectGroup do
       expect(item['uplinkSets'].first).to eq(uplink.data)
     end
   end
+
+  describe '::get_default_settings' do
+    it 'should get the default settings' do
+      expect(@client_300).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings', @client_300.api_version)
+        .and_return(FakeResponse.new)
+      expect(OneviewSDK::LogicalInterconnectGroup.get_default_settings(@client_300)).to be
+    end
+  end
 end

--- a/spec/unit/resource/api300/synergy/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api300/synergy/logical_interconnect_group_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe klass do
         .and_return(FakeResponse.new('Default' => 'Settings'))
       expect(klass.get_default_settings(@client_300)).to eq('Default' => 'Settings')
     end
+  end
 
+  describe '#get_settings' do
     it 'gets the current settings' do
       item = klass.new(@client_300, uri: '/rest/fake')
       expect(@client_300).to receive(:rest_get).with('/rest/fake/settings', 300)

--- a/spec/unit/resource/api300/synergy/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api300/synergy/logical_interconnect_group_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe klass do
     end
   end
 
-  describe '#settings' do
+  describe '::get_default_settings' do
     it 'gets the default settings' do
       expect(@client_300).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings')
         .and_return(FakeResponse.new('Default' => 'Settings'))


### PR DESCRIPTION
### Description
Changed access to get_default_settings method just for class object (as a class method) in LogicalInterconnectGroup

### Issues Resolved
 Fixes #132 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
