### PR TITLE
Added extract bundle method to ArtifactBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Added full support to Image Streamer Rest API version 300:
 - [#174](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/174) I3S - Integration test for Build Plan failing
 - [#183](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/183) Image Streamer Client cannot be created with the OneView environment variables
 - [#184](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/184) Coveralls badge showing coverage as unknown
+- [#196](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/196) Missing endpoint for extract backup in Artifact Bundle
 
 # v4.0.0
 

--- a/examples/image-streamer/api300/artifact_bundle.rb
+++ b/examples/image-streamer/api300/artifact_bundle.rb
@@ -69,6 +69,11 @@ puts 'Downloaded successfully.' if File.exist?(backup_download_path)
 puts "\nUploading backup bundle"
 puts OneviewSDK::ImageStreamer::API300::ArtifactBundle.create_backup_from_file!(@client, deployment_group, backup_download_path, 'Backup Bundle')
 
+puts "\nExtracting backup bundle uploaded"
+backup = OneviewSDK::ImageStreamer::API300::ArtifactBundle.get_backups(@client).first
+puts OneviewSDK::ImageStreamer::API300::ArtifactBundle.extract_backup(@client, deployment_group, backup)
+puts 'Backup extracted successfully'
+
 puts "\nDeleting the artifact bundles"
 item.delete
 item_uploaded.delete

--- a/spec/integration/image-streamer/api300/artifact_bundle/create_spec.rb
+++ b/spec/integration/image-streamer/api300/artifact_bundle/create_spec.rb
@@ -110,4 +110,11 @@ RSpec.describe klass, integration_i3s: true, type: CREATE, sequence: i3s_seq(kla
       expect { klass.create_backup_from_file!($client_i3s_300, deployment_group, @backup_bundle_file_path, 'BundleBackup') }.not_to raise_error
     end
   end
+
+  describe '::extract_backup' do
+    it 'should extract the backup created' do
+      artifact_bundle_backup = klass.get_backups($client_i3s_300).first
+      expect { klass.extract_backup($client_i3s_300, deployment_group, artifact_bundle_backup) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
### Description
Added extract bundle method to ArtifactBundle

The backup bundle, when uploaded, already is extracted (in documentation has this description).
The extract method (for already backup uploaded) is not necessary if user use only the Ruby SDK, because when backup is did, the extraction of artifacts already occurs). Anyway, this PR solve the #196 issue.

### Issues Resolved
Fixes #196  

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
