### PR TITLE
Allow client attributes to be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#145](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/145) REST methods now handle redirects
 - [#149](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/149) API300::EnclosureGroup resources support enclosureIndex in interconnectBayMappings
 - [#152](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/152) Update client logger's log level with `client.log_level=`
+- [#161](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/161) Allow client attributes to be set after initialization, and token to be refreshed
 
 #### New Resources:
 - Scope

--- a/lib/oneview-sdk/client.rb
+++ b/lib/oneview-sdk/client.rb
@@ -17,8 +17,9 @@ require_relative 'ssl_helper'
 module OneviewSDK
   # The client defines the connection to the OneView server and handles communication with it.
   class Client
-    attr_reader :url, :user, :token, :password, :max_api_version
-    attr_accessor :ssl_enabled, :api_version, :logger, :log_level, :cert_store, :print_wait_dots, :timeout
+    attr_reader :max_api_version
+    attr_accessor :url, :user, :token, :password, :ssl_enabled, :api_version, \
+                  :logger, :log_level, :cert_store, :print_wait_dots, :timeout
 
     include Rest
 
@@ -145,6 +146,15 @@ module OneviewSDK
       end
     end
 
+    # Refresh the client's session token & max_api_version.
+    # Call this after a token expires or the user and/or password is updated on the client object.
+    # @return [OneviewSDK::Client] self
+    def refresh_login
+      @max_api_version = appliance_api_version
+      @token = login
+      self
+    end
+
 
     private
 
@@ -161,7 +171,7 @@ module OneviewSDK
       OneviewSDK::DEFAULT_API_VERSION
     end
 
-    # Log in to OneView appliance and set max_api_version
+    # Log in to OneView appliance and return the session token
     def login(retries = 2)
       options = {
         'body' => {

--- a/lib/oneview-sdk/image-streamer/client.rb
+++ b/lib/oneview-sdk/image-streamer/client.rb
@@ -16,7 +16,10 @@ module OneviewSDK
     # The client defines the connection to the Image Streamer server and handles communication with it.
     class Client < OneviewSDK::Client
       undef :user
+      undef :user=
       undef :password
+      undef :password=
+      undef :refresh_login
 
       # Creates client object, establish connection, and set up logging and api version.
       # @param [Hash] options the options to configure the client

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -64,16 +64,6 @@ RSpec.describe OneviewSDK::Client do
       expect(client.logger.level).to eq(3)
     end
 
-    it 'allows the log level to be set again' do
-      options = { url: 'https://oneview.example.com', password: 'secret123', log_level: :error }
-      client = OneviewSDK::Client.new(options)
-      expect(client.log_level).to eq(:error)
-      expect(client.logger.level).to eq(Logger.const_get(client.log_level.upcase))
-      client.log_level = :warn
-      expect(client.log_level).to eq(:warn)
-      expect(client.logger.level).to eq(Logger.const_get(client.log_level.upcase))
-    end
-
     it 'picks the lower of the default api version and appliance api version' do
       allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(120)
       options = { url: 'https://oneview.example.com', token: 'token123' }
@@ -130,6 +120,41 @@ RSpec.describe OneviewSDK::Client do
       expect(OneviewSDK).to receive(:api_version_updated?).and_return false
       expect(OneviewSDK).to receive(:api_version=).with(200).and_return true
       OneviewSDK::Client.new(url: 'https://oneview.example.com', token: 'token123', api_version: 200)
+    end
+  end
+
+  describe 'attributes' do
+    include_context 'shared context'
+
+    it 'allows the url to be re-set' do
+      @client.url = 'https://new-url.example.com'
+      expect(@client.url).to eq('https://new-url.example.com')
+    end
+
+    it 'allows the user to be re-set' do
+      @client.user = 'updatedUser'
+      expect(@client.user).to eq('updatedUser')
+    end
+
+    it 'allows the password to be re-set' do
+      @client.password = 'updatedPassword'
+      expect(@client.password).to eq('updatedPassword')
+    end
+
+    it 'allows the token to be re-set' do
+      @client.token = 'updatedToken'
+      expect(@client.token).to eq('updatedToken')
+    end
+
+    it 'allows the log level to be re-set' do
+      expect(@client.log_level).to_not eq(:error)
+      @client.log_level = :error
+      expect(@client.log_level).to eq(:error)
+      expect(@client.logger.level).to eq(Logger.const_get(:ERROR))
+    end
+
+    it 'does not allow the max_api_version to be set manually' do
+      expect { @client.max_api_version = 1 }.to raise_error(NoMethodError, /undefined method/)
     end
   end
 
@@ -216,6 +241,18 @@ RSpec.describe OneviewSDK::Client do
 
     it 'fails when a bogus resource type is given' do
       expect { @client.get_all('BogusResources') }.to raise_error(TypeError, /Invalid resource type/)
+    end
+  end
+
+  describe '#refresh_login' do
+    include_context 'shared context'
+
+    it 'refreshes the token and max_api_version' do
+      expect(@client).to receive(:appliance_api_version).and_return(250)
+      expect(@client).to receive(:login).and_return('newToken')
+      @client.refresh_login
+      expect(@client.max_api_version).to eq(250)
+      expect(@client.token).to eq('newToken')
     end
   end
 

--- a/spec/unit/image-streamer/client_spec.rb
+++ b/spec/unit/image-streamer/client_spec.rb
@@ -43,16 +43,6 @@ RSpec.describe OneviewSDK::ImageStreamer::Client do
       expect(client.logger.level).to eq(3)
     end
 
-    it 'allows the log level to be set again' do
-      options = { url: 'https://oneview.example.com', token: 'secret123', log_level: :error }
-      client = OneviewSDK::ImageStreamer::Client.new(options)
-      expect(client.log_level).to eq(:error)
-      expect(client.logger.level).to eq(Logger.const_get(client.log_level.upcase))
-      client.log_level = :warn
-      expect(client.log_level).to eq(:warn)
-      expect(client.logger.level).to eq(Logger.const_get(client.log_level.upcase))
-    end
-
     it 'picks the lower of the default api version and appliance api version' do
       allow_any_instance_of(OneviewSDK::ImageStreamer::Client).to receive(:appliance_i3s_api_version).and_return(120)
       options = { url: 'https://oneview.example.com', token: 'token123' }
@@ -110,6 +100,39 @@ RSpec.describe OneviewSDK::ImageStreamer::Client do
       expect(OneviewSDK::ImageStreamer).to receive(:api_version_updated?).and_return false
       expect(OneviewSDK::ImageStreamer).to receive(:api_version=).with(300).and_return true
       OneviewSDK::ImageStreamer::Client.new(url: 'https://oneview.example.com', token: 'token123', api_version: 300)
+    end
+  end
+
+  describe 'attributes' do
+    include_context 'shared context'
+
+    it 'allows the url to be re-set' do
+      @client_i3s_300.url = 'https://new-url.example.com'
+      expect(@client_i3s_300.url).to eq('https://new-url.example.com')
+    end
+
+    it 'allows the token to be re-set' do
+      @client_i3s_300.token = 'updatedToken'
+      expect(@client_i3s_300.token).to eq('updatedToken')
+    end
+
+    it 'allows the log level to be re-set' do
+      expect(@client_i3s_300.log_level).to_not eq(:error)
+      @client_i3s_300.log_level = :error
+      expect(@client_i3s_300.log_level).to eq(:error)
+      expect(@client_i3s_300.logger.level).to eq(Logger.const_get(:ERROR))
+    end
+
+    it 'does not allow the user to be set manually' do
+      expect { @client_i3s_300.user = 'new' }.to raise_error(NoMethodError, /undefined method/)
+    end
+
+    it 'does not allow the password to be set manually' do
+      expect { @client_i3s_300.password = 'new' }.to raise_error(NoMethodError, /undefined method/)
+    end
+
+    it 'does not allow the max_api_version to be set manually' do
+      expect { @client_i3s_300.max_api_version = 1 }.to raise_error(NoMethodError, /undefined method/)
     end
   end
 
@@ -174,6 +197,14 @@ RSpec.describe OneviewSDK::ImageStreamer::Client do
 
     it 'fails when a bogus resource type is given' do
       expect { @client_i3s_300.get_all('BogusResources') }.to raise_error(TypeError, /Invalid resource type/)
+    end
+  end
+
+  describe '#refresh_login' do
+    include_context 'shared context'
+
+    it 'is not defined' do
+      expect { @client_i3s_300.refresh_login }.to raise_error(NoMethodError, /undefined method/)
     end
   end
 


### PR DESCRIPTION
### Description
- Allows most of the client attributes (including url, user & token) to be set after initialization
- Provides a new `#refresh_login` method to refresh the token & max_api_version (in the case of an attribute update or token expiring)

Note that since the I3S client does not have a user or password, and it does not attempt a login, the following client methods are not available: `#user=`, `#password=`, `#refresh_login`.

### Issues Resolved
Fixes #161

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
