### PR TITLE
Added exception data attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,9 @@ Added full support to Image Streamer Rest API version 300:
    - Plan Script
 
 #### Bug fixes & Enhancements:
- - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
- - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
-
-#### Bug fixes & Enhancements:
- - [#135](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/135) Firmware Bundle timeout does not give proper instructions for user post failure
-
-#### Bug fixes & Enhancements:
+- [#135](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/135) Firmware Bundle timeout does not give proper instructions for user post failure
+- [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
+- [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
 - Give custom exception classes a data attribute for more error context and default message
 
 # v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Added full support to Image Streamer Rest API version 300:
    - OS Volumes
    - Plan Scripts
 
+#### Bug fixes & Enhancements:
+- Give custom exception classes a data attribute for more error context
+
 # v4.0.0
 
 #### Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Added full support to Image Streamer Rest API version 300:
    - Plan Scripts
 
 #### Bug fixes & Enhancements:
-- Give custom exception classes a data attribute for more error context
+- Give custom exception classes a data attribute for more error context and default message
 
 # v4.0.0
 

--- a/lib/oneview-sdk.rb
+++ b/lib/oneview-sdk.rb
@@ -37,8 +37,10 @@ module OneviewSDK
   # Set the default API version
   def self.api_version=(version)
     version = version.to_i rescue version
-    raise "API version #{version} is not supported!" unless SUPPORTED_API_VERSIONS.include?(version)
-    raise "The module for API version #{@api_version} is undefined" unless constants.include?("API#{@api_version}".to_sym)
+    raise UnsupportedVersion, "API version #{version} is not supported!"\
+      unless SUPPORTED_API_VERSIONS.include?(version)
+    raise UnsupportedVariant, "The module for API version #{@api_version} is undefined"\
+      unless constants.include?("API#{@api_version}".to_sym)
     @api_version_updated = true
     @api_version = version
   end

--- a/lib/oneview-sdk/exceptions.rb
+++ b/lib/oneview-sdk/exceptions.rb
@@ -1,7 +1,7 @@
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed
@@ -11,45 +11,65 @@
 
 # Contains all the custom Exception classes
 module OneviewSDK
-  class ConnectionError < StandardError # Cannot connect to client/resource
+  # Error class allowing storage of a data attribute
+  class OVError < ::StandardError
+    attr_accessor :data
+
+    def initialize(msg = nil, data = nil)
+      @data = data
+      super(msg)
+    end
+
+    # Shorthand method to raise an error.
+    # @example
+    #   OneviewSDK::OVError.raise! 'Message', { data: 'stuff' }
+    def self.raise!(msg = nil, data = nil)
+      raise new(msg, data)
+    end
   end
 
-  class InvalidURL < StandardError # URL is invalid
+  class ConnectionError < OVError # Cannot connect to client/resource
   end
 
-  class InvalidClient < StandardError # Client configuration is invalid
+  class InvalidURL < OVError # URL is invalid
   end
 
-  class InvalidResource < StandardError # Failed resource validations
+  class InvalidClient < OVError # Client configuration is invalid
   end
 
-  class IncompleteResource < StandardError # Missing required resource data to complete action
+  class InvalidResource < OVError # Failed resource validations
   end
 
-  class MethodUnavailable < StandardError # Resource does not support this method
+  class IncompleteResource < OVError # Missing required resource data to complete action
   end
 
-  class UnsupportedVersion < StandardError # Resource not supported on this API version
+  class MethodUnavailable < OVError # Resource does not support this method
   end
 
-  class InvalidRequest < StandardError # Could not make request
+  class UnsupportedVariant < OVError # Variant is not supported
   end
 
-  class BadRequest < StandardError # 400
+  class UnsupportedVersion < OVError # Resource not supported on this API version
   end
 
-  class Unauthorized < StandardError # 401
+  class InvalidRequest < OVError # Could not make request
   end
 
-  class NotFound < StandardError # 404
+  class BadRequest < OVError # 400
   end
 
-  class RequestError < StandardError # Other bad response codes
+  class Unauthorized < OVError # 401
   end
 
-  class TaskError < StandardError # Task ended in a bad state
+  class NotFound < OVError # 404
   end
 
-  class InvalidFormat < StandardError # File format is invalid
+  class RequestError < OVError # Other bad response codes
+  end
+
+  class TaskError < OVError # Task ended in a bad state
+  end
+
+  class InvalidFormat < OVError # File format is invalid
   end
 end

--- a/lib/oneview-sdk/exceptions.rb
+++ b/lib/oneview-sdk/exceptions.rb
@@ -12,64 +12,80 @@
 # Contains all the custom Exception classes
 module OneviewSDK
   # Error class allowing storage of a data attribute
-  class OVError < ::StandardError
+  class OneViewError < ::StandardError
     attr_accessor :data
+    MESSAGE = '(No message)'.freeze
 
-    def initialize(msg = nil, data = nil)
+    def initialize(msg = self.class::MESSAGE, data = nil)
       @data = data
       super(msg)
     end
 
     # Shorthand method to raise an error.
     # @example
-    #   OneviewSDK::OVError.raise! 'Message', { data: 'stuff' }
-    def self.raise!(msg = nil, data = nil)
+    #   OneviewSDK::OneViewError.raise! 'Message', { data: 'stuff' }
+    def self.raise!(msg = self::MESSAGE, data = nil)
       raise new(msg, data)
     end
   end
 
-  class ConnectionError < OVError # Cannot connect to client/resource
+  class ConnectionError < OneViewError # Cannot connect to client/resource
+    MESSAGE = 'Cannot connect to client/resource'.freeze
   end
 
-  class InvalidURL < OVError # URL is invalid
+  class InvalidURL < OneViewError # URL is invalid
+    MESSAGE = 'URL is invalid'.freeze
   end
 
-  class InvalidClient < OVError # Client configuration is invalid
+  class InvalidClient < OneViewError # Client configuration is invalid
+    MESSAGE = 'Client configuration is invalid'.freeze
   end
 
-  class InvalidResource < OVError # Failed resource validations
+  class InvalidResource < OneViewError # Failed resource validations
+    MESSAGE = 'Failed resource validations'.freeze
   end
 
-  class IncompleteResource < OVError # Missing required resource data to complete action
+  class IncompleteResource < OneViewError # Missing required resource data to complete action
+    MESSAGE = 'Missing required resource data to complete action'.freeze
   end
 
-  class MethodUnavailable < OVError # Resource does not support this method
+  class MethodUnavailable < OneViewError # Resource does not support this method
+    MESSAGE = 'Resource does not support this method'.freeze
   end
 
-  class UnsupportedVariant < OVError # Variant is not supported
+  class UnsupportedVariant < OneViewError # Variant is not supported
+    MESSAGE = 'Variant is not supported'.freeze
   end
 
-  class UnsupportedVersion < OVError # Resource not supported on this API version
+  class UnsupportedVersion < OneViewError # Resource not supported on this API version
+    MESSAGE = 'Resource not supported on this API version'.freeze
   end
 
-  class InvalidRequest < OVError # Could not make request
+  class InvalidRequest < OneViewError # Could not make request
+    MESSAGE = 'Could not make request'.freeze
   end
 
-  class BadRequest < OVError # 400
+  class BadRequest < OneViewError # 400
+    MESSAGE = '400'.freeze
   end
 
-  class Unauthorized < OVError # 401
+  class Unauthorized < OneViewError # 401
+    MESSAGE = '401'.freeze
   end
 
-  class NotFound < OVError # 404
+  class NotFound < OneViewError # 404
+    MESSAGE = '404'.freeze
   end
 
-  class RequestError < OVError # Other bad response codes
+  class RequestError < OneViewError # Other bad response codes
+    MESSAGE = 'Bad response code'.freeze
   end
 
-  class TaskError < OVError # Task ended in a bad state
+  class TaskError < OneViewError # Task ended in a bad state
+    MESSAGE = 'Task ended in a bad state'.freeze
   end
 
-  class InvalidFormat < OVError # File format is invalid
+  class InvalidFormat < OneViewError # File format is invalid
+    MESSAGE = 'File format is invalid'.freeze
   end
 end

--- a/lib/oneview-sdk/resource.rb
+++ b/lib/oneview-sdk/resource.rb
@@ -31,7 +31,8 @@ module OneviewSDK
     # @param [Integer] api_ver The api version to use when interracting with this resource.
     #   Defaults to the client.api_version if it exists, or the OneviewSDK::Client::DEFAULT_API_VERSION.
     def initialize(client, params = {}, api_ver = nil)
-      raise InvalidClient, 'Must specify a valid client' unless client.is_a?(OneviewSDK::Client) || client.is_a?(OneviewSDK::ImageStreamer::Client)
+      raise InvalidClient, 'Must specify a valid client'\
+        unless client.is_a?(OneviewSDK::Client) || client.is_a?(OneviewSDK::ImageStreamer::Client)
       @client = client
       @logger = @client.logger
       @api_version = api_ver || @client.api_version
@@ -364,9 +365,8 @@ module OneviewSDK
   # @param [String] variant API module variant to fetch resource from
   # @return [Class] Resource class or nil if not found
   def self.resource_named(type, api_ver = @api_version, variant = nil)
-    unless SUPPORTED_API_VERSIONS.include?(api_ver)
-      raise UnsupportedVersion, "API version #{api_ver} is not supported! Try one of: #{SUPPORTED_API_VERSIONS}"
-    end
+    raise UnsupportedVersion, "API version #{api_ver} is not supported! Try one of: #{SUPPORTED_API_VERSIONS}"\
+      unless SUPPORTED_API_VERSIONS.include?(api_ver)
     api_module = OneviewSDK.const_get("API#{api_ver}")
     variant ? api_module.resource_named(type, variant) : api_module.resource_named(type)
   end

--- a/lib/oneview-sdk/rest.rb
+++ b/lib/oneview-sdk/rest.rb
@@ -133,8 +133,7 @@ module OneviewSDK
     #   If an asynchronous task was started, this waits for it to complete.
     # @param [HTTPResponse] response HTTP response
     # @param [Boolean] wait_on_task Wait on task (or just return task details)
-    # @raise [StandardError] if the request failed
-    # @raise [StandardError] if a task was returned that did not complete successfully
+    # @raise [OneviewSDK::OVError] if the request failed or a task did not complete successfully
     # @return [Hash] The parsed JSON body
     def response_handler(response, wait_on_task = true)
       case response.code.to_i
@@ -158,13 +157,13 @@ module OneviewSDK
       when RESPONSE_CODE_NO_CONTENT # Synchronous delete
         return {}
       when RESPONSE_CODE_BAD_REQUEST
-        raise BadRequest, "400 BAD REQUEST #{response.body}"
+        BadRequest.raise! "400 BAD REQUEST #{response.body}", response
       when RESPONSE_CODE_UNAUTHORIZED
-        raise Unauthorized, "401 UNAUTHORIZED #{response.body}"
+        Unauthorized.raise! "401 UNAUTHORIZED #{response.body}", response
       when RESPONSE_CODE_NOT_FOUND
-        raise NotFound, "404 NOT FOUND #{response.body}"
+        NotFound.raise! "404 NOT FOUND #{response.body}", response
       else
-        raise RequestError, "#{response.code} #{response.body}"
+        RequestError.raise! "#{response.code} #{response.body}", response
       end
     end
 

--- a/lib/oneview-sdk/rest.rb
+++ b/lib/oneview-sdk/rest.rb
@@ -133,7 +133,7 @@ module OneviewSDK
     #   If an asynchronous task was started, this waits for it to complete.
     # @param [HTTPResponse] response HTTP response
     # @param [Boolean] wait_on_task Wait on task (or just return task details)
-    # @raise [OneviewSDK::OVError] if the request failed or a task did not complete successfully
+    # @raise [OneviewSDK::OneViewError] if the request failed or a task did not complete successfully
     # @return [Hash] The parsed JSON body
     def response_handler(response, wait_on_task = true)
       case response.code.to_i

--- a/spec/unit/exceptions_spec.rb
+++ b/spec/unit/exceptions_spec.rb
@@ -3,12 +3,14 @@ require_relative './../spec_helper'
 # Tests for custom exception classes
 
 classes = [
+  OneviewSDK::OVError,
   OneviewSDK::ConnectionError,
   OneviewSDK::InvalidURL,
   OneviewSDK::InvalidClient,
   OneviewSDK::InvalidResource,
   OneviewSDK::IncompleteResource,
   OneviewSDK::MethodUnavailable,
+  OneviewSDK::UnsupportedVariant,
   OneviewSDK::UnsupportedVersion,
   OneviewSDK::InvalidRequest,
   OneviewSDK::BadRequest,
@@ -20,8 +22,18 @@ classes = [
 ]
 classes.each do |klass|
   RSpec.describe klass do
-    it 'exists and supports a message parameter' do
+    it 'behaves like the StandardError class' do
       expect { raise described_class, 'Msg' }.to raise_error(described_class, /Msg/)
+    end
+
+    it 'supports a message and data parameter' do
+      e = klass.new('Msg', key: :val)
+      expect(e.message).to eq('Msg')
+      expect(e.data).to eq(key: :val)
+    end
+
+    it 'has a shorthand raise! method' do
+      expect { described_class.raise! 'Msg', :data }.to raise_error(described_class, /Msg/)
     end
   end
 end

--- a/spec/unit/exceptions_spec.rb
+++ b/spec/unit/exceptions_spec.rb
@@ -3,7 +3,7 @@ require_relative './../spec_helper'
 # Tests for custom exception classes
 
 classes = [
-  OneviewSDK::OVError,
+  OneviewSDK::OneViewError,
   OneviewSDK::ConnectionError,
   OneviewSDK::InvalidURL,
   OneviewSDK::InvalidClient,
@@ -30,6 +30,17 @@ classes.each do |klass|
       e = klass.new('Msg', key: :val)
       expect(e.message).to eq('Msg')
       expect(e.data).to eq(key: :val)
+    end
+
+    it 'has a default message' do
+      e = klass.new
+      expect(e.message).to be_a(String)
+      expect(e.message.empty?).to be false
+      if klass == OneviewSDK::OneViewError
+        expect(e.message).to eq('(No message)')
+      else
+        expect(e.message).to_not eq('(No message)')
+      end
     end
 
     it 'has a shorthand raise! method' do

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -152,17 +152,29 @@ RSpec.describe OneviewSDK::Client do
 
     it 'raises an error for 400 status' do
       resp = FakeResponse.new({ message: 'Blah' }, 400)
-      expect { @client.response_handler(resp) }.to raise_error(OneviewSDK::BadRequest, /400 BAD REQUEST.*Blah/)
+      expect { @client.response_handler(resp) }.to raise_error { |e|
+        expect(e).to be_a(OneviewSDK::BadRequest)
+        expect(e.message).to match(/400 BAD REQUEST.*Blah/)
+        expect(e.data).to eq(resp)
+      }
     end
 
     it 'raises an error for 401 status' do
       resp = FakeResponse.new({ message: 'Blah' }, 401)
-      expect { @client.response_handler(resp) }.to raise_error(OneviewSDK::Unauthorized, /401 UNAUTHORIZED.*Blah/)
+      expect { @client.response_handler(resp) }.to raise_error { |e|
+        expect(e).to be_a(OneviewSDK::Unauthorized)
+        expect(e.message).to match(/401 UNAUTHORIZED.*Blah/)
+        expect(e.data).to eq(resp)
+      }
     end
 
     it 'raises an error for 404 status' do
       resp = FakeResponse.new({ message: 'Blah' }, 404)
-      expect { @client.response_handler(resp) }.to raise_error(OneviewSDK::NotFound, /404 NOT FOUND.*Blah/)
+      expect { @client.response_handler(resp) }.to raise_error { |e|
+        expect(e).to be_a(OneviewSDK::NotFound)
+        expect(e.message).to match(/404 NOT FOUND.*Blah/)
+        expect(e.data).to eq(resp)
+      }
     end
 
     it 'raises an error for undefined status codes' do


### PR DESCRIPTION
### Description
- Adds a data attribute to the custom exception classes
- Adds a few new exception classes

This will be very helpful when rescuing from errors, because now you can attach and see additional data related to the error. For instance, the response object returned from a bad REST call. You can do whatever you want with it, not just have to deal with the message string.

### Issues Resolved
(none)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
