### PR TITLE
Removed the ::get_default_settings method from integration test of LIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 (none)
 
 # v4.1.0
+#### Bug fixes & Enhancements:
+- [#202](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/202) The method #get_default_settings in LogicalInterconnectGroup is used on integration test
 
 #### New Resources:
 Added full support to Image Streamer Rest API version 300:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,12 @@
 #### Bug fixes & Enhancements:
 - [#201](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/201) Code to search the collection of resources (paginated search) is repeated in some resources
 - [#119](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/112) VolumeAttachment::remove_extra_unmanaged_volume throw Unexpected Http Error
+- [#202](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/202) The method #get_default_settings in LogicalInterconnectGroup is used on integration test
 
 #### Design changes:
    - Architecture for future API500 support. Features for API500 are not yet supported.
 
 # v4.1.0
-#### Bug fixes & Enhancements:
-- [#202](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/202) The method #get_default_settings in LogicalInterconnectGroup is used on integration test
 
 #### New Resources:
 Added full support to Image Streamer Rest API version 300:

--- a/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
@@ -138,14 +138,6 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
     end
 
-    it 'default settings from the lig instance' do
-      default_settings = @item.get_default_settings
-      expect(default_settings).to be
-      expect(default_settings['type']).to eq('InterconnectSettingsV201')
-      expect(default_settings['uri']).to_not be
-      expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
-    end
-
     it 'current settings' do
       default_settings = @item.get_settings
       expect(default_settings).to be


### PR DESCRIPTION
### Description
The ::get_default_settings was being used in integration test of Logical Interconnect Group (LIG), but this method there is not in LIG.
So, It was removed.

### Issues Resolved
Fixes #202 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
