### PR TITLE
Update client logger level with client.log_level=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
      - Plan Scripts
    - Fixes for API300::Synergy::LogicalInterconnectGroup. See issue [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141)
 
+#### Bug fixes & Enhancements
+- [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141) Fixes for API300::Synergy::LogicalInterconnectGroup
+- [#152](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/152) Update client logger's log level with `client.log_level=`
+
 # v3.1.0
 Added full support to OneView Rest API version 300 for the hardware variants C7000 and Synergy to the already existing features:
    - Interconnect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
      - Golden Image
      - OS Volumes
      - Plan Scripts
-   - Fixes for API300::Synergy::LogicalInterconnectGroup. See issue [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141)
 
 #### Bug fixes & Enhancements
 - [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141) Fixes for API300::Synergy::LogicalInterconnectGroup

--- a/lib/oneview-sdk/client.rb
+++ b/lib/oneview-sdk/client.rb
@@ -41,8 +41,7 @@ module OneviewSDK
       STDOUT.sync = true
       @logger = options[:logger] || Logger.new(STDOUT)
       [:debug, :info, :warn, :error, :level=].each { |m| raise InvalidClient, "Logger must respond to #{m} method " unless @logger.respond_to?(m) }
-      @log_level = options[:log_level] || :info
-      @logger.level = @logger.class.const_get(@log_level.upcase) rescue @log_level
+      self.log_level = options[:log_level] || :info
       @print_wait_dots = options.fetch(:print_wait_dots, false)
       @url = options[:url] || ENV['ONEVIEWSDK_URL']
       raise InvalidClient, 'Must set the url option' unless @url
@@ -71,6 +70,11 @@ module OneviewSDK
       @password = options[:password] || ENV['ONEVIEWSDK_PASSWORD']
       raise InvalidClient, 'Must set user & password options or token option' unless @password
       @token = login
+    end
+
+    def log_level=(level)
+      @logger.level = @logger.class.const_get(level.upcase) rescue level
+      @log_level = level
     end
 
     # Tells OneView to create the resource using the current attribute data

--- a/lib/oneview-sdk/image-streamer/client.rb
+++ b/lib/oneview-sdk/image-streamer/client.rb
@@ -34,8 +34,7 @@ module OneviewSDK
         STDOUT.sync = true
         @logger = options[:logger] || Logger.new(STDOUT)
         [:debug, :info, :warn, :error, :level=].each { |m| raise InvalidClient, "Logger must respond to #{m} method " unless @logger.respond_to?(m) }
-        @log_level = options[:log_level] || :info
-        @logger.level = @logger.class.const_get(@log_level.upcase) rescue @log_level
+        self.log_level = options[:log_level] || :info
         @print_wait_dots = options.fetch(:print_wait_dots, false)
         @url = options[:url] || ENV['I3S_URL']
         raise InvalidClient, 'Must set the url option' unless @url

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe OneviewSDK::Client do
       expect(client.logger.level).to eq(3)
     end
 
+    it 'allows the log level to be set again' do
+      options = { url: 'https://oneview.example.com', password: 'secret123', log_level: :error }
+      client = OneviewSDK::Client.new(options)
+      expect(client.log_level).to eq(:error)
+      expect(client.logger.level).to eq(Logger.const_get(client.log_level.upcase))
+      client.log_level = :warn
+      expect(client.log_level).to eq(:warn)
+      expect(client.logger.level).to eq(Logger.const_get(client.log_level.upcase))
+    end
+
     it 'picks the lower of the default api version and appliance api version' do
       allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(120)
       options = { url: 'https://oneview.example.com', token: 'token123' }

--- a/spec/unit/image-streamer/client_spec.rb
+++ b/spec/unit/image-streamer/client_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe OneviewSDK::ImageStreamer::Client do
       expect(client.logger.level).to eq(3)
     end
 
+    it 'allows the log level to be set again' do
+      options = { url: 'https://oneview.example.com', token: 'secret123', log_level: :error }
+      client = OneviewSDK::ImageStreamer::Client.new(options)
+      expect(client.log_level).to eq(:error)
+      expect(client.logger.level).to eq(Logger.const_get(client.log_level.upcase))
+      client.log_level = :warn
+      expect(client.log_level).to eq(:warn)
+      expect(client.logger.level).to eq(Logger.const_get(client.log_level.upcase))
+    end
+
     it 'picks the lower of the default api version and appliance api version' do
       allow_any_instance_of(OneviewSDK::ImageStreamer::Client).to receive(:appliance_i3s_api_version).and_return(120)
       options = { url: 'https://oneview.example.com', token: 'token123' }


### PR DESCRIPTION
### Description
Allow the client `#log_level=` method to update the logger's level

### Issues Resolved
Fixes #152

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] Changes are documented in the CHANGELOG.
