### PR TITLE
Updated client.get_all to support variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#145](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/145) REST methods now handle redirects
 - [#149](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/149) API300::EnclosureGroup resources support enclosureIndex in interconnectBayMappings
 - [#152](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/152) Update client logger's log level with `client.log_level=`
+- Client #get_all method now supports an (optional) variant parameter
 
 #### New Resources:
 - User

--- a/lib/oneview-sdk/client.rb
+++ b/lib/oneview-sdk/client.rb
@@ -108,12 +108,14 @@ module OneviewSDK
     # Get array of all resources of a specified type
     # @param [String] type Resource type
     # @param [Integer] api_ver API module version to fetch resources from
+    # @param [String] variant API module variant to fetch resource from
     # @return [Array<Resource>] Results
     # @example Get all Ethernet Networks
     #   networks = @client.get_all('EthernetNetworks')
+    #   synergy_networks = @client.get_all('EthernetNetworks', 300, 'Synergy')
     # @raise [TypeError] if the type is invalid
-    def get_all(type, api_ver = @api_version)
-      klass = OneviewSDK.resource_named(type, api_ver)
+    def get_all(type, api_ver = @api_version, variant = nil)
+      klass = OneviewSDK.resource_named(type, api_ver, variant)
       raise TypeError, "Invalid resource type '#{type}'. OneviewSDK::API#{api_ver} does not contain a class like it." unless klass
       klass.get_all(self)
     end

--- a/lib/oneview-sdk/resource/api300.rb
+++ b/lib/oneview-sdk/resource/api300.rb
@@ -22,7 +22,7 @@ module OneviewSDK
     # @param [String] variant Variant (C7000 or Synergy)
     # @return [Class] Resource class or nil if not found
     def self.resource_named(type, variant = @variant)
-      raise "API300 variant #{variant} is not supported!" unless SUPPORTED_VARIANTS.include?(variant)
+      raise "API300 variant #{variant} is not supported!" unless SUPPORTED_VARIANTS.include?(variant.to_s)
       new_type = type.to_s.downcase.gsub(/[ -_]/, '')
       api_module = OneviewSDK::API300.const_get(variant)
       api_module.constants.each do |c|

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -252,6 +252,14 @@ RSpec.describe OneviewSDK::Client do
     it 'fails when a bogus resource type is given' do
       expect { @client.get_all('BogusResources') }.to raise_error(TypeError, /Invalid resource type/)
     end
+
+    it 'fails when a bogus API version is given' do
+      expect { @client.get_all('ServerProfiles', 100) }.to raise_error(OneviewSDK::UnsupportedVersion, /version 100 is not supported/)
+    end
+
+    it 'fails when a bogus variant is given' do
+      expect { @client.get_all('ServerProfiles', 300, 'Bogus') }.to raise_error(/variant 'Bogus' is not supported/)
+    end
   end
 
   describe '#refresh_login' do

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -210,8 +210,18 @@ RSpec.describe OneviewSDK::Client do
     include_context 'shared context'
 
     it "calls the correct resource's get_all method" do
-      expect(OneviewSDK::ServerProfile).to receive(:get_all).with(@client)
+      expect(OneviewSDK::API200::ServerProfile).to receive(:get_all).with(@client)
       @client.get_all('ServerProfiles')
+    end
+
+    it 'accepts API version and variant parameters' do
+      expect(OneviewSDK::API300::Synergy::ServerProfile).to receive(:get_all).with(@client)
+      @client.get_all('ServerProfiles', 300, 'Synergy')
+    end
+
+    it 'accepts symbols instead of strings' do
+      expect(OneviewSDK::API300::Synergy::ServerProfile).to receive(:get_all).with(@client)
+      @client.get_all(:ServerProfiles, 300, :Synergy)
     end
 
     it 'fails when a bogus resource type is given' do


### PR DESCRIPTION
### Description
The client's #get_all method now supports a variant, just like the API module #resource_named methods do.

### Issues Resolved
(none)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
