### PR TITLE
I3S enviroment variable token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ Added full support to Image Streamer Rest API version 300:
    - Plan Script
 
 #### Bug fixes & Enhancements:
- - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
- - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
-
-#### Bug fixes & Enhancements:
  - [#135](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/135) Firmware Bundle timeout does not give proper instructions for user post failure
+ - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
+ - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
+ - [#183](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/183) Image Streamer Client cannot be created with the OneView environment variables
 
 # v4.0.0
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ export ONEVIEWSDK_SSL_ENABLED=false
 
 # Image Streamer (I3S) client options:
 export I3S_URL='https://image-streamer.example.com'
-export I3S_TOKEN='xxxx...'
 export I3S_SSL_ENABLED=false
 # NOTE: Disabling SSL is strongly discouraged. Please see the CLI section for import instructions.
 ```
@@ -106,6 +105,16 @@ Then you can leave out these options from your config, enabling you to just do:
 require 'oneview-sdk'
 client = OneviewSDK::Client.new
 # and/or
+i3s_client = OneviewSDK::ImageStreamer::Client.new
+```
+
+You can create the i3s client with environment variables in the following ways:
+```ruby
+require 'oneview-sdk'
+# Uses this way when you set ONEVIEWSDK_USER and ONEVIEWSDK_PASSWORD to create Oneview client
+client = OneviewSDK::Client.new
+i3s_client = client.new_i3s_client # Returns an instance of i3s client
+# or uses this way when you set ONEVIEWSDK_TOKEN
 i3s_client = OneviewSDK::ImageStreamer::Client.new
 ```
 

--- a/examples/_client_i3s.rb.example
+++ b/examples/_client_i3s.rb.example
@@ -5,7 +5,7 @@ require 'pry'
 # Client for the Image Streamer
 @client = OneviewSDK::ImageStreamer::Client.new(
   url: 'https://i3s.example.com', # or set ENV['I3S_URL']
-  token: 'token_oneview', # or set ENV['I3S_TOKEN']
+  token: 'token_oneview', # or set ENV['ONEVIEWSDK_TOKEN']
   ssl_enabled: false
 )
 

--- a/lib/oneview-sdk.rb
+++ b/lib/oneview-sdk.rb
@@ -21,7 +21,7 @@ require_relative 'oneview-sdk/image_streamer'
 module OneviewSDK
   env_sdk = %w(ONEVIEWSDK_URL ONEVIEWSDK_USER ONEVIEWSDK_PASSWORD ONEVIEWSDK_TOKEN)
   env_sdk.concat %w(ONEVIEWSDK_SSL_ENABLED ONEVIEWSDK_API_VERSION ONEVIEWSDK_VARIANT)
-  env_i3s = %w(I3S_URL I3S_TOKEN I3S_SSL_ENABLED)
+  env_i3s = %w(I3S_URL I3S_SSL_ENABLED)
   ENV_VARS = env_sdk.concat(env_i3s).freeze
 
   SUPPORTED_API_VERSIONS = [200, 300].freeze

--- a/lib/oneview-sdk/image-streamer/client.rb
+++ b/lib/oneview-sdk/image-streamer/client.rb
@@ -28,7 +28,7 @@ module OneviewSDK
       # @option options [Symbol] :log_level (:info) Log level. Logger must define a constant with this name. ie Logger::INFO
       # @option options [Boolean] :print_wait_dots (false) When true, prints status dots while waiting on the tasks to complete.
       # @option options [String] :url URL of Image Streamer
-      # @option options [String] :token (ENV['I3S_TOKEN']) The token to use for authentication with Image Streamer
+      # @option options [String] :token (ENV['ONEVIEWSDK_TOKEN']) The token to use for authentication
       # @option options [Integer] :api_version (300) This is the API version to use by default for requests
       # @option options [Boolean] :ssl_enabled (true) Use ssl for requests? Respects ENV['I3S_SSL_ENABLED']
       # @option options [Integer] :timeout (nil) Override the default request timeout value
@@ -60,8 +60,8 @@ module OneviewSDK
         @ssl_enabled = options[:ssl_enabled] unless options[:ssl_enabled].nil?
         @timeout = options[:timeout] unless options[:timeout].nil?
         @cert_store = OneviewSDK::SSLHelper.load_trusted_certs if @ssl_enabled
-        raise InvalidClient, 'Must set token option' unless options[:token] || ENV['I3S_TOKEN']
-        @token = options[:token] || ENV['I3S_TOKEN']
+        raise InvalidClient, 'Must set token option' unless options[:token] || ENV['ONEVIEWSDK_TOKEN']
+        @token = options[:token] || ENV['ONEVIEWSDK_TOKEN']
       end
 
       # Get array of all resources of a specified type

--- a/spec/unit/cli/env_spec.rb
+++ b/spec/unit/cli/env_spec.rb
@@ -46,11 +46,6 @@ RSpec.describe OneviewSDK::Cli do
       expect { command }.to output(%r{I3S_URL\s+=\s'https:\/\/i3s\.example\.com'}).to_stdout_from_any_process
     end
 
-    it 'shows I3S_TOKEN when set' do
-      ENV['I3S_TOKEN'] = 'secret789'
-      expect { command }.to output(/I3S_TOKEN\s+=\s'secret789'/).to_stdout_from_any_process
-    end
-
     it 'shows I3S_SSL_ENABLED as nil' do
       expect { command }.to output(/I3S_SSL_ENABLED\s+=\snil/).to_stdout_from_any_process
     end

--- a/spec/unit/image-streamer/client_spec.rb
+++ b/spec/unit/image-streamer/client_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OneviewSDK::ImageStreamer::Client do
     end
 
     it 'respects the token environment variable' do
-      ENV['I3S_TOKEN'] = 'secret456'
+      ENV['ONEVIEWSDK_TOKEN'] = 'secret456'
       client = OneviewSDK::ImageStreamer::Client.new(url: 'https://oneview.example.com')
       expect(client.token).to eq('secret456')
     end


### PR DESCRIPTION
### Description
Implementation of improvements in i3s configuration, removing I3S_TOKEN, because is unncessary and updating the README and adjustig the creation of the i3s client to use ONEVIEWSDK_TOKEN when using the enviroment variable. 

### Issues Resolved
#183 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
