### PR TITLE
Make REST methods support redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
      - Golden Image
      - OS Volumes
      - Plan Scripts
-   - Fixes for API300::Synergy::LogicalInterconnectGroup. See issue [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141)
+
+#### Bug fixes & Enhancements
+- [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141) Fixes for API300::Synergy::LogicalInterconnectGroup
+- [#145](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/145) REST methods now handle redirects
 
 # v3.1.0
 Added full support to OneView Rest API version 300 for the hardware variants C7000 and Synergy to the already existing features:

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe OneviewSDK::Client do
       response1 = FakeResponse.new({ name: 'New' }, 301, 'location' => path)
       expect(response1).to receive(:class).and_return(Net::HTTPRedirection) # Simulate 301 on first request
       response2 = FakeResponse.new({ name: 'New' }, 200)
-      expect(http).to receive(:request).ordered.and_return(response1)
-      expect(http).to receive(:request).ordered.and_return(response2)
+      expect(http).to receive(:request).and_return(response1, response2)
       r = @client.rest_api(:get, path)
       expect(r).to eq(response2)
     end

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -37,6 +37,32 @@ RSpec.describe OneviewSDK::Client do
       expect_any_instance_of(Net::HTTP).to receive(:open_timeout=).with(5).and_call_original
       client.rest_api(:get, path)
     end
+
+    it 'supports following redirects' do
+      response1 = FakeResponse.new({ name: 'New' }, 301, location: path)
+      response2 = FakeResponse.new({ name: 'New' }, 200, location: path)
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response1)
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response2)
+      r = @client.rest_api(:get, path)
+      expect(r).to eq(response2)
+    end
+
+    it 'follows a limited number of redirects' do
+      response = FakeResponse.new({ name: 'New' }, 301, 'location' => path)
+      allow(response.class).to receive(:<=).with(Net::HTTPRedirection).and_return(true)
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
+      expect(@client).to receive(:rest_api).exactly(4).times.and_call_original
+      r = @client.rest_api(:get, path)
+      expect(r).to eq(response)
+    end
+
+    it 'only follows redirects if there is a location header' do
+      response = FakeResponse.new({ name: 'New' }, 301)
+      allow(response.class).to receive(:<=).with(Net::HTTPRedirection).and_return(true)
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
+      expect(@client).to receive(:rest_api).once.and_call_original
+      @client.rest_api(:get, path)
+    end
   end
 
   describe '#rest_get' do


### PR DESCRIPTION
### Description
Allows REST methods to support redirects. There's a default limit of 3 redirects, but is configurable.

### Issues Resolved
Fixes #145

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
