### PR TITLE
Fixing coveralls badge/integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Added full support to Image Streamer Rest API version 300:
 - Give custom exception classes a data attribute for more error context and default message
 - [#174](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/174) I3S - Integration test for Build Plan failing
 - [#183](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/183) Image Streamer Client cannot be created with the OneView environment variables
+- [#184](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/184) Coveralls badge showing coverage as unknown
 
 # v4.0.0
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Yard Docs](https://img.shields.io/badge/yard-docs-yellow.svg)](http://www.rubydoc.info/gems/oneview-sdk)
 
 [![Build Status](https://travis-ci.org/HewlettPackard/oneview-sdk-ruby.svg?branch=master)](https://travis-ci.org/HewlettPackard/oneview-sdk-ruby)
-[![Coverage Status](https://coveralls.io/repos/github/HewlettPackard/oneview-sdk-ruby/badge.svg?branch=master)](https://coveralls.io/github/HewlettPackard/oneview-sdk-ruby?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/HewlettPackard/oneview-sdk-ruby/badge.svg)](https://coveralls.io/github/HewlettPackard/oneview-sdk-ruby)
 [![Code Climate](https://codeclimate.com/github/HewlettPackard/oneview-sdk-ruby/badges/gpa.svg)](https://codeclimate.com/github/HewlettPackard/oneview-sdk-ruby)
 
 The OneView SDK provides a Ruby library to easily interact with HPE OneView and Image Streamer APIs. The Ruby SDK enables developers to easily build integrations and scalable solutions with HPE OneView and Image Streamer.

--- a/oneview-sdk.gemspec
+++ b/oneview-sdk.gemspec
@@ -34,11 +34,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'pry'
   spec.add_runtime_dependency 'multipart-post'
 
+  spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'rubocop', '= 0.42.0'
   spec.add_development_dependency 'byebug'
-
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rubocop', '= 0.42.0'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,17 @@
 require 'pry'
 require 'simplecov'
+require 'coveralls'
 
 client_files = %w(client.rb rest.rb config_loader.rb ssl_helper.rb image-streamer/client.rb)
 resource_path = 'lib/oneview-sdk/resource'
 image_streamer_path = 'lib/oneview-sdk/image-streamer/resource'
 
+Coveralls.wear!
+
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
 SimpleCov.profiles.define 'unit' do
   add_filter 'spec/'
   add_group 'Client', client_files


### PR DESCRIPTION
### Description
Fixes the coveralls badge and adds coverage dashboard to each PR and master.
This is related to my comment on #184 of coveralls vs codeclimate for code coverage.
Sample badge: [![Coverage Status](https://coveralls.io/repos/github/HewlettPackard/oneview-sdk-ruby/badge.svg?branch=fix-ci%2Fcoveralls)](https://coveralls.io/github/HewlettPackard/oneview-sdk-ruby?branch=fix-ci%2Fcoveralls)

### Issues Resolved
#184

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
