### PR TITLE
#141 Fixed Synergy LIG #add_interconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
      - Golden Image
      - OS Volumes
      - Plan Scripts
+   - Fixes for API300::Synergy::LogicalInterconnectGroup. See issue [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141)
 
 # v3.1.0
 Added full support to OneView Rest API version 300 for the hardware variants C7000 and Synergy to the already existing features:

--- a/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
@@ -65,6 +65,13 @@ module OneviewSDK
 
       # Get the logical interconnect group default settings
       # @return [Hash] The logical interconnect group settings
+      def self.get_default_settings(client)
+        response = client.rest_get(BASE_URI + '/defaultSettings')
+        client.response_handler(response)
+      end
+
+      # Get the logical interconnect group default settings
+      # @return [Hash] The logical interconnect group settings
       def get_default_settings
         get_uri = self.class::BASE_URI + '/defaultSettings'
         response = @client.rest_get(get_uri, @api_version)

--- a/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
@@ -65,13 +65,6 @@ module OneviewSDK
 
       # Get the logical interconnect group default settings
       # @return [Hash] The logical interconnect group settings
-      def self.get_default_settings(client)
-        response = client.rest_get(BASE_URI + '/defaultSettings')
-        client.response_handler(response)
-      end
-
-      # Get the logical interconnect group default settings
-      # @return [Hash] The logical interconnect group settings
       def get_default_settings
         get_uri = self.class::BASE_URI + '/defaultSettings'
         response = @client.rest_get(get_uri, @api_version)

--- a/spec/unit/resource/api200/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api200/logical_interconnect_group_spec.rb
@@ -57,14 +57,6 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
     end
   end
 
-  describe '#get_default_settings' do
-    it 'gets the default settings' do
-      expect(@client).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings')
-        .and_return(FakeResponse.new('Default' => 'Settings'))
-      expect(described_class.get_default_settings(@client)).to eq('Default' => 'Settings')
-    end
-  end
-
   describe '#get_settings' do
     it 'should get the settings' do
       item = described_class.new(@client, uri: '/rest/fake')

--- a/spec/unit/resource/api200/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api200/logical_interconnect_group_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = OneviewSDK::LogicalInterconnectGroup.new(@client)
+      item = described_class.new(@client)
       expect(item['enclosureType']).to eq('C7000')
       expect(item['state']).to eq('Active')
       expect(item['uplinkSets']).to eq([])
@@ -18,7 +18,7 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
 
   describe '#add_interconnect' do
     before :each do
-      @item = OneviewSDK::LogicalInterconnectGroup.new(@client)
+      @item = described_class.new(@client)
       @type = 'HP VC FlexFabric-20/40 F8 Module'
     end
 
@@ -40,7 +40,7 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
 
   describe '#add_uplink_set' do
     it 'adds it to the \'uplinkSets\' data attribute' do
-      item = OneviewSDK::LogicalInterconnectGroup.new(@client)
+      item = described_class.new(@client)
       uplink = OneviewSDK::UplinkSet.new(@client)
       item.add_uplink_set(uplink)
       expect(item['uplinkSets'].size).to eq(1)
@@ -50,16 +50,24 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
 
   describe '#get_default_settings' do
     it 'should get the default settings' do
-      item = OneviewSDK::LogicalInterconnectGroup.new(@client, uri: '/rest/fake')
+      item = described_class.new(@client, uri: '/rest/fake')
       expect(@client).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings', item.api_version)
         .and_return(FakeResponse.new)
       expect(item.get_default_settings).to be
     end
   end
 
+  describe '#get_default_settings' do
+    it 'gets the default settings' do
+      expect(@client).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings')
+        .and_return(FakeResponse.new('Default' => 'Settings'))
+      expect(described_class.get_default_settings(@client)).to eq('Default' => 'Settings')
+    end
+  end
+
   describe '#get_settings' do
     it 'should get the settings' do
