### PR TITLE
Added client domain attribute and destroy_session method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,9 @@ Added full support to Image Streamer Rest API version 300:
    - Plan Script
 
 #### Bug fixes & Enhancements:
- - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
- - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
-
-#### Bug fixes & Enhancements:
- - [#135](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/135) Firmware Bundle timeout does not give proper instructions for user post failure
-
-#### Bug fixes & Enhancements:
+- [#135](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/135) Firmware Bundle timeout does not give proper instructions for user post failure
+- [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
+- [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
 - [#178](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/178) Add client destroy_session method and domain attribute
 
 # v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Added full support to Image Streamer Rest API version 300:
    - Plan Scripts
 
 #### Bug fixes & Enhancements:
-- Add client destroy_session method and domain attribute
+- [#178](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/178) Add client destroy_session method and domain attribute
 
 # v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Added full support to Image Streamer Rest API version 300:
    - OS Volumes
    - Plan Scripts
 
+#### Bug fixes & Enhancements:
+- Add client destroy_session method and domain attribute
+
 # v4.0.0
 
 #### Breaking changes:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ client = OneviewSDK::Client.new(
   ssl_enabled: true,                  # This is the default and strongly encouraged
   logger: Logger.new(STDOUT),         # This is the default
   log_level: :info,                   # This is the default
+  domain: 'LOCAL',                    # This is the default
   api_version: 200                    # Defaults to minimum of 200 and appliance's max API version
 )
 ```
@@ -67,6 +68,7 @@ You can also set many of the client attributes using environment variables. To s
 ```bash
 # OneView client options:
 export ONEVIEWSDK_URL='https://oneview.example.com'
+export ONEVIEWSDK_DOMAIN='LOCAL'
 # You can set the token if you know it, or set the user and password to generate one:
 export ONEVIEWSDK_TOKEN='xxxx...'
 export ONEVIEWSDK_USER='Administrator'

--- a/lib/oneview-sdk.rb
+++ b/lib/oneview-sdk.rb
@@ -19,7 +19,7 @@ require_relative 'oneview-sdk/image_streamer'
 
 # Module for interacting with the HPE OneView API
 module OneviewSDK
-  env_sdk = %w(ONEVIEWSDK_URL ONEVIEWSDK_USER ONEVIEWSDK_PASSWORD ONEVIEWSDK_TOKEN)
+  env_sdk = %w(ONEVIEWSDK_URL ONEVIEWSDK_USER ONEVIEWSDK_PASSWORD ONEVIEWSDK_TOKEN ONEVIEWSDK_DOMAIN)
   env_sdk.concat %w(ONEVIEWSDK_SSL_ENABLED ONEVIEWSDK_API_VERSION ONEVIEWSDK_VARIANT)
   env_i3s = %w(I3S_URL I3S_TOKEN I3S_SSL_ENABLED)
   ENV_VARS = env_sdk.concat(env_i3s).freeze

--- a/lib/oneview-sdk/client.rb
+++ b/lib/oneview-sdk/client.rb
@@ -1,7 +1,7 @@
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed
@@ -18,7 +18,7 @@ module OneviewSDK
   # The client defines the connection to the OneView server and handles communication with it.
   class Client
     attr_reader :max_api_version
-    attr_accessor :url, :user, :token, :password, :ssl_enabled, :api_version, \
+    attr_accessor :url, :user, :token, :password, :domain, :ssl_enabled, :api_version, \
                   :logger, :log_level, :cert_store, :print_wait_dots, :timeout
 
     include Rest
@@ -32,6 +32,7 @@ module OneviewSDK
     # @option options [String] :url URL of OneView appliance
     # @option options [String] :user ('Administrator') The username to use for authentication with the OneView appliance
     # @option options [String] :password (ENV['ONEVIEWSDK_PASSWORD']) The password to use for authentication with OneView appliance
+    # @option options [String] :domain ('LOCAL') The name of the domain directory used for authentication
     # @option options [String] :token (ENV['ONEVIEWSDK_TOKEN']) The token to use for authentication with OneView appliance
     #   Use the token or the username and password (not both). The token has precedence.
     # @option options [Integer] :api_version (200) This is the API version to use by default for requests
@@ -65,12 +66,12 @@ module OneviewSDK
       @timeout = options[:timeout] unless options[:timeout].nil?
       @cert_store = OneviewSDK::SSLHelper.load_trusted_certs if @ssl_enabled
       @token = options[:token] || ENV['ONEVIEWSDK_TOKEN']
-      return if @token
-      @logger.warn 'User option not set. Using default (Administrator)' unless options[:user] || ENV['ONEVIEWSDK_USER']
+      @logger.warn 'User option not set. Using default (Administrator)' unless @token || options[:user] || ENV['ONEVIEWSDK_USER']
       @user = options[:user] || ENV['ONEVIEWSDK_USER'] || 'Administrator'
       @password = options[:password] || ENV['ONEVIEWSDK_PASSWORD']
-      raise InvalidClient, 'Must set user & password options or token option' unless @password
-      @token = login
+      raise InvalidClient, 'Must set user & password options or token option' unless @token || @password
+      @domain = options[:domain] || ENV['ONEVIEWSDK_DOMAIN'] || 'LOCAL'
+      @token ||= login
     end
 
     def log_level=(level)
@@ -157,6 +158,15 @@ module OneviewSDK
       self
     end
 
+    # Delete the session on the appliance, invalidating the client's token.
+    # To generate a new token after calling this method, use the refresh_login method.
+    # Call this after a token expires or the user and/or password is updated on the client object.
+    # @return [OneviewSDK::Client] self
+    def destroy_session
+      response_handler(rest_delete('/rest/login-sessions'))
+      self
+    end
+
 
     private
 
@@ -179,7 +189,7 @@ module OneviewSDK
         'body' => {
           'userName' => @user,
           'password' => @password,
-          'authLoginDomain' => 'LOCAL'
+          'authLoginDomain' => @domain
         }
       }
       response = rest_post('/rest/login-sessions', options)

--- a/lib/oneview-sdk/image-streamer/client.rb
+++ b/lib/oneview-sdk/image-streamer/client.rb
@@ -19,7 +19,10 @@ module OneviewSDK
       undef :user=
       undef :password
       undef :password=
+      undef :domain
+      undef :domain=
       undef :refresh_login
+      undef :destroy_session
 
       # Creates client object, establish connection, and set up logging and api version.
       # @param [Hash] options the options to configure the client

--- a/spec/unit/cli/env_spec.rb
+++ b/spec/unit/cli/env_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe OneviewSDK::Cli do
       expect { command }.to output(/ONEVIEWSDK_PASSWORD\s+=\s'secret123'/).to_stdout_from_any_process
     end
 
+    it 'shows ONEVIEWSDK_DOMAIN' do
+      ENV['ONEVIEWSDK_DOMAIN'] = 'Other'
+      expect { command }.to output(/ONEVIEWSDK_DOMAIN\s+=\s'Other'/).to_stdout_from_any_process
+    end
+
     it 'shows ONEVIEWSDK_TOKEN' do
       expect { command }.to output(/ONEVIEWSDK_TOKEN\s+=\s'secret456'/).to_stdout_from_any_process
     end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe OneviewSDK::Client do
       expect(client.user).to eq('Administrator')
     end
 
+    it 'sets the domain to "LOCAL" by default' do
+      options = { url: 'https://oneview.example.com', token: 'secret123' }
+      client = OneviewSDK::Client.new(options)
+      expect(client.domain).to eq('LOCAL')
+    end
+
     it 'respects credential environment variables' do
       ENV['ONEVIEWSDK_USER'] = 'Admin'
       ENV['ONEVIEWSDK_PASSWORD'] = 'secret456'
@@ -43,6 +49,12 @@ RSpec.describe OneviewSDK::Client do
       ENV['ONEVIEWSDK_TOKEN'] = 'secret456'
       client = OneviewSDK::Client.new(url: 'https://oneview.example.com')
       expect(client.token).to eq('secret456')
+    end
+
+    it 'respects the domain environment variable' do
+      ENV['ONEVIEWSDK_DOMAIN'] = 'Other'
+      client = OneviewSDK::Client.new(url: 'https://oneview.example.com', token: 'secret123')
+      expect(client.domain).to eq('Other')
     end
 
     it 'respects the ssl environment variable' do
@@ -271,6 +283,15 @@ RSpec.describe OneviewSDK::Client do
       @client.refresh_login
       expect(@client.max_api_version).to eq(250)
       expect(@client.token).to eq('newToken')
+    end
+  end
+
+  describe '#destroy_session' do
+    include_context 'shared context'
+
+    it 'makes a REST call to destroy the session' do
+      expect(@client).to receive(:rest_delete).with('/rest/login-sessions').and_return(FakeResponse.new)
+      expect(@client.destroy_session).to eq(@client)
     end
   end
 


### PR DESCRIPTION
### Description
- Adds a client method that will destroy the current session (invalidate the session token). This is good to clean up sessions before exiting.
- Supports other login domains when signing in with username & password

### Issues Resolved
Fixes #178

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
