### PR TITLE
Fixed require issues

### DIFF
--- a/lib/oneview-sdk/image-streamer/resource/api_300.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api_300.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+require_relative '../../resource'
+
 module OneviewSDK
   # Module Image Streamer
   module ImageStreamer

--- a/lib/oneview-sdk/resource/api300/synergy/enclosure.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/enclosure.rb
@@ -9,7 +9,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-require_relative '../../api200/enclosure'
+require_relative '../c7000/enclosure'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api300/synergy/logical_switch.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/logical_switch.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+require_relative '../c7000/logical_switch'
+
 module OneviewSDK
   module API300
     module Synergy

--- a/lib/oneview-sdk/resource/api300/synergy/scope.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/scope.rb
@@ -9,7 +9,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-require_relative 'resource'
+require_relative '../c7000/scope'
 
 module OneviewSDK
   module API300


### PR DESCRIPTION
### Description
Fixes issue I was having where it would get in an infinite loop trying to find the `API300::C7000` constant. This was caused because we were trying to use `API300::C7000` resources without requiring them first.

### Issues Resolved
When trying to run the tests...

```ruby
/home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_missing': stack level too deep (SystemStackError)
        from /home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_get'
        from /home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_missing'
        from /home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_get'
        from /home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_missing'
        from /home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_get'
        from /home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_missing'
        from /home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_get'
        from /home/vagrant/oneview-sdk-ruby/lib/oneview-sdk/resource/api300.rb:57:in `const_missing'
         ... 9027 levels...
        from /usr/local/rvm/gems/ruby-2.2.4/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
        from /usr/local/rvm/gems/ruby-2.2.4/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
        from /usr/local/rvm/gems/ruby-2.2.4/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
        from /usr/local/rvm/gems/ruby-2.2.4/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
```

Come to find out that const that was missing was `:C7000`. This constant is expected to exist [here](https://github.com/HewlettPackard/oneview-sdk-ruby/blob/ace3ee85c1071289c2aaa68af34da2fa99f289ef/lib/oneview-sdk/resource/api300.rb#L57), hence the infinite loop that maxes out the stack