### PR TITLE
Resource named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,16 @@ Added full support to Image Streamer Rest API version 300:
    - Plan Script
 
 #### Bug fixes & Enhancements:
+- Give custom exception classes a data attribute for more error context and default message
 - [#116](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/112) VolumeAttachment::remove_extra_unmanaged_volume throw Unexpected Http Error
 - [#135](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/135) Firmware Bundle timeout does not give proper instructions for user post failure
 - [#146](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/146) Why is Switch the only resource that directly implements #set_scope_uris?
 - [#166](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/166) I3S - Simplify login to i3s through oneview client
 - [#178](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/178) Add client destroy_session method and domain attribute
-- Give custom exception classes a data attribute for more error context and default message
 - [#174](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/174) I3S - Integration test for Build Plan failing
+- [#176](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/176) OneviewSDK.resource_named now finds resources that are not children of Resource
 - [#183](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/183) Image Streamer Client cannot be created with the OneView environment variables
 - [#184](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/184) Coveralls badge showing coverage as unknown
-- [#176](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/176) OneviewSDK.resource_named now finds resources that are not children of Resource
 
 # v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Added full support to Image Streamer Rest API version 300:
 - [#174](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/174) I3S - Integration test for Build Plan failing
 - [#183](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/183) Image Streamer Client cannot be created with the OneView environment variables
 - [#184](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/184) Coveralls badge showing coverage as unknown
+- [#176](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/176) OneviewSDK.resource_named now finds resources that are not children of Resource
 
 # v4.0.0
 

--- a/lib/oneview-sdk/cli.rb
+++ b/lib/oneview-sdk/cli.rb
@@ -466,7 +466,7 @@ module OneviewSDK
       r = OneviewSDK.resource_named(type, api_ver, variant)
       # Try default API version as last resort
       r ||= OneviewSDK.resource_named(type, OneviewSDK.api_version, variant) unless api_ver == OneviewSDK.api_version
-      return r if r
+      return r if r && r.respond_to?(:find_by)
       valid_classes = []
       api_module = OneviewSDK.const_get("API#{api_ver}")
       api_module = api_module.const_get(variant.to_s) unless api_ver.to_i == 200

--- a/lib/oneview-sdk/cli.rb
+++ b/lib/oneview-sdk/cli.rb
@@ -472,7 +472,7 @@ module OneviewSDK
       api_module = api_module.const_get(variant.to_s) unless api_ver.to_i == 200
       api_module.constants.each do |c|
         klass = api_module.const_get(c)
-        next unless klass.is_a?(Class) && klass < OneviewSDK::Resource
+        next unless klass.is_a?(Class) && klass.respond_to?(:find_by)
         valid_classes.push(klass.name.split('::').last)
       end
       vc = valid_classes.sort_by!(&:downcase).join("\n  ")

--- a/lib/oneview-sdk/resource/api200.rb
+++ b/lib/oneview-sdk/resource/api200.rb
@@ -21,7 +21,7 @@ module OneviewSDK
       new_type = type.to_s.downcase.gsub(/[ -_]/, '')
       constants.each do |c|
         klass = const_get(c)
-        next unless klass.is_a?(Class) && klass < OneviewSDK::Resource
+        next unless klass.is_a?(Class)
         name = klass.name.split('::').last.downcase.delete('_').delete('-')
         return klass if new_type =~ /^#{name}[s]?$/
       end

--- a/lib/oneview-sdk/resource/api300.rb
+++ b/lib/oneview-sdk/resource/api300.rb
@@ -27,7 +27,7 @@ module OneviewSDK
       api_module = OneviewSDK::API300.const_get(variant)
       api_module.constants.each do |c|
         klass = api_module.const_get(c)
-        next unless klass.is_a?(Class) && klass < OneviewSDK::Resource
+        next unless klass.is_a?(Class)
         name = klass.name.split('::').last.downcase.delete('_').delete('-')
         return klass if new_type =~ /^#{name}[s]?$/
       end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -414,21 +414,30 @@ RSpec.describe OneviewSDK do
       expect(OneviewSDK.resource_named('FCoENetwork', 300, 'C7000')).to eq(OneviewSDK::API300::C7000::FCoENetwork)
     end
 
-    it 'ignores case' do
+    it 'gets resource classes that are not children of Resource' do
+      expect(OneviewSDK.resource_named('FirmwareBundle')).to eq(OneviewSDK::FirmwareBundle)
+      expect(OneviewSDK.resource_named('FirmwareBundle', 300)).to eq(OneviewSDK::API300::FirmwareBundle)
+    end
+
+    it 'ignores case of the resource name' do
       expect(OneviewSDK.resource_named('SERVERProfilE')).to eq(OneviewSDK::ServerProfile)
     end
 
-    it 'ignores dashes, underscores & spaces' do
+    it 'ignores dashes, underscores & spaces in the resource name' do
       expect(OneviewSDK.resource_named('se rver-prof_ile')).to eq(OneviewSDK::ServerProfile)
     end
 
-    it 'supports symbols' do
+    it 'supports resource name symbols' do
       expect(OneviewSDK.resource_named(:server_profile)).to eq(OneviewSDK::ServerProfile)
     end
 
     it 'raises an error if the api_version is not supported' do
       expect { OneviewSDK.resource_named(:server_profile, 15) }
         .to raise_error(OneviewSDK::UnsupportedVersion, /not supported/)
+    end
+
+    it 'returns nil if the resource name is not defined' do
+      expect(OneviewSDK.resource_named(:fakeResource)).to be_nil
     end
   end
 end


### PR DESCRIPTION
### Description
Allows `OneviewSDK.resource_named` to return classes that aren't children of `Resource` also.

### Issues Resolved
Fixes #176

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.


### Feedback requested
Is this what we want to do? I understand that FirmwareBundle may be moved to another resource in the future, but this generic functionality enables other classes that might not be children of Resource also.