-      item = OneviewSDK::LogicalInterconnectGroup.new(@client, uri: '/rest/fake')
+      item = described_class.new(@client, uri: '/rest/fake')
       expect(@client).to receive(:rest_get).with('/rest/fake/settings', item.api_version)
         .and_return(FakeResponse.new)
       expect(item.get_settings).to be

--- a/spec/unit/resource/api300/synergy/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api300/synergy/logical_interconnect_group_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
-klass = OneviewSDK::API300::Synergy::LogicalInterconnectGroup
-RSpec.describe klass do
+RSpec.describe OneviewSDK::API300::Synergy::LogicalInterconnectGroup do
   include_context 'shared context'
 
-  it 'inherits from API200 and does not inherit from LogicalInterconnectGroup' do
+  it 'inherits from the base API300::Resource class, not API200::LogicalInterconnectGroup' do
     expect(described_class).to be < OneviewSDK::API300::Synergy::Resource
-    expect(klass).not_to be < OneviewSDK::API300::Synergy::LogicalInterconnectGroup
+    expect(described_class).not_to be < OneviewSDK::API200::LogicalInterconnectGroup
   end
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = klass.new(@client_300)
+      item = described_class.new(@client_300)
       expect(item['enclosureType']).to eq('SY12000')
       expect(item['state']).to eq('Active')
       expect(item['uplinkSets']).to eq([])
       expect(item['type']).to eq('logical-interconnect-groupV300')
       expect(item['interconnectMapTemplate']).to eq('interconnectMapEntryTemplates' => [])
       expect(item['interconnectMapTemplate']['interconnectMapEntryTemplates']).to be_empty
+      expect(item['redundancyType']).to eq('Redundant')
     end
   end
 
   describe '#add_uplink_set' do
     it 'adds it to the \'uplinkSets\' data attribute' do
-      item = klass.new(@client_300)
+      item = described_class.new(@client_300)
       uplink = OneviewSDK::API300::Synergy::UplinkSet.new(@client_300)
       item.add_uplink_set(uplink)
       expect(item['uplinkSets'].size).to eq(1)
@@ -31,15 +31,17 @@ RSpec.describe klass do
     end
   end
 
-  describe '#settings' do
+  describe '#get_default_settings' do
     it 'gets the default settings' do
       expect(@client_300).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings')
         .and_return(FakeResponse.new('Default' => 'Settings'))
-      expect(klass.get_default_settings(@client_300)).to eq('Default' => 'Settings')
+      expect(described_class.get_default_settings(@client_300)).to eq('Default' => 'Settings')
     end
+  end
 
+  describe '#settings' do
     it 'gets the current settings' do
-      item = klass.new(@client_300, uri: '/rest/fake')
+      item = described_class.new(@client_300, uri: '/rest/fake')
       expect(@client_300).to receive(:rest_get).with('/rest/fake/settings', 300)
         .and_return(FakeResponse.new('Current' => 'Settings'))
       expect(item.get_settings).to eq('Current' => 'Settings')
@@ -48,7 +50,7 @@ RSpec.describe klass do
 
   describe '#add_internal_network' do
     it 'adds a network' do
-      item = klass.new(@client_300)
+      item = described_class.new(@client_300)
       network = OneviewSDK::API300::Synergy::EthernetNetwork.new(@client, uri: '/rest/fake')
       expect(item.add_internal_network(network)).to be
       expect(item['internalNetworkUris']).to eq(['/rest/fake'])
@@ -56,20 +58,57 @@ RSpec.describe klass do
   end
 
   describe '#add_interconnect' do
+    before :each do
+      @item = described_class.new(@client_300)
+      @type = 'Virtual Connect SE 40Gb F8 Module for Synergy'
+      @type2 = 'Virtual Connect SE 16Gb FC Module for Synergy'
+      @interconnect = { 'uri' => '/rest/fake' }
+    end
     it 'adds a valid interconnect type' do
