### PR TITLE
Added scope helper methods to Switch resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Added full support to Image Streamer Rest API version 300:
 
 #### Bug fixes & Enhancements:
  - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
+ - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
 
 # v4.0.0
 

--- a/examples/api300/c7000/switch.rb
+++ b/examples/api300/c7000/switch.rb
@@ -11,6 +11,8 @@
 
 require_relative '../../_client' # Gives access to @client
 
+# NOTE: It is needed have a Switch created previously.
+
 # Retrieves all switch types from the Appliance
 OneviewSDK::API300::C7000::Switch.get_types(@client).each do |type|
   puts "Switch Type: #{type['name']}\nURI: #{type['uri']}\n\n"
@@ -19,3 +21,35 @@ end
 # Retrieves switch type by name
 item = OneviewSDK::API300::C7000::Switch.get_type(@client, 'Cisco Nexus 50xx')
 puts "Switch Type by name: #{item['name']}\nURI: #{item['uri']}\n\n"
+
+# Retrieves switch type by name
+item = OneviewSDK::API300::C7000::Switch.get_type(@client, 'Cisco Nexus 50xx')
+puts "Switch Type by name: #{item['name']}\nURI: #{item['uri']}\n\n"
+
+# Create Scopes
+scope_1 = OneviewSDK::API300::C7000::Scope.new(@client, name: 'Scope 1')
+scope_1.create
+scope_2 = OneviewSDK::API300::C7000::Scope.new(@client, name: 'Scope 2')
+scope_2.create
+
+item = OneviewSDK::API300::C7000::Switch.get_all(@client).first
+
+puts "\nAdding scopes"
+item.add_scope(scope_1)
+item.retrieve!
+puts 'Scopes:', item['scopeUris']
+
+puts "\nReplacing scopes"
+item.replace_scopes(scope_2)
+item.retrieve!
+puts 'Scopes:', item['scopeUris']
+
+puts "\nRemoving scopes"
+item.remove_scope(scope_1)
+item.remove_scope(scope_2)
+item.retrieve!
+puts 'Scopes:', item['scopeUris']
+
+# Delete scopes
+scope_1.delete
+scope_2.delete

--- a/lib/oneview-sdk/resource/api300/c7000/switch.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/switch.rb
@@ -10,20 +10,20 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api200/switch'
+require_relative 'scope'
 
 module OneviewSDK
   module API300
     module C7000
       # Switch resource implementation
       class Switch < OneviewSDK::API200::Switch
+        include OneviewSDK::API300::C7000::Scope::ScopeHelperMethods
 
         # Updates the scope URIs of a specific switch
         # @param [Array] scope_uris Array of scope uri strings
+        # @deprecated Use {#add_scope}, {#remove_scope}, and {#replace_scopes} instead.
         def set_scope_uris(scope_uris)
-          ensure_client && ensure_uri
-          body = { op: 'replace', path: '/scopeUris', value: scope_uris }
-          response = @client.rest_patch(@data['uri'], { 'body' => [body] }, @api_version)
-          @client.response_handler(response)
+          patch('replace', '/scopeUris', scope_uris)
         end
       end
     end

--- a/spec/integration/resource/api300/c7000/switch/update_spec.rb
+++ b/spec/integration/resource/api300/c7000/switch/update_spec.rb
@@ -4,11 +4,61 @@ klass = OneviewSDK::API300::C7000::Switch
 RSpec.describe klass, integration: true, type: UPDATE do
   include_context 'integration api300 context'
 
-  describe '#patch' do
+  let(:scope_1) { OneviewSDK::API300::C7000::Scope.get_all($client_300)[0] }
+  let(:scope_2) { OneviewSDK::API300::C7000::Scope.get_all($client_300)[1] }
+  let(:scope_clean) { OneviewSDK::API300::C7000::Scope.new($client_300) }
+  subject(:item) { klass.find_by($client_300, {}).first }
+
+  describe '#set_scope_uris' do
     it 'replaces the switch scopeUris' do
-      item = klass.find_by($client_300, {}).first
-      item.retrieve!
-      expect { item.set_scope_uris(item['scopeUris']) }.not_to raise_error
+      scope_uris = scope_1['uri'], scope_2['uri']
+      expect { item.set_scope_uris(scope_uris) }.not_to raise_error
+      expect(item.retrieve!).to eq(true)
+      expect(item['scopeUris']).to match_array([scope_1['uri'], scope_2['uri']])
+
+      expect { item.set_scope_uris([]) }.not_to raise_error
+      expect(item.retrieve!).to eq(true)
+      expect(item['scopeUris']).to be_empty
+    end
+  end
+
+  describe '#add_scope' do
+    context 'when scope has no URI' do
+      it { expect { item.add_scope(scope_clean) }.to raise_error(OneviewSDK::IncompleteResource) }
+    end
+
+    it 'should add scope' do
+      expect { item.add_scope(scope_1) }.to_not raise_error
+      expect(item.retrieve!).to eq(true)
+      expect(item['scopeUris']).to match_array([scope_1['uri']])
+    end
+  end
+
+  describe '#replace_scopes' do
+    context 'when scope has no URI' do
+      it { expect { item.replace_scopes(scope_clean) }.to raise_error(OneviewSDK::IncompleteResource) }
+    end
+
+    it 'should replace the list of scopes' do
+      expect { item.replace_scopes(scope_1, scope_2) }.to_not raise_error
+      expect(item.retrieve!).to eq(true)
+      expect(item['scopeUris']).to match_array([scope_1['uri'], scope_2['uri']])
+    end
+  end
+
+  describe '#remove_scope' do
+    context 'when scope has no URI' do
+      it { expect { item.remove_scope(scope_clean) }.to raise_error(OneviewSDK::IncompleteResource) }
+    end
+
+    it 'should remove scope' do
+      expect { item.remove_scope(scope_2) }.to_not raise_error
+      expect(item.retrieve!).to eq(true)
+      expect(item['scopeUris']).to match_array([scope_1['uri']]) # scope_2 was removed
+
+      expect { item.remove_scope(scope_1) }.to_not raise_error
+      expect(item.retrieve!).to eq(true)
+      expect(item['scopeUris']).to be_empty
     end
   end
 end

--- a/spec/unit/resource/api300/c7000/switch_spec.rb
+++ b/spec/unit/resource/api300/c7000/switch_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe OneviewSDK::API300::C7000::Switch do
   describe '#set_scope_uris' do
     it 'does a PATCH containing the scope uris to a switch' do
       item = described_class.new(@client_300, uri: '/rest/fake')
-      data = { 'body' => [{ op: 'replace', path: '/scopeUris', value: ['/rest/scopes/fee00629-9931-426d-8771-a597917eb9d2'] }] }
+      data = { 'body' => [{ 'op' => 'replace', 'path' => '/scopeUris', 'value' => ['/rest/scopes/fee00629-9931-426d-8771-a597917eb9d2'] }] }
       expect(@client_300).to receive(:rest_patch).with('/rest/fake', data, item.api_version).and_return(FakeResponse.new(key: 'Val'))
       expect(item.set_scope_uris(['/rest/scopes/fee00629-9931-426d-8771-a597917eb9d2'])).to eq('key' => 'Val')
     end


### PR DESCRIPTION
### Description
Added scope helper methods to Switch resource: add_scope, remove_scope and replace_scopes.

### Issues Resolved
Fixes #146 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
