### PR TITLE
Enhanced API300::EnclosureGroup#add_logical_interconnect_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 #### Bug fixes & Enhancements
 - [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141) Fixes for API300::Synergy::LogicalInterconnectGroup
+- [#142](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/142) EnclosureGroup should raise error in `#add_logical_interconnect_group` if LIG could not be retrieved
 - [#149](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/149) API300::EnclosureGroup resources support enclosureIndex in interconnectBayMappings
 
 # v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
      - Golden Image
      - OS Volumes
      - Plan Scripts
-   - Fixes for API300::Synergy::LogicalInterconnectGroup. See issue [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141)
+
+#### Bug fixes & Enhancements
+- [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141) Fixes for API300::Synergy::LogicalInterconnectGroup
+- [#149](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/149) API300::EnclosureGroup resources support enclosureIndex in interconnectBayMappings
 
 # v3.1.0
 Added full support to OneView Rest API version 300 for the hardware variants C7000 and Synergy to the already existing features:

--- a/examples/api300/c7000/enclosure_group.rb
+++ b/examples/api300/c7000/enclosure_group.rb
@@ -22,7 +22,7 @@ options = {
 item = OneviewSDK::API300::C7000::EnclosureGroup.new(@client, options)
 
 # Adds a logical interconnect group to the enclosure group
-lig = OneviewSDK::API300::C7000::LogicalInterconnectGroup.find_by(@client, {}).first
+lig = OneviewSDK::API300::C7000::LogicalInterconnectGroup.get_all(@client).first
 item.add_logical_interconnect_group(lig)
 
 item.create!

--- a/examples/api300/synergy/enclosure_group.rb
+++ b/examples/api300/synergy/enclosure_group.rb
@@ -16,14 +16,17 @@ require_relative '../../_client' # Gives access to @client
 type = 'enclosure group'
 options = {
   name: 'OneViewSDK Test Enclosure Group',
-  interconnectBayMappingCount: 6
+  interconnectBayMappingCount: 6,
+  enclosureCount: 3
 }
 
 item = OneviewSDK::API300::Synergy::EnclosureGroup.new(@client, options)
 
-# Adds a logical interconnect group to the enclosure group
-lig = OneviewSDK::API300::Synergy::LogicalInterconnectGroup.find_by(@client, {}).first
-item.add_logical_interconnect_group(lig)
+# Adds interconnects from 2 logical interconnect groups to the enclosure group
+lig = OneviewSDK::API300::Synergy::LogicalInterconnectGroup.get_all(@client)[0]
+lig2 = OneviewSDK::API300::Synergy::LogicalInterconnectGroup.get_all(@client)[1]
+item.add_logical_interconnect_group(lig)     # Add interconnects to all enclosures
+item.add_logical_interconnect_group(lig2, 3) # Add interconnects only to enclosure 3
 
 item.create!
 puts "\nCreated #{type} '#{item[:name]}' sucessfully.\n  uri = '#{item[:uri]}'"

--- a/lib/oneview-sdk/resource/api200/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api200/enclosure_group.rb
@@ -49,9 +49,11 @@ module OneviewSDK
 
       # Adds the logical interconnect group
       # @param [OneviewSDK::LogicalInterconnectGroup] lig Logical Interconnect Group
+      # @raise [OneviewSDK::NotFound] if the LIG uri is not set and cannot be retrieved
       # @return [OneviewSDK::EnclosureGroup] self
       def add_logical_interconnect_group(lig)
         lig.retrieve! unless lig['uri']
+        raise(NotFound, 'LIG not found!') unless lig['uri']
         lig['interconnectMapTemplate']['interconnectMapEntryTemplates'].each do |entry|
           entry['logicalLocation']['locationEntries'].each do |location|
             add_lig_to_bay(location['relativeValue'], lig) if location['type'] == 'Bay' && entry['permittedInterconnectTypeUri']

--- a/lib/oneview-sdk/resource/api200/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api200/enclosure_group.rb
@@ -49,6 +49,7 @@ module OneviewSDK
 
       # Adds the logical interconnect group
       # @param [OneviewSDK::LogicalInterconnectGroup] lig Logical Interconnect Group
+      # @return [OneviewSDK::EnclosureGroup] self
       def add_logical_interconnect_group(lig)
         lig.retrieve! unless lig['uri']
         lig['interconnectMapTemplate']['interconnectMapEntryTemplates'].each do |entry|
@@ -56,9 +57,11 @@ module OneviewSDK
             add_lig_to_bay(location['relativeValue'], lig) if location['type'] == 'Bay' && entry['permittedInterconnectTypeUri']
           end
         end
+        self
       end
 
       # Creates the interconnect bay mapping
+      # @return [OneviewSDK::EnclosureGroup] self
       def create_interconnect_bay_mapping
         @data['interconnectBayMappings'] = []
         1.upto(@data['interconnectBayMappingCount']) do |bay_number|
@@ -68,6 +71,7 @@ module OneviewSDK
           }
           @data['interconnectBayMappings'] << entry
         end
+        self
       end
 
       private

--- a/lib/oneview-sdk/resource/api200/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api200/enclosure_group.rb
@@ -53,7 +53,7 @@ module OneviewSDK
       # @return [OneviewSDK::EnclosureGroup] self
       def add_logical_interconnect_group(lig)
         lig.retrieve! unless lig['uri']
-        raise(NotFound, 'LIG not found!') unless lig['uri']
+        raise(NotFound, "The logical interconnect group #{lig['name']} was not found.") unless lig['uri']
         lig['interconnectMapTemplate']['interconnectMapEntryTemplates'].each do |entry|
           entry['logicalLocation']['locationEntries'].each do |location|
             add_lig_to_bay(location['relativeValue'], lig) if location['type'] == 'Bay' && entry['permittedInterconnectTypeUri']

--- a/lib/oneview-sdk/resource/api300/c7000/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/enclosure_group.rb
@@ -26,11 +26,62 @@ module OneviewSDK
           # Default values:
           @data['type'] ||= 'EnclosureGroupV300'
           @data['stackingMode'] ||= 'Enclosure'
+          @data['enclosureCount'] ||= 1
           @data['interconnectBayMappingCount'] ||= 8
-          create_interconnect_bay_mapping unless @data['interconnectBayMappings']
           super
         end
 
+        # Adds the logical interconnect group
+        # @param [OneviewSDK::LogicalInterconnectGroup] lig Logical Interconnect Group
+        # @param [Integer] enclosureIndex Enclosure index of bay to add LIG to. If nil, interconnects will be added for all enclosures
+        # @return [OneviewSDK::EnclosureGroup] self
+        def add_logical_interconnect_group(lig, enclosureIndex = nil)
+          lig.retrieve! unless lig['uri']
+          lig['interconnectMapTemplate']['interconnectMapEntryTemplates'].each do |entry|
+            entry['logicalLocation']['locationEntries'].each do |location|
+              next unless location['type'] == 'Bay' && entry['permittedInterconnectTypeUri']
+              add_lig_to_bay(location['relativeValue'], lig, enclosureIndex)
+            end
+          end
+          self
+        end
+
+        # Creates the interconnect bay mapping
+        # @return [OneviewSDK::EnclosureGroup] self
+        def create_interconnect_bay_mapping
+          @data['interconnectBayMappings'] = []
+          1.upto(@data['enclosureCount']) do |enclosureIndex|
+            1.upto(@data['interconnectBayMappingCount']) do |bay_number|
+              entry = {
+                'enclosureIndex' => enclosureIndex,
+                'interconnectBay' => bay_number,
+                'logicalInterconnectGroupUri' => nil
+              }
+              @data['interconnectBayMappings'] << entry
+            end
+          end
+          self
+        end
+
+        private
+
+        # Add logical interconnect group to bay
+        # @param [Integer] bay Bay number
+        # @param [OneviewSDK::LogicalInterconnectGroup] lig Logical Interconnect Group
+        # @param [Integer] enclosureIndex Enclosure index of bay to add LIG to. If nil, interconnects will be added for all enclosures
+        def add_lig_to_bay(bay, lig, enclosureIndex)
+          @data['interconnectBayMappings'].each do |location|
+            next unless location['interconnectBay'] == bay
+            if enclosureIndex
+              next unless location['enclosureIndex'] == enclosureIndex
+              location['logicalInterconnectGroupUri'] = lig['uri']
+              location['enclosureIndex'] = enclosureIndex
+              break
+            else
+              location['logicalInterconnectGroupUri'] = lig['uri']
+            end
+          end
+        end
       end
     end
   end

--- a/lib/oneview-sdk/resource/api300/c7000/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/enclosure_group.rb
@@ -34,9 +34,11 @@ module OneviewSDK
         # Adds the logical interconnect group
         # @param [OneviewSDK::LogicalInterconnectGroup] lig Logical Interconnect Group
         # @param [Integer] enclosureIndex Enclosure index of bay to add LIG to. If nil, interconnects will be added for all enclosures
+        # @raise [OneviewSDK::NotFound] if the LIG uri is not set and cannot be retrieved
         # @return [OneviewSDK::EnclosureGroup] self
         def add_logical_interconnect_group(lig, enclosureIndex = nil)
           lig.retrieve! unless lig['uri']
+          raise(NotFound, 'LIG not found!') unless lig['uri']
           lig['interconnectMapTemplate']['interconnectMapEntryTemplates'].each do |entry|
             entry['logicalLocation']['locationEntries'].each do |location|
               next unless location['type'] == 'Bay' && entry['permittedInterconnectTypeUri']

--- a/lib/oneview-sdk/resource/api300/c7000/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/enclosure_group.rb
@@ -38,7 +38,7 @@ module OneviewSDK
         # @return [OneviewSDK::API300::C7000::EnclosureGroup] self
         def add_logical_interconnect_group(lig, enclosureIndex = nil)
           lig.retrieve! unless lig['uri']
-          raise(NotFound, 'LIG not found!') unless lig['uri']
+          raise(NotFound, "The logical interconnect group #{lig['name']} was not found") unless lig['uri']
           lig['interconnectMapTemplate']['interconnectMapEntryTemplates'].each do |entry|
             entry['logicalLocation']['locationEntries'].each do |location|
               next unless location['type'] == 'Bay' && entry['permittedInterconnectTypeUri']

--- a/lib/oneview-sdk/resource/api300/c7000/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/enclosure_group.rb
@@ -35,7 +35,7 @@ module OneviewSDK
         # @param [OneviewSDK::LogicalInterconnectGroup] lig Logical Interconnect Group
         # @param [Integer] enclosureIndex Enclosure index of bay to add LIG to. If nil, interconnects will be added for all enclosures
         # @raise [OneviewSDK::NotFound] if the LIG uri is not set and cannot be retrieved
-        # @return [OneviewSDK::EnclosureGroup] self
+        # @return [OneviewSDK::API300::C7000::EnclosureGroup] self
         def add_logical_interconnect_group(lig, enclosureIndex = nil)
           lig.retrieve! unless lig['uri']
           raise(NotFound, 'LIG not found!') unless lig['uri']
@@ -49,7 +49,7 @@ module OneviewSDK
         end
 
         # Creates the interconnect bay mapping
-        # @return [OneviewSDK::EnclosureGroup] self
+        # @return [OneviewSDK::API300::C7000::EnclosureGroup] self
         def create_interconnect_bay_mapping
           @data['interconnectBayMappings'] = []
           1.upto(@data['enclosureCount']) do |enclosureIndex|

--- a/lib/oneview-sdk/resource/api300/synergy/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/enclosure_group.rb
@@ -9,13 +9,13 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-require_relative '../../api200/enclosure_group'
+require_relative '../c7000/enclosure_group'
 
 module OneviewSDK
   module API300
     module Synergy
       # Enclosure group resource implementation on API300 Synergy
-      class EnclosureGroup < OneviewSDK::API200::EnclosureGroup
+      class EnclosureGroup < OneviewSDK::API300::C7000::EnclosureGroup
 
         # Create a resource object, associate it with a client, and set its properties.
         # @param [OneviewSDK::Client] client The client object for the OneView appliance
@@ -24,8 +24,6 @@ module OneviewSDK
         def initialize(client, params = {}, api_ver = nil)
           @data ||= {}
           # Default values:
-          @data['type'] ||= 'EnclosureGroupV300'
-          @data['stackingMode'] ||= 'Enclosure'
           @data['ipAddressingMode'] ||= 'DHCP'
           @data['interconnectBayMappingCount'] ||= 6
           super
@@ -36,7 +34,6 @@ module OneviewSDK
         def set_script
           unavailable_method
         end
-
       end
     end
   end

--- a/spec/unit/resource/api200/enclosure_group_spec.rb
+++ b/spec/unit/resource/api200/enclosure_group_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe klass do
       @lig['uri'] = nil
       expect(@lig).to receive(:retrieve!).and_return false
       expect { @item.add_logical_interconnect_group(@lig) }
-        .to raise_error(OneviewSDK::NotFound, /LIG not found/)
+        .to raise_error(OneviewSDK::NotFound, /not found/)
     end
   end
 end

--- a/spec/unit/resource/api200/enclosure_group_spec.rb
+++ b/spec/unit/resource/api200/enclosure_group_spec.rb
@@ -1,12 +1,13 @@
 require 'spec_helper'
 
-RSpec.describe OneviewSDK::EnclosureGroup do
+klass = OneviewSDK::API200::EnclosureGroup
+RSpec.describe klass do
   include_context 'shared context'
 
   describe '#initialize' do
     context 'OneView 2.0' do
       it 'sets the defaults correctly' do
-        item = OneviewSDK::EnclosureGroup.new(@client)
+        item = klass.new(@client)
         expect(item[:type]).to eq('EnclosureGroupV200')
       end
     end
@@ -14,11 +15,11 @@ RSpec.describe OneviewSDK::EnclosureGroup do
 
   describe '#script' do
     it 'requires a uri' do
-      expect { OneviewSDK::EnclosureGroup.new(@client).get_script }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { klass.new(@client).get_script }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/script' do
-      item = OneviewSDK::EnclosureGroup.new(@client, uri: '/rest/fake')
+      item = klass.new(@client, uri: '/rest/fake')
       expect(@client).to receive(:rest_get).with('/rest/fake/script', item.api_version).and_return(FakeResponse.new('Blah'))
       expect(@client.logger).to receive(:warn).with(/Failed to parse JSON response/).and_return(true)
       expect(item.get_script).to eq('Blah')
@@ -27,14 +28,46 @@ RSpec.describe OneviewSDK::EnclosureGroup do
 
   describe '#set_script' do
     it 'requires a uri' do
-      expect { OneviewSDK::EnclosureGroup.new(@client).set_script('Blah') }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { klass.new(@client).set_script('Blah') }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to uri/script' do
-      item = OneviewSDK::EnclosureGroup.new(@client, uri: '/rest/fake')
+      item = klass.new(@client, uri: '/rest/fake')
       expect(@client).to receive(:rest_put).with('/rest/fake/script', { 'body' => 'Blah' }, item.api_version).and_return(FakeResponse.new('Blah'))
       expect(@client.logger).to receive(:warn).with(/Failed to parse JSON response/).and_return(true)
       expect(item.set_script('Blah')).to eq(true)
+    end
+  end
+
+  describe '#create_interconnect_bay_mapping' do
+    it 'creates entries for each bay' do
+      item = klass.new(@client, name: 'EG', enclosureCount: 3)
+      expect(item['interconnectBayMappings'].size).to eq(8)
+    end
+  end
+
+  describe '#add_logical_interconnect_group' do
+    before :each do
+      @lig = OneviewSDK::API200::LogicalInterconnectGroup.new(@client, uri: '/fakelig')
+      @lig['interconnectMapTemplate']['interconnectMapEntryTemplates'] = [
+        { 'permittedInterconnectTypeUri' => '/fake', 'logicalLocation' => { 'locationEntries' => [{ 'type' => 'Bay', 'relativeValue' => 1 }] } },
+        { 'permittedInterconnectTypeUri' => '/fake', 'logicalLocation' => { 'locationEntries' => [{ 'type' => 'Bay', 'relativeValue' => 4 }] } }
+      ]
+      @item = klass.new(@client, name: 'EG', enclosureCount: 3)
+    end
+
+    it 'it adds the LIG uri to each applicable bay' do
+      @item.add_logical_interconnect_group(@lig)
+      bays_with_lig = @item['interconnectBayMappings'].find_all { |i| i['logicalInterconnectGroupUri'] == @lig['uri'] }
+      bays = bays_with_lig.map { |i| i['interconnectBay'] }
+      expect(bays).to eq([1, 4])
+    end
+
+    it 'raises an error if the LIG cannot be retrieved' do
+      @lig['uri'] = nil
+      expect(@lig).to receive(:retrieve!).and_return false
+      expect { @item.add_logical_interconnect_group(@lig) }
+        .to raise_error(OneviewSDK::NotFound, /LIG not found/)
     end
   end
 end

--- a/spec/unit/resource/api300/c7000/enclosure_group_spec.rb
+++ b/spec/unit/resource/api300/c7000/enclosure_group_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe klass do
       @lig['uri'] = nil
       expect(@lig).to receive(:retrieve!).and_return false
       expect { @item.add_logical_interconnect_group(@lig) }
-        .to raise_error(OneviewSDK::NotFound, /LIG not found/)
+        .to raise_error(OneviewSDK::NotFound, /not found/)
     end
   end
 end

--- a/spec/unit/resource/api300/c7000/enclosure_group_spec.rb
+++ b/spec/unit/resource/api300/c7000/enclosure_group_spec.rb
@@ -89,5 +89,12 @@ RSpec.describe klass do
       expect(bays_map).to include([2, 4])
       expect(bays_map).to_not include([3, 4])
     end
+
+    it 'raises an error if the LIG cannot be retrieved' do
+      @lig['uri'] = nil
+      expect(@lig).to receive(:retrieve!).and_return false
+      expect { @item.add_logical_interconnect_group(@lig) }
+        .to raise_error(OneviewSDK::NotFound, /LIG not found/)
+    end
   end
 end

--- a/spec/unit/resource/api300/synergy/enclosure_group_spec.rb
+++ b/spec/unit/resource/api300/synergy/enclosure_group_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe klass do
       it 'sets the defaults correctly' do
         item = klass.new(@client_300)
         expect(item[:type]).to eq('EnclosureGroupV300')
+        expect(item[:stackingMode]).to eq('Enclosure')
+        expect(item[:ipAddressingMode]).to eq('DHCP')
+        expect(item[:enclosureCount]).to eq(1)
+        expect(item[:interconnectBayMappingCount]).to eq(6)
       end
     end
   end
@@ -35,6 +39,15 @@ RSpec.describe klass do
     it 'returns method unavailable for the set_script method' do
       item = klass.new(@client_300, uri: '/rest/fake')
       expect { item.set_script }.to raise_error(/The method #set_script is unavailable for this resource/)
+    end
+  end
+
+  describe '#create_interconnect_bay_mapping' do
+    it 'creates entries for each bay in each enclosure' do
+      item = klass.new(@client_300, name: 'EG', enclosureCount: 3)
+      expect(item['interconnectBayMappings'].size).to eq(18)
+      expect(item['interconnectBayMappings'].first['enclosureIndex']).to eq(1)
+      expect(item['interconnectBayMappings'].first['interconnectBay']).to eq(1)
     end
   end
 end


### PR DESCRIPTION
### Description
Allows you to specify which enclosures to apply the LIG settings for in the `#add_logical_interconnect_group` method.

To do this, we needed to expand the interconnectBayMappings to include entries for each enclosureIndex-interconnectBay combination. I added an optional parameter to the `#add_logical_interconnect_group` method that allows you to specify a specific enclosure to attach to the LIG, or if left out/nil, will attach to all enclosures (the old behavior). It will send an expanded set of interconnectBayMappings data to the API, but will match the old behavior in function, so I do not consider this a breaking change.

The only other change is updating a few of the methods in the EnclosureGroup resources to return the resource itself, not an indeterminate & uninteresting hash or array.

### Issues Resolved
Fixes #149

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
