### PR TITLE
Bugfix in integration test for Build Plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Added full support to Image Streamer Rest API version 300:
    - OS Volumes
    - Plan Scripts
 
+#### Bug fixes & Enhancements:
+ - [#174](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/174) I3S - Integration test for Build Plan failing
+
 # v4.0.0
 
 #### Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Added full support to Image Streamer Rest API version 300:
 - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
 - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
 - Give custom exception classes a data attribute for more error context and default message
- - [#174](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/174) I3S - Integration test for Build Plan failing
+- [#174](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/174) I3S - Integration test for Build Plan failing
 
 # v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ Added full support to Image Streamer Rest API version 300:
 - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
 - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
 - Give custom exception classes a data attribute for more error context and default message
-
-#### Bug fixes & Enhancements:
  - [#174](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/174) I3S - Integration test for Build Plan failing
 
 # v4.0.0

--- a/examples/_client_i3s.rb.example
+++ b/examples/_client_i3s.rb.example
@@ -35,4 +35,5 @@ puts "Connected to Image Streamer at #{@client.url}\n\n"
 # @golden_image_download_path = 'golden_image_demo.zip'
 # @golden_image_upload_path = 'vmwareesxi6_demo.zip'
 # @golden_image_log_path = 'details_gi.log'
-# @plan_script_name = 'Plan_Script_1'
+# @plan_script1_name = 'Plan_Script_1'
+# @plan_script2_name = 'Plan_Script_2'

--- a/examples/image-streamer/api300/build_plan.rb
+++ b/examples/image-streamer/api300/build_plan.rb
@@ -12,16 +12,20 @@
 require_relative '../../_client_i3s' # Gives access to @client
 
 # Example: Create a build plan for an API300 Image Streamer
-# NOTE: This will create a build plan named 'Build_Plan_1', then delete it.
+# NOTE: This will create three things with the following names 'Build_Plan_1', 'Build_Plan_2' and 'Build_Plan_3', then delete them.
 # NOTE: You'll need to add the following instance variables to the _client.rb file with valid URIs for your environment:
-#   @plan_script_name
+#   @plan_script1_name
+#   @plan_script2_name (plan script with build step and custom attributes)
 
 options = {
   name: 'Build_Plan_1',
   oeBuildPlanType: 'Deploy'
 }
 
-plan_script = OneviewSDK::ImageStreamer::API300::PlanScript.find_by(@client, name: @plan_script_name).first
+plan_script = OneviewSDK::ImageStreamer::API300::PlanScript.find_by(@client, name: @plan_script1_name).first
+plan_script2 = OneviewSDK::ImageStreamer::API300::PlanScript.find_by(@client, name: @plan_script2_name).first
+custom_attributes = JSON.parse(plan_script2['customAttributes'])
+custom_attributes.replace([custom_attributes[0].merge('type' => 'String')])
 
 build_step = [
   {
@@ -32,10 +36,26 @@ build_step = [
   }
 ]
 
+build_step2 = [
+  {
+    serialNumber: '1',
+    parameters: 'anystring',
+    planScriptName: 'Plan_Script_2',
+    planScriptUri: plan_script2['uri']
+  }
+]
+
 options2 = {
   name: 'Build_Plan_2',
   oeBuildPlanType: 'Deploy',
   buildStep: build_step
+}
+
+options3 = {
+  name: 'Build_Plan_3',
+  oeBuildPlanType: 'Deploy',
+  buildStep: build_step2,
+  customAttributes: custom_attributes
 }
 
 # Creating a build plan
@@ -53,6 +73,14 @@ item2.create!
 item2.retrieve!
 puts "\n#Build plan with name #{item2['name']} and uri #{item2['uri']} created successfully."
 
+# Creating a build plan with custom attributes
+item3 = OneviewSDK::ImageStreamer::API300::BuildPlan.new(@client, options3)
+
+puts "\n#Creating a build plan with name #{options3[:name]}."
+item3.create!
+item3.retrieve!
+puts "\n#Build plan with name #{item3['name']} and uri #{item3['uri']} created successfully."
+
 # List all builds
 list = OneviewSDK::ImageStreamer::API300::BuildPlan.get_all(@client)
 puts "\n#Listing all:"
@@ -61,21 +89,24 @@ list.each { |p| puts "  #{p['name']}" }
 id = list.first['uri']
 # Gets a build plan by id
 puts "\n#Gets a build plan by id #{id}:"
-item3 = OneviewSDK::ImageStreamer::API300::BuildPlan.find_by(@client, uri: id).first
-puts "\n#Build Plan with id #{item3['uri']} was found."
+item4 = OneviewSDK::ImageStreamer::API300::BuildPlan.find_by(@client, uri: id).first
+puts "\n#Build Plan with id #{item4['uri']} was found."
 
 # Updates a build plan
-item4 = OneviewSDK::ImageStreamer::API300::BuildPlan.find_by(@client, name: 'Build_Plan_1').first
-puts "\n#Updating a build plan with id #{item4['uri']} and name #{item4['name']}:"
-item4['name'] = 'Build_Plan_Updated'
-item4.update
-item4.retrieve!
-puts "\n#Build Plan updated successfully with id #{item4['uri']} and new name #{item4['name']}."
+item5 = OneviewSDK::ImageStreamer::API300::BuildPlan.find_by(@client, name: 'Build_Plan_1').first
+puts "\n#Updating a build plan with id #{item5['uri']} and name #{item5['name']}:"
+item5['name'] = 'Build_Plan_Updated'
+item5.update
+item5.retrieve!
+puts "\n#Build Plan updated successfully with id #{item5['uri']} and new name #{item5['name']}."
 
 # Removes all build plan
 puts "\n#Removing a build plan with id #{item2['uri']} and name #{item2['name']}:"
 item2.delete
 puts "\n#Build plan with id #{item2['uri']} and name #{item2['name']} removed successfully."
-puts "\n#Removing a build plan with id #{item4['uri']} and name #{item4['name']}:"
-item4.delete
-puts "\n#Build plan with id #{item4['uri']} and name #{item4['name']} removed successfully."
+puts "\n#Removing a build plan with id #{item3['uri']} and name #{item3['name']}:"
+item3.delete
+puts "\n#Build plan with id #{item3['uri']} and name #{item3['name']} removed successfully."
+puts "\n#Removing a build plan with id #{item5['uri']} and name #{item5['name']}:"
+item5.delete
+puts "\n#Build plan with id #{item5['uri']} and name #{item5['name']} removed successfully."

--- a/examples/image-streamer/api300/build_plan.rb
+++ b/examples/image-streamer/api300/build_plan.rb
@@ -12,7 +12,7 @@
 require_relative '../../_client_i3s' # Gives access to @client
 
 # Example: Create a build plan for an API300 Image Streamer
-# NOTE: This will create three things with the following names 'Build_Plan_1', 'Build_Plan_2' and 'Build_Plan_3', then delete them.
+# NOTE: This will create three build plans with the following names 'Build_Plan_1', 'Build_Plan_2' and 'Build_Plan_3', then delete them.
 # NOTE: You'll need to add the following instance variables to the _client.rb file with valid URIs for your environment:
 #   @plan_script1_name
 #   @plan_script2_name (plan script with build step and custom attributes)

--- a/examples/image-streamer/api300/build_plan.rb
+++ b/examples/image-streamer/api300/build_plan.rb
@@ -31,7 +31,7 @@ build_step = [
   {
     serialNumber: '1',
     parameters: 'anystring',
-    planScriptName: @plan_script_name,
+    planScriptName: @plan_script1_name,
     planScriptUri: plan_script['uri']
   }
 ]
@@ -40,7 +40,7 @@ build_step2 = [
   {
     serialNumber: '1',
     parameters: 'anystring',
-    planScriptName: 'Plan_Script_2',
+    planScriptName: @plan_script2_name,
     planScriptUri: plan_script2['uri']
   }
 ]

--- a/spec/integration/image-streamer/api300/build_plan/create_spec.rb
+++ b/spec/integration/image-streamer/api300/build_plan/create_spec.rb
@@ -75,6 +75,9 @@ RSpec.describe klass, integration_i3s: true, type: CREATE, sequence: i3s_seq(kla
     it 'creates a build plan with build step and custom attributes' do
       plan_script = OneviewSDK::ImageStreamer::API300::PlanScript.find_by($client_i3s_300, name: PLAN_SCRIPT2_NAME).first
 
+      custom_attributes = JSON.parse(plan_script['customAttributes'])
+      custom_attributes.replace([custom_attributes[0].merge('type' => 'String')])
+
       build_step = [
         {
           serialNumber: '1',
@@ -87,7 +90,8 @@ RSpec.describe klass, integration_i3s: true, type: CREATE, sequence: i3s_seq(kla
       options = {
         name: BUILD_PLAN4_NAME,
         oeBuildPlanType: 'deploy',
-        buildStep: build_step
+        buildStep: build_step,
+        customAttributes: custom_attributes
       }
 
       item = klass.new($client_i3s_300, options)

--- a/spec/integration/image-streamer/api300/build_plan/delete_spec.rb
+++ b/spec/integration/image-streamer/api300/build_plan/delete_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe klass, integration_i3s: true, type: DELETE, sequence: i3s_rseq(kl
   include_context 'integration i3s api300 context'
 
   describe '#delete' do
-    it 'removes a plan script' do
-      item = klass.find_by($client_i3s_300, name: BUILD_PLAN1_NAME_UPDATED).first
+    it 'removes all build plans' do
+      item = klass.find_by($client_i3s_300, name: BUILD_PLAN1_NAME).first
       item2 = klass.find_by($client_i3s_300, name: BUILD_PLAN2_NAME).first
       item3 = klass.find_by($client_i3s_300, name: BUILD_PLAN3_NAME).first
       item4 = klass.find_by($client_i3s_300, name: BUILD_PLAN4_NAME).first

--- a/spec/integration/image-streamer/api300/build_plan/update_spec.rb
+++ b/spec/integration/image-streamer/api300/build_plan/update_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe klass, integration_i3s: true, type: UPDATE do
   include_context 'integration i3s api300 context'
 
   describe '#update' do
-    it 'updates the name of the plan script' do
+    it 'updates the name of the build plan' do
       item = klass.find_by($client_i3s_300, name: BUILD_PLAN1_NAME).first
       expect(item).to be
       item['name'] = BUILD_PLAN1_NAME_UPDATED


### PR DESCRIPTION
### Description
The integration test for the build plan was not possible to test the appliance error. After reimaging the appliance, the test was performed and errors were found due to object search that did not exist.

### Issues Resolved
#174 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