-      item = klass.new(@client_300)
-      type = 'Virtual Connect SE 40Gb F8 Module for Synergy'
-      logical_downlink = OneviewSDK::API300::Synergy::LogicalDownlink.new(@client_300, name: 'LD')
+      logical_downlink = OneviewSDK::API300::Synergy::LogicalDownlink.new(@client_300, name: 'LD', uri: '/rest/fake')
       allow(OneviewSDK::API300::Synergy::LogicalDownlink).to receive(:find_by).with(anything, name: 'LD')
         .and_return([logical_downlink])
-      logical_downlink['uri'] = '/rest/fake'
-      allow(OneviewSDK::API300::Synergy::Interconnect).to receive(:get_type).with(anything, type)
-        .and_return('uri' => '/rest/fake')
-      item.add_interconnect(1, type, 'LD')
-      expect(item['interconnectMapTemplate']['interconnectMapEntryTemplates'][0]['permittedInterconnectTypeUri'])
+      allow(OneviewSDK::API300::Synergy::Interconnect).to receive(:get_type).with(anything, @type)
+        .and_return(@interconnect)
+      @item.add_interconnect(1, @type, 'LD')
+      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'][0]['permittedInterconnectTypeUri'])
         .to eq('/rest/fake')
-      expect(item['interconnectMapTemplate']['interconnectMapEntryTemplates'][0]['logicalDownlinkUri'])
+      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'][0]['logicalDownlinkUri'])
         .to eq('/rest/fake')
+    end
+
+    it 'accepts a LogicalDownlink resource as a parameter' do
+      logical_downlink = OneviewSDK::API300::Synergy::LogicalDownlink.new(@client_300, name: 'LD', uri: '/rest/fake')
+      allow(OneviewSDK::API300::Synergy::Interconnect).to receive(:get_type).and_return(@interconnect)
+      @item.add_interconnect(1, @type, logical_downlink)
+      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'][0]['permittedInterconnectTypeUri'])
+        .to eq('/rest/fake')
+      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'][0]['logicalDownlinkUri'])
+        .to eq('/rest/fake')
+    end
+
+    it 'only adds an interconnect if it is not already added' do
+      allow(OneviewSDK::API300::Synergy::Interconnect).to receive(:get_type).and_return(@interconnect)
+      @item.add_interconnect(1, @type)
+      @item.add_interconnect(1, @type)
+      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'].size).to eq(1)
+    end
+
+    it 'adds interconnects with the same bay but different enclosureIndex' do
+      allow(OneviewSDK::API300::Synergy::Interconnect).to receive(:get_type).and_return(@interconnect)
+      @item.add_interconnect(1, @type, nil, 1)
+      @item.add_interconnect(1, @type, nil, -1)
+      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'].size).to eq(2)
+    end
+
+    it 'sets the correct default enclosureIndex for interconnect types' do
+      allow(OneviewSDK::API300::Synergy::Interconnect).to receive(:get_type).twice.and_return(@interconnect)
+      @item.add_interconnect(1, @type)
+      @item.add_interconnect(1, @type2)
+      templates = @item['interconnectMapTemplate']['interconnectMapEntryTemplates']
+      expect(templates.size).to eq(2)
+      expect(templates[0]['enclosureIndex']).to eq(1)
+      expect(templates[1]['enclosureIndex']).to eq(-1)
     end
   end
 end


### PR DESCRIPTION
### Description
See the linked issue for more context and description, but here's the short of it:
1. In `#add_interconnect` for Synergy LIG, set the correct default enclosureIndex based on the interconnect type
2. In `#add_interconnect`, for Synergy LIG, set the relativeValue of the enclosure to the given `enclosure_index` value. This is necessary for LIGs with multiple enclosures
3. In `#initialize`, for Synergy LIG, set the default `redundancyType` value (required) to `Redundant`, like the GUI.

### Issues Resolved
Fixes #141

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
