### PR TITLE
Bugfix remove extra unmanaged volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Added full support to Image Streamer Rest API version 300:
    - OS Volumes
    - Plan Scripts
 
+#### Bug fixes & Enhancements:
+ - [#116](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/112) VolumeAttachment::remove_extra_unmanaged_volume throw Unexpected Http Error
+
 # v4.0.0
 
 #### Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,11 @@ Added full support to Image Streamer Rest API version 300:
    - Plan Script
 
 #### Bug fixes & Enhancements:
+ - [#116](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/112) VolumeAttachment::remove_extra_unmanaged_volume throw Unexpected Http Error
 - [#135](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/135) Firmware Bundle timeout does not give proper instructions for user post failure
 - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
 - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
 - Give custom exception classes a data attribute for more error context and default message
-
-#### Bug fixes & Enhancements:
- - [#116](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/112) VolumeAttachment::remove_extra_unmanaged_volume throw Unexpected Http Error
 
 # v4.0.0
 

--- a/lib/oneview-sdk/resource/api200/volume_attachment.rb
+++ b/lib/oneview-sdk/resource/api200/volume_attachment.rb
@@ -60,7 +60,7 @@ module OneviewSDK
           type: 'ExtraUnmanagedStorageVolumes',
           resourceUri: resource['uri']
         }
-        response = client.rest_post(BASE_URI + '/repair', 'body' => requestBody)
+        response = client.rest_post(BASE_URI + '/repair', { 'Accept-Language' => 'en_US', 'body' => requestBody }, client.api_version)
         client.response_handler(response)
       end
 

--- a/spec/integration/resource/api200/volume_attachment/update_spec.rb
+++ b/spec/integration/resource/api200/volume_attachment/update_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe OneviewSDK::VolumeAttachment, integration: true, type: UPDATE do
+klass = OneviewSDK::VolumeAttachment
+RSpec.describe klass, integration: true, type: UPDATE do
   include_context 'integration context'
 
   describe '#update' do
@@ -17,7 +18,7 @@ RSpec.describe OneviewSDK::VolumeAttachment, integration: true, type: UPDATE do
   end
 
   describe '::remove_extra_unmanaged_volume' do
-    it 'should remove extra presentations from a specific server profile (Fail/Bug: occurs error on the http method of ruby)' do
+    it 'should remove extra presentations from a specific server profile' do
       server_profile = OneviewSDK::ServerProfile.find_by($client, name: SERVER_PROFILE_NAME).first
       expect { klass.remove_extra_unmanaged_volume($client, server_profile) }.to_not raise_error
     end

--- a/spec/integration/resource/api300/c7000/volume_attachment/update_spec.rb
+++ b/spec/integration/resource/api300/c7000/volume_attachment/update_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe OneviewSDK::API300::C7000::VolumeAttachment, integration: true, type: UPDATE do
+klass = OneviewSDK::API300::C7000::VolumeAttachment
+RSpec.describe klass, integration: true, type: UPDATE do
   include_context 'integration api300 context'
 
   describe '#update' do
@@ -17,7 +18,7 @@ RSpec.describe OneviewSDK::API300::C7000::VolumeAttachment, integration: true, t
   end
 
   describe '::remove_extra_unmanaged_volume' do
-    it 'should remove extra presentations from a specific server profile (Fail/Bug: occurs error on the http method of ruby)' do
+    it 'should remove extra presentations from a specific server profile' do
       server_profile = OneviewSDK::API300::C7000::ServerProfile.find_by($client_300, name: SERVER_PROFILE_NAME).first
       expect { klass.remove_extra_unmanaged_volume($client_300, server_profile) }.to_not raise_error
     end

--- a/spec/integration/resource/api300/synergy/volume_attachment/update_spec.rb
+++ b/spec/integration/resource/api300/synergy/volume_attachment/update_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe OneviewSDK::API300::Synergy::VolumeAttachment, integration: true, type: UPDATE do
+klass = OneviewSDK::API300::Synergy::VolumeAttachment
+RSpec.describe klass, integration: true, type: UPDATE do
   include_context 'integration api300 context'
 
   describe '#update' do
@@ -17,7 +18,7 @@ RSpec.describe OneviewSDK::API300::Synergy::VolumeAttachment, integration: true,
   end
 
   describe '::remove_extra_unmanaged_volume' do
-    it 'should remove extra presentations from a specific server profile (Fail/Bug: occurs error on the http method of ruby)' do
+    it 'should remove extra presentations from a specific server profile' do
       server_profile = OneviewSDK::API300::Synergy::ServerProfile.find_by($client_300_synergy, name: SERVER_PROFILE_NAME).first
       expect { klass.remove_extra_unmanaged_volume($client_300_synergy, server_profile) }.to_not raise_error
     end

--- a/spec/unit/resource/api200/volume_attachment_spec.rb
+++ b/spec/unit/resource/api200/volume_attachment_spec.rb
@@ -12,12 +12,11 @@ RSpec.describe OneviewSDK::VolumeAttachment do
 
   describe 'Unmanaged Storage volumes' do
     it 'remove' do
+      options = { type: 'ExtraUnmanagedStorageVolumes', resourceUri: '/rest/server-profiles/1' }
       expect(@client).to receive(:rest_post).with(
         '/rest/storage-volume-attachments/repair',
-        'body' => {
-          type: 'ExtraUnmanagedStorageVolumes',
-          resourceUri: '/rest/server-profiles/1'
-        }
+        { 'Accept-Language' => 'en_US', 'body' => options },
+        @client.api_version
       ).and_return(FakeResponse.new({}))
       OneviewSDK::VolumeAttachment.remove_extra_unmanaged_volume(@client, 'uri' => '/rest/server-profiles/1')
     end

--- a/spec/unit/resource/api300/c7000/volume_attachment_spec.rb
+++ b/spec/unit/resource/api300/c7000/volume_attachment_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe OneviewSDK::API300::C7000::VolumeAttachment do
 
   describe 'Unmanaged Storage volumes' do
     it 'remove' do
+      options = { type: 'ExtraUnmanagedStorageVolumes', resourceUri: '/rest/server-profiles/1' }
       expect(@client_300).to receive(:rest_post).with(
         '/rest/storage-volume-attachments/repair',
-        'body' => {
-          type: 'ExtraUnmanagedStorageVolumes',
-          resourceUri: '/rest/server-profiles/1'
-        }
+        { 'Accept-Language' => 'en_US', 'body' => options },
+        @client_300.api_version
       ).and_return(FakeResponse.new({}))
       OneviewSDK::API300::C7000::VolumeAttachment.remove_extra_unmanaged_volume(@client_300, 'uri' => '/rest/server-profiles/1')
     end

--- a/spec/unit/resource/api300/synergy/volume_attachment_spec.rb
+++ b/spec/unit/resource/api300/synergy/volume_attachment_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe OneviewSDK::API300::Synergy::VolumeAttachment do
 
   describe 'Unmanaged Storage volumes' do
     it 'remove' do
+      options = { type: 'ExtraUnmanagedStorageVolumes', resourceUri: '/rest/server-profiles/1' }
       expect(@client_300).to receive(:rest_post).with(
         '/rest/storage-volume-attachments/repair',
-        'body' => {
-          type: 'ExtraUnmanagedStorageVolumes',
-          resourceUri: '/rest/server-profiles/1'
-        }
+        { 'Accept-Language' => 'en_US', 'body' => options },
+        @client_300.api_version
       ).and_return(FakeResponse.new({}))
       OneviewSDK::API300::Synergy::VolumeAttachment.remove_extra_unmanaged_volume(@client_300, 'uri' => '/rest/server-profiles/1')
     end


### PR DESCRIPTION
### Description
When we call ::remove_extra_unmanaged_volume of VolumeAttachment resource.

### Issues Resolved
Fixes #112 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
