### PR TITLE
Bugfix in timeout Firmware Bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Added full support to Image Streamer Rest API version 300:
    - OS Volumes
    - Plan Scripts
 
+#### Bug fixes & Enhancements:
+ - [#135](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/135) Firmware Bundle timeout does not give proper instructions for user post failure
+
 # v4.0.0
 
 #### Breaking changes:

--- a/lib/oneview-sdk/resource/api200/firmware_bundle.rb
+++ b/lib/oneview-sdk/resource/api200/firmware_bundle.rb
@@ -52,7 +52,8 @@ module OneviewSDK
             rescue Net::ReadTimeout
               raise "The connection was closed because the timeout of #{timeout} seconds has expired."\
                 'You can specify the timeout in seconds by passing the timeout on the method call.'\
-                'If the firmware is corrupted in the search appliance, you should clean it.'
+                'Interrupted firmware uploads may result in corrupted firmware remaining in the appliance.'\
+                'HPE recommends checking the appliance for corrupted firmware and removing it.'
             end
           end
         end

--- a/lib/oneview-sdk/resource/api200/firmware_bundle.rb
+++ b/lib/oneview-sdk/resource/api200/firmware_bundle.rb
@@ -45,9 +45,15 @@ module OneviewSDK
           http_request.read_timeout = timeout
 
           http_request.start do |http|
-            response = http.request(req)
-            data = client.response_handler(response)
-            return OneviewSDK::FirmwareDriver.new(client, data)
+            begin
+              response = http.request(req)
+              data = client.response_handler(response)
+              return OneviewSDK::FirmwareDriver.new(client, data)
+            rescue Net::ReadTimeout
+              raise "The connection was closed because the timeout of #{timeout} seconds has expired."\
+                'You can specify the timeout in seconds by passing the timeout on the method call.'\
+                'If the firmware is corrupted in the search appliance, you should clean it.'
+            end
           end
         end
       end

--- a/spec/unit/resource/api200/firmware_bundle_spec.rb
+++ b/spec/unit/resource/api200/firmware_bundle_spec.rb
@@ -38,5 +38,14 @@ RSpec.describe OneviewSDK::FirmwareBundle do
       OneviewSDK::FirmwareBundle.add(@client, 'file.tar', 600)
       expect(http_fake).to have_received(:read_timeout=).with(600)
     end
+
+    it 'raises an exception when timeout expire' do
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_raise(Net::ReadTimeout)
+      allow_any_instance_of(Net::HTTP).to receive(:connect).and_return(true)
+      allow(File).to receive(:file?).and_return(true)
+      allow(File).to receive(:open).with('file.tar').and_yield('FAKE FILE CONTENT')
+      allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
+      expect { OneviewSDK::FirmwareBundle.add(@client, 'file.tar') }.to raise_error(/The connection was closed/)
+    end
   end
 end

--- a/spec/unit/resource/api300/c7000/firmware_bundle_spec.rb
+++ b/spec/unit/resource/api300/c7000/firmware_bundle_spec.rb
@@ -42,5 +42,14 @@ RSpec.describe OneviewSDK::API300::C7000::FirmwareBundle do
       described_class.add(@client, 'file.tar', 600)
       expect(http_fake).to have_received(:read_timeout=).with(600)
     end
+
+    it 'raises an exception when timeout expire' do
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_raise(Net::ReadTimeout)
+      allow_any_instance_of(Net::HTTP).to receive(:connect).and_return(true)
+      allow(File).to receive(:file?).and_return(true)
+      allow(File).to receive(:open).with('file.tar').and_yield('FAKE FILE CONTENT')
+      allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
+      expect { described_class.add(@client, 'file.tar') }.to raise_error(/The connection was closed/)
+    end
   end
 end

--- a/spec/unit/resource/api300/synergy/firmware_bundle_spec.rb
+++ b/spec/unit/resource/api300/synergy/firmware_bundle_spec.rb
@@ -42,5 +42,14 @@ RSpec.describe OneviewSDK::API300::Synergy::FirmwareBundle do
       described_class.add(@client, 'file.tar', 600)
       expect(http_fake).to have_received(:read_timeout=).with(600)
     end
+
+    it 'raises an exception when timeout expire' do
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_raise(Net::ReadTimeout)
+      allow_any_instance_of(Net::HTTP).to receive(:connect).and_return(true)
+      allow(File).to receive(:file?).and_return(true)
+      allow(File).to receive(:open).with('file.tar').and_yield('FAKE FILE CONTENT')
+      allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
+      expect { described_class.add(@client, 'file.tar') }.to raise_error(/The connection was closed/)
+    end
   end
 end


### PR DESCRIPTION
### Description
Have a clearer output when failing due to timeouts on firmware uploads.

### Issues Resolved
#135 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
