### PR TITLE
Structuring the Ruby SDK for API500 development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Metrics/ModuleLength:
     - 'lib/oneview-sdk/rest.rb'
 
 Style/GlobalVars:
-  AllowedVariables: [$config, $secrets, $client, $client_120, $client_300, $client_300_synergy, $config_synergy, $secrets_synergy, $config_i3s, $client_i3s_300]
+  AllowedVariables: [$config, $secrets, $client, $client_120, $client_300, $client_300_synergy, $config_synergy, $secrets_synergy, $config_i3s, $client_i3s_300, $client_500, $client_500_synergy]
 
 Style/IndentationWidth:
   Width: 2

--- a/lib/oneview-sdk.rb
+++ b/lib/oneview-sdk.rb
@@ -24,7 +24,7 @@ module OneviewSDK
   env_i3s = %w(I3S_URL I3S_SSL_ENABLED)
   ENV_VARS = env_sdk.concat(env_i3s).freeze
 
-  SUPPORTED_API_VERSIONS = [200, 300].freeze
+  SUPPORTED_API_VERSIONS = [200, 300, 500].freeze
   DEFAULT_API_VERSION = 200
   @api_version = DEFAULT_API_VERSION
   @api_version_updated = false # Whether or not the API version has been set by the user

--- a/lib/oneview-sdk/resource/api500.rb
+++ b/lib/oneview-sdk/resource/api500.rb
@@ -1,0 +1,66 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+module OneviewSDK
+  # Module for API v500
+  module API500
+    SUPPORTED_VARIANTS = %w(C7000 Synergy).freeze
+    DEFAULT_VARIANT = 'C7000'.freeze
+    @variant = DEFAULT_VARIANT
+    @variant_updated = false # Whether or not the API variant has been set by the user
+
+    # Get resource class that matches the type given
+    # @param [String] type Name of the desired class type
+    # @param [String] variant Variant (C7000 or Synergy)
+    # @return [Class] Resource class or nil if not found
+    def self.resource_named(type, variant = @variant)
+      raise "API500 variant '#{variant}' is not supported! Try one of #{SUPPORTED_VARIANTS}" unless SUPPORTED_VARIANTS.include?(variant.to_s)
+      new_type = type.to_s.downcase.gsub(/[ -_]/, '')
+      api_module = OneviewSDK::API500.const_get(variant)
+      api_module.constants.each do |c|
+        klass = api_module.const_get(c)
+        next unless klass.is_a?(Class)
+        name = klass.name.split('::').last.downcase.delete('_').delete('-')
+        return klass if new_type =~ /^#{name}[s]?$/
+      end
+      nil
+    end
+
+    # Get the current API500 variant
+    def self.variant
+      @variant
+    end
+
+    # Has the API500 variant been set by the user?
+    # @return [TrueClass, FalseClass]
+    def self.variant_updated?
+      @variant_updated
+    end
+
+    # Sets the API500 variant
+    def self.variant=(variant)
+      raise "API500 variant '#{variant}' is not supported! Try one of #{SUPPORTED_VARIANTS}" unless SUPPORTED_VARIANTS.include?(variant)
+      @variant_updated = true
+      @variant = variant
+    end
+
+    # Helps redirect resources to the correct API500 variant
+    def self.const_missing(const)
+      api500_module = OneviewSDK::API500.const_get(@variant.to_s)
+      api500_module.const_get(const)
+    rescue NameError
+      raise NameError, "The #{const} method or resource does not exist for OneView API500 variant #{@variant}."
+    end
+  end
+end
+
+# Load all API500-specific resources:
+Dir[File.dirname(__FILE__) + '/api500/*.rb'].each { |file| require file }

--- a/lib/oneview-sdk/resource/api500/c7000.rb
+++ b/lib/oneview-sdk/resource/api500/c7000.rb
@@ -1,0 +1,27 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+module OneviewSDK
+  module API500
+    # Module for API500 C7000
+    module C7000
+      # Get resource class that matches the type given
+      # @param [String] type Name of the desired class type
+      # @return [Class] Resource class or nil if not found
+      def self.resource_named(type)
+        OneviewSDK::API500.resource_named(type, 'C7000')
+      end
+    end
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/c7000/*.rb'].each { |file| require file }

--- a/lib/oneview-sdk/resource/api500/c7000/connection_template.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/connection_template.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/connection_template'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Connection template resource implementation for API500 C7000
+      class ConnectionTemplate < OneviewSDK::API300::C7000::ConnectionTemplate
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/datacenter.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/datacenter.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/datacenter'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Datacenter resource implementation for API500 C7000
+      class Datacenter < OneviewSDK::API300::C7000::Datacenter
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/enclosure.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/enclosure.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/enclosure'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Enclosure resource implementation for API500 C7000
+      class Enclosure < OneviewSDK::API300::C7000::Enclosure
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/enclosure_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/enclosure_group'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Enclosure group resource implementation on API500 C7000
+      class EnclosureGroup < OneviewSDK::API300::C7000::EnclosureGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/ethernet_network.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/ethernet_network.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/ethernet_network'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Ethernet network resource implementation for API500 C7000
+      class EthernetNetwork < OneviewSDK::API300::C7000::EthernetNetwork
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/fabric.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/fabric.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/fabric'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Fabric resource implementation for API500 C7000
+      class Fabric < OneviewSDK::API300::C7000::Fabric
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/fc_network.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/fc_network.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/fc_network'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # FC network resource implementation for API500 C7000
+      class FCNetwork < OneviewSDK::API300::C7000::FCNetwork
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/fcoe_network.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/fcoe_network.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/fcoe_network'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # FCoE network resource implementation for API500 C7000
+      class FCoENetwork < OneviewSDK::API300::C7000::FCoENetwork
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/firmware_bundle.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/firmware_bundle.rb
@@ -1,0 +1,21 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/firmware_bundle'
+
+module OneviewSDK
+  module API500
+    module C7000
+      class FirmwareBundle < OneviewSDK::API300::C7000::FirmwareBundle
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/firmware_driver.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/firmware_driver.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/firmware_driver'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # FirmwareDriver resource implementation for API500 C7000
+      class FirmwareDriver < OneviewSDK::API300::C7000::FirmwareDriver
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/interconnect.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/interconnect.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/interconnect'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Interconnect resource implementation on API500 C7000
+      class Interconnect < OneviewSDK::API300::C7000::Interconnect
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/lig_uplink_set.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/lig_uplink_set.rb
@@ -1,0 +1,21 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/lig_uplink_set'
+
+module OneviewSDK
+  module API500
+    module C7000
+      class LIGUplinkSet < OneviewSDK::API300::C7000::LIGUplinkSet
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/logical_downlink.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/logical_downlink.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/logical_downlink'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Logical downlink resource implementation for API500 C7000
+      class LogicalDownlink < OneviewSDK::API300::C7000::LogicalDownlink
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/logical_enclosure.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/logical_enclosure.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/logical_enclosure'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Logical Enclosure resource implementation on API500 C7000
+      class LogicalEnclosure < OneviewSDK::API300::C7000::LogicalEnclosure
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/logical_interconnect.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/logical_interconnect.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/logical_interconnect'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Logical interconnect resource implementation for API500 C7000
+      class LogicalInterconnect < OneviewSDK::API300::C7000::LogicalInterconnect
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/logical_interconnect_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/logical_interconnect_group'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Logical interconnect group resource implementation on API500 C7000
+      class LogicalInterconnectGroup < OneviewSDK::API300::C7000::LogicalInterconnectGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/logical_switch.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/logical_switch.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/logical_switch'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Logical switch resource implementation for API500 C7000
+      class LogicalSwitch < OneviewSDK::API300::C7000::LogicalSwitch
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/logical_switch_group.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/logical_switch_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/logical_switch_group'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Logical switch group resource implementation for API500 C7000
+      class LogicalSwitchGroup < OneviewSDK::API300::C7000::LogicalSwitchGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/managed_san.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/managed_san.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/managed_san'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Managed SAN resource implementation for API500 C7000
+      class ManagedSAN < OneviewSDK::API300::C7000::ManagedSAN
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/network_set.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/network_set.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/network_set'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Network set resource implementation for API500 C7000
+      class NetworkSet < OneviewSDK::API300::C7000::NetworkSet
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/power_device.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/power_device.rb
@@ -1,0 +1,21 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/power_device'
+
+module OneviewSDK
+  module API500
+    module C7000
+      class PowerDevice < OneviewSDK::API300::C7000::PowerDevice
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/rack.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/rack.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/rack'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Rack resource implementation for API500 C7000
+      class Rack < OneviewSDK::API300::C7000::Rack
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/resource.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/resource.rb
@@ -1,0 +1,21 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/resource'
+
+module OneviewSDK
+  module API500
+    module C7000
+      class Resource < OneviewSDK::API300::C7000::Resource
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/san_manager.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/san_manager.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/san_manager'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # SAN manager resource implementation for API500 C7000
+      class SANManager < OneviewSDK::API300::C7000::SANManager
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/scope.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/scope.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/scope'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Scope resource implementation for API500 C7000
+      class Scope < OneviewSDK::API300::C7000::Scope
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/server_hardware.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/server_hardware.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/server_hardware'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Server Hardware resource implementation on API500 C7000
+      class ServerHardware < OneviewSDK::API300::C7000::ServerHardware
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/server_hardware_type.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/server_hardware_type.rb
@@ -1,0 +1,21 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/server_hardware_type'
+
+module OneviewSDK
+  module API500
+    module C7000
+      class ServerHardwareType < OneviewSDK::API300::C7000::ServerHardwareType
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/server_profile.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/server_profile.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/server_profile'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Server Profile resource implementation on API500 C7000
+      class ServerProfile < OneviewSDK::API300::C7000::ServerProfile
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/server_profile_template.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/server_profile_template.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/server_profile_template'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Server Profile Template resource implementation on API500 C7000
+      class ServerProfileTemplate < OneviewSDK::API300::C7000::ServerProfileTemplate
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/storage_pool.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/storage_pool.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/storage_pool'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Storage pool resource implementation for API500 C7000
+      class StoragePool < OneviewSDK::API300::C7000::StoragePool
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/storage_system.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/storage_system.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/storage_system'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Storage System resource implementation for API500 C7000
+      class StorageSystem < OneviewSDK::API300::C7000::StorageSystem
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/switch.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/switch.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/switch'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Switch resource implementation for API 500 C7000
+      class Switch < OneviewSDK::API300::C7000::Switch
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/unmanaged_device.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/unmanaged_device.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/unmanaged_device'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Unmanaged Device resource implementation for API500 C7000
+      class UnmanagedDevice < OneviewSDK::API300::C7000::UnmanagedDevice
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/uplink_set.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/uplink_set.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/uplink_set'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Uplink set resource implementation for API500 C7000
+      class UplinkSet < OneviewSDK::API300::C7000::UplinkSet
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/user.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/user.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/user'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # User resource implementation for API500 C7000
+      class User < OneviewSDK::API300::C7000::User
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/volume.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/volume.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/volume'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Volume resource implementation on API500 C7000
+      class Volume < OneviewSDK::API300::C7000::Volume
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/volume_attachment.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/volume_attachment.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/volume_attachment'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Storage volume attachment resource implementation for API500 C7000
+      class VolumeAttachment < OneviewSDK::API300::C7000::VolumeAttachment
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/volume_snapshot.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/volume_snapshot.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/volume_snapshot'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Volume snapshot resource implementation for API500 C7000
+      class VolumeSnapshot < OneviewSDK::API300::C7000::VolumeSnapshot
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/c7000/volume_template.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/volume_template.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/volume_template'
+
+module OneviewSDK
+  module API500
+    module C7000
+      # Volume Template resource implementation for API500 Synergy
+      class VolumeTemplate < OneviewSDK::API300::C7000::VolumeTemplate
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy.rb
+++ b/lib/oneview-sdk/resource/api500/synergy.rb
@@ -1,0 +1,27 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+module OneviewSDK
+  module API500
+    # Module for API500 Synergy
+    module Synergy
+      # Get resource class that matches the type given
+      # @param [String] type Name of the desired class type
+      # @return [Class] Resource class or nil if not found
+      def self.resource_named(type)
+        OneviewSDK::API500.resource_named(type, 'Synergy')
+      end
+    end
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/synergy/*.rb'].each { |file| require file }

--- a/lib/oneview-sdk/resource/api500/synergy/connection_template.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/connection_template.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/connection_template'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Connection template resource implementation for API500 Synergy
+      class ConnectionTemplate < OneviewSDK::API300::Synergy::ConnectionTemplate
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/datacenter.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/datacenter.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/datacenter'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Datacenter resource implementation for API500 Synergy
+      class Datacenter < OneviewSDK::API300::Synergy::Datacenter
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/drive_enclosure.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/drive_enclosure.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/drive_enclosure'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Drive enclosure resource implementation for API500 Synergy
+      class DriveEnclosure < OneviewSDK::API300::Synergy::DriveEnclosure
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/enclosure.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/enclosure.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/enclosure'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Enclosure resource implementation for API500 Synergy
+      class Enclosure < OneviewSDK::API300::Synergy::Enclosure
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/enclosure_group.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/enclosure_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/enclosure_group'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Enclosure group resource implementation on API500 Synergy
+      class EnclosureGroup < OneviewSDK::API300::Synergy::EnclosureGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/ethernet_network.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/ethernet_network.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/ethernet_network'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Ethernet network resource implementation for API500 Synergy
+      class EthernetNetwork < OneviewSDK::API300::Synergy::EthernetNetwork
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/fabric.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/fabric.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/fabric'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Fabric resource implementation for API500 Synergy
+      class Fabric < OneviewSDK::API300::Synergy::Fabric
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/fc_network.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/fc_network.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/fc_network'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # FC network resource implementation for API500 Synergy
+      class FCNetwork < OneviewSDK::API300::Synergy::FCNetwork
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/fcoe_network.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/fcoe_network.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/fcoe_network'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # FCoE network resource implementation for API500 Synergy
+      class FCoENetwork < OneviewSDK::API300::Synergy::FCoENetwork
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/firmware_bundle.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/firmware_bundle.rb
@@ -1,0 +1,21 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/firmware_bundle'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      class FirmwareBundle < OneviewSDK::API300::Synergy::FirmwareBundle
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/firmware_driver.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/firmware_driver.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/firmware_driver'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # FirmwareDriver resource implementation for API500 Synergy
+      class FirmwareDriver < OneviewSDK::API300::Synergy::FirmwareDriver
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/interconnect.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/interconnect.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/interconnect'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Interconnect resource implementation on API500 Synergy
+      class Interconnect < OneviewSDK::API300::Synergy::Interconnect
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/lig_uplink_set.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/lig_uplink_set.rb
@@ -1,0 +1,21 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/lig_uplink_set'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      class LIGUplinkSet < OneviewSDK::API300::Synergy::LIGUplinkSet
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/logical_downlink.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/logical_downlink.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/logical_downlink'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Logical downlink resource implementation for API500 Synergy
+      class LogicalDownlink < OneviewSDK::API300::Synergy::LogicalDownlink
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/logical_enclosure.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/logical_enclosure.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/logical_enclosure'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Logical Enclosure resource implementation on API500 Synergy
+      class LogicalEnclosure < OneviewSDK::API300::Synergy::LogicalEnclosure
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/logical_interconnect.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/logical_interconnect.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/logical_interconnect'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Logical interconnect resource implementation for API500 Synergy
+      class LogicalInterconnect < OneviewSDK::API300::Synergy::LogicalInterconnect
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/logical_interconnect_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/logical_interconnect_group'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Logical interconnect group resource implementation for API500 Synergy
+      class LogicalInterconnectGroup < OneviewSDK::API300::Synergy::LogicalInterconnectGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/logical_switch.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/logical_switch.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/logical_switch'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Logical switch resource implementation for API500 Synergy
+      class LogicalSwitch
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/managed_san.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/managed_san.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/managed_san'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Managed SAN resource implementation for API500 Synergy
+      class ManagedSAN < OneviewSDK::API300::Synergy::ManagedSAN
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/network_set.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/network_set.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/network_set'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Network set resource implementation for API500 Synergy
+      class NetworkSet < OneviewSDK::API300::Synergy::NetworkSet
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/power_device.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/power_device.rb
@@ -1,0 +1,21 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/power_device'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      class PowerDevice < OneviewSDK::API300::Synergy::PowerDevice
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/rack.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/rack.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/rack'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Rack resource implementation for API500 Synergy
+      class Rack < OneviewSDK::API300::Synergy::Rack
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/resource.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/resource.rb
@@ -1,0 +1,21 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/resource'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      class Resource < OneviewSDK::API300::Synergy::Resource
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/san_manager.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/san_manager.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/san_manager'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # SAN manager resource implementation for API500 Synergy
+      class SANManager < OneviewSDK::API300::Synergy::SANManager
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/sas_interconnect.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/sas_interconnect.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/sas_interconnect'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # SAS Interconnect resource implementation for API500 Synergy
+      class SASInterconnect < OneviewSDK::API300::Synergy::SASInterconnect
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/sas_logical_interconnect.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/sas_logical_interconnect.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/sas_logical_interconnect'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # SAS Logical interconnect group resource implementation for API500 Synergy
+      class SASLogicalInterconnect < OneviewSDK::API300::Synergy::SASLogicalInterconnect
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/sas_logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/sas_logical_interconnect_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/sas_logical_interconnect_group'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # SAS Logical interconnect group resource implementation for API500 Synergy
+      class SASLogicalInterconnectGroup < OneviewSDK::API300::Synergy::SASLogicalInterconnectGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/scope.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/scope.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/scope'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Scope resource implementation for API500 Synergy
+      class Scope < OneviewSDK::API300::Synergy::Scope
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/server_hardware.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/server_hardware.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/server_hardware'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Server Hardware resource implementation on API500 Synergy
+      class ServerHardware < OneviewSDK::API300::Synergy::ServerHardware
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/server_hardware_type.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/server_hardware_type.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/server_hardware_type'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Server hardware type resource implementation for API500 Synergy
+      class ServerHardwareType < OneviewSDK::API300::Synergy::ServerHardwareType
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/server_profile.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/server_profile.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/server_profile'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Server profile resource implementation for API500 Synergy
+      class ServerProfile < OneviewSDK::API300::Synergy::ServerProfile
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/server_profile_template.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/server_profile_template.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/server_profile_template'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Server Profile Template resource implementation for API500 Synergy
+      class ServerProfileTemplate < OneviewSDK::API300::Synergy::ServerProfileTemplate
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/storage_pool.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/storage_pool.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/storage_pool'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Storage pool resource implementation for API 500 Synergy
+      class StoragePool < OneviewSDK::API300::Synergy::StoragePool
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/storage_system.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/storage_system.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/storage_system'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Storage system resource implementation for API 500 Synergy
+      class StorageSystem < OneviewSDK::API300::Synergy::StorageSystem
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/switch.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/switch.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/switch'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Switch resource implementation for API 500 Synergy
+      class Switch < OneviewSDK::API300::Synergy::Switch
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/unmanaged_device.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/unmanaged_device.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/unmanaged_device'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Unmanaged Device resource implementation for API500 Synergy
+      class UnmanagedDevice < OneviewSDK::API300::Synergy::UnmanagedDevice
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/uplink_set.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/uplink_set.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/uplink_set'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Uplink set resource implementation for API500 Synergy
+      class UplinkSet < OneviewSDK::API300::Synergy::UplinkSet
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/user.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/user.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/user'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # User resource implementation for API500 Synergy
+      class User < OneviewSDK::API300::Synergy::User
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/volume.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/volume.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/volume'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Volume resource implementation for API500 Synergy
+      class Volume < OneviewSDK::API300::Synergy::Volume
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/volume_attachment.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/volume_attachment.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/volume_attachment'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Storage volume attachment resource implementation for API500 Synergy
+      class VolumeAttachment < OneviewSDK::API300::Synergy::VolumeAttachment
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/volume_snapshot.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/volume_snapshot.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/volume_snapshot'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Volume snapshot resource implementation for API500 Synergy
+      class VolumeSnapshot < OneviewSDK::API300::Synergy::VolumeSnapshot
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/resource/api500/synergy/volume_template.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/volume_template.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/volume_template'
+
+module OneviewSDK
+  module API500
+    module Synergy
+      # Volume Template resource implementation for API500 Synergy
+      class VolumeTemplate < OneviewSDK::API300::Synergy::VolumeTemplate
+      end
+    end
+  end
+end

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -1,17 +1,20 @@
 # General context for unit testing:
 RSpec.shared_context 'shared context', a: :b do
   before :each do
-    options_120 = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123', api_version: 120 }
-    @client_120 = OneviewSDK::Client.new(options_120)
+    options = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123' }
 
-    options_200 = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123' }
-    @client = OneviewSDK::Client.new(options_200)
+    # Creates dynamically the variables @client_120, @client_200 and etc.
+    api_versions = [120, 200, 300, 500]
+    api_versions.each do |v|
+      instance_variable_set("@client_#{v}", OneviewSDK::Client.new(options.merge(api_version: v)))
+    end
 
-    options_300 = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123', api_version: 300 }
-    @client_300 = OneviewSDK::Client.new(options_300)
-
-    options_i3s_300 = { url: 'https://oneview.example.com', token: 'token123' }
-    @client_i3s_300 = OneviewSDK::ImageStreamer::Client.new(options_i3s_300)
+    options_i3s = { url: 'https://oneview.example.com', token: 'token123' }
+    # Creates dynamically the variables @client_i3s_300 and etc.
+    i3s_api_versions = [300]
+    i3s_api_versions.each do |v|
+      instance_variable_set("@client_i3s_#{v}", OneviewSDK::ImageStreamer::Client.new(options_i3s.merge(api_version: v)))
+    end
   end
 end
 
@@ -43,6 +46,17 @@ RSpec.shared_context 'integration api300 context', a: :b do
     integration_context
     $client_300 ||= OneviewSDK::Client.new($config.merge(api_version: 300))
     $client_300_synergy ||= OneviewSDK::Client.new($config_synergy.merge(api_version: 300))
+  end
+
+  integration_context_debugging
+end
+
+# Context for API500 integration testing:
+RSpec.shared_context 'integration api500 context', a: :b do
+  before :all do
+    integration_context
+    $client_500 ||= OneviewSDK::Client.new($config.merge(api_version: 500))
+    $client_500_synergy ||= OneviewSDK::Client.new($config_synergy.merge(api_version: 500))
   end
 
   integration_context_debugging

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,7 +94,7 @@ RSpec.configure do |config|
   config.before(:each) do
     unless config.filter_manager.inclusions.rules[:integration] || config.filter_manager.inclusions.rules[:system]
       # Mock appliance version and login api requests, as well as loading trusted certs
-      allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(300)
+      allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(500)
       allow_any_instance_of(OneviewSDK::Client).to receive(:login).and_return('secretToken')
       allow_any_instance_of(OneviewSDK::ImageStreamer::Client).to receive(:appliance_i3s_api_version).and_return(300)
       allow(OneviewSDK::SSLHelper).to receive(:load_trusted_certs).and_return(nil)

--- a/spec/unit/cli/console_spec.rb
+++ b/spec/unit/cli/console_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe OneviewSDK::Cli do
   describe '#console' do
     let(:command) { OneviewSDK::Cli.start(['console']) }
 
-    context 'with a valid @client object' do
+    context 'with a valid @client_200 object' do
       it 'starts a Pry session' do
         expect(Pry).to receive(:start).and_return true
         expect(STDOUT).to receive(:puts).with(/Console Connected to/)
-        expect(STDOUT).to receive(:puts).with(/HINT: The @client object is available to you/)
+        expect(STDOUT).to receive(:puts).with(/HINT: The @client_200 object is available to you/)
         allow_any_instance_of(Object).to receive(:warn).with(/was not found/).and_return true
         command
       end
     end
 
-    context 'with no @client object' do
+    context 'with no @client_200 object' do
       it 'starts a Pry session' do
         expect(OneviewSDK::Client).to receive(:new).and_raise 'Error'
         expect(Pry).to receive(:start).and_return true

--- a/spec/unit/cli/create_from_file_spec.rb
+++ b/spec/unit/cli/create_from_file_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OneviewSDK::Cli do
     context 'with valid options' do
       before :each do
         @resource_data = { 'name' => 'My', 'uri' => '/rest/fake', 'description' => 'Blah' }
-        response = [OneviewSDK::EthernetNetwork.new(@client, @resource_data)]
+        response = [OneviewSDK::EthernetNetwork.new(@client_200, @resource_data)]
         allow(OneviewSDK::Resource).to receive(:find_by).and_return(response)
         allow_any_instance_of(OneviewSDK::Resource).to receive(:create).and_return(true)
         allow_any_instance_of(OneviewSDK::Resource).to receive(:update).and_return(true)
@@ -32,7 +32,7 @@ RSpec.describe OneviewSDK::Cli do
 
       it 'updates a valid resource by name' do
         resource_data = { 'name' => 'My_Ethernet_Network', 'description' => 'Blah' }
-        response = [OneviewSDK::EthernetNetwork.new(@client, resource_data)]
+        response = [OneviewSDK::EthernetNetwork.new(@client_200, resource_data)]
         allow(OneviewSDK::Resource).to receive(:find_by).and_return(response)
         expect { OneviewSDK::Cli.start(['create_from_file', yaml_file]) }
           .to output(/Updated Successfully!/).to_stdout_from_any_process
@@ -40,7 +40,7 @@ RSpec.describe OneviewSDK::Cli do
 
       it 'makes no changes if the resource is up to date' do
         resource_data = { 'name' => 'My_Ethernet_Network', 'description' => 'Short Description' }
-        response = [OneviewSDK::EthernetNetwork.new(@client, resource_data)]
+        response = [OneviewSDK::EthernetNetwork.new(@client_200, resource_data)]
         allow(OneviewSDK::Resource).to receive(:find_by).and_return(response)
         expect { OneviewSDK::Cli.start(['create_from_file', yaml_file]) }
           .to output(/Skipped.*up to date/).to_stdout_from_any_process
@@ -58,7 +58,7 @@ RSpec.describe OneviewSDK::Cli do
       end
 
       it 'fails if the resource is a generic "Resource" type' do
-        resource = OneviewSDK::Resource.new(@client)
+        resource = OneviewSDK::Resource.new(@client_200)
         allow(OneviewSDK::Resource).to receive(:from_file).and_return(resource)
         expect(STDOUT).to receive(:puts).with(/Failed to determine resource type/)
         expect { OneviewSDK::Cli.start(['create_from_file', yaml_file]) }
@@ -66,7 +66,7 @@ RSpec.describe OneviewSDK::Cli do
       end
 
       it 'fails if the file does not specify a unique identifier' do
-        resource = OneviewSDK::EthernetNetwork.new(@client)
+        resource = OneviewSDK::EthernetNetwork.new(@client_200)
         allow(OneviewSDK::Resource).to receive(:from_file).and_return(resource)
         expect(STDOUT).to receive(:puts).with(/Must set/)
         expect { OneviewSDK::Cli.start(['create_from_file', yaml_file]) }

--- a/spec/unit/cli/delete_from_file_spec.rb
+++ b/spec/unit/cli/delete_from_file_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OneviewSDK::Cli do
     context 'with valid options' do
       before :each do
         @resource_data = { 'name' => 'My', 'uri' => '/rest/fake', 'description' => 'Blah' }
-        response = [OneviewSDK::EthernetNetwork.new(@client, @resource_data)]
+        response = [OneviewSDK::EthernetNetwork.new(@client_200, @resource_data)]
         allow(OneviewSDK::Resource).to receive(:find_by).and_return(response)
         allow_any_instance_of(OneviewSDK::Resource).to receive(:delete).and_return(true)
         allow_any_instance_of(OneviewSDK::Resource).to receive(:retrieve!).and_return(true)
@@ -51,7 +51,7 @@ RSpec.describe OneviewSDK::Cli do
       end
 
       it 'fails if the file does not specify a name or uri' do
-        resource = OneviewSDK::Resource.new(@client)
+        resource = OneviewSDK::Resource.new(@client_200)
         allow(OneviewSDK::Resource).to receive(:from_file).and_return(resource)
         allow_any_instance_of(OneviewSDK::Resource).to receive(:retrieve!).and_call_original
         expect(STDOUT).to receive(:puts).with(/Must set/)

--- a/spec/unit/cli/delete_spec.rb
+++ b/spec/unit/cli/delete_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OneviewSDK::Cli do
     context 'with valid options' do
       before :each do
         @resource_data = { 'name' => 'Profile1', 'uri' => '/rest/fake', 'description' => 'Blah' }
-        response = [OneviewSDK::ServerProfile.new(@client, @resource_data)]
+        response = [OneviewSDK::ServerProfile.new(@client_200, @resource_data)]
         allow(OneviewSDK::Resource).to receive(:find_by).and_return(response)
         allow_any_instance_of(OneviewSDK::Resource).to receive(:delete).and_return(true)
         allow_any_instance_of(HighLine).to receive(:agree).and_return(true)

--- a/spec/unit/cli/search_spec.rb
+++ b/spec/unit/cli/search_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe OneviewSDK::Cli do
 
     let(:response) do
       [
-        OneviewSDK::ServerProfile.new(@client, resource_data),
-        OneviewSDK::ServerProfile.new(@client, resource_data2)
+        OneviewSDK::ServerProfile.new(@client_200, resource_data),
+        OneviewSDK::ServerProfile.new(@client_200, resource_data2)
       ]
     end
 

--- a/spec/unit/cli/show_spec.rb
+++ b/spec/unit/cli/show_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OneviewSDK::Cli do
 
     before :each do
       @resource_data = { 'name' => 'Profile1', 'uri' => '/rest/fake', 'description' => 'Blah' }
-      response = [OneviewSDK::Resource.new(@client, @resource_data)]
+      response = [OneviewSDK::Resource.new(@client_200, @resource_data)]
       allow(OneviewSDK::Resource).to receive(:find_by).and_return(response)
     end
 

--- a/spec/unit/cli/to_file_spec.rb
+++ b/spec/unit/cli/to_file_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe OneviewSDK::Cli do
     context 'with valid options' do
       before :each do
         @resource_data = { 'name' => 'Test', 'uri' => '/rest/fake' }
-        @response = [OneviewSDK::EthernetNetwork.new(@client, @resource_data)]
+        @response = [OneviewSDK::EthernetNetwork.new(@client_200, @resource_data)]
         allow(OneviewSDK::Resource).to receive(:find_by).and_return(@response)
       end
 
@@ -66,7 +66,7 @@ RSpec.describe OneviewSDK::Cli do
       end
 
       it 'accepts an api-version parameter: 300' do
-        @response = [OneviewSDK::API300::EthernetNetwork.new(@client, @resource_data)]
+        @response = [OneviewSDK::API300::EthernetNetwork.new(@client_200, @resource_data)]
         expect(OneviewSDK::Resource).to receive(:find_by).and_return(@response)
         expect_any_instance_of(OneviewSDK::API300::EthernetNetwork).to receive(:to_file).and_return(true)
         expect { OneviewSDK::Cli.start(['to_file', 'EthernetNetwork', 'Test', '-p', path, '--api-version', 300]) }

--- a/spec/unit/cli/update_spec.rb
+++ b/spec/unit/cli/update_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OneviewSDK::Cli do
     end
 
     let(:sp1) do
-      OneviewSDK::ServerProfile.new(@client, resource_data)
+      OneviewSDK::ServerProfile.new(@client_200, resource_data)
     end
 
     let(:sp_list) do

--- a/spec/unit/cli/version_spec.rb
+++ b/spec/unit/cli/version_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OneviewSDK::Cli do
     end
 
     it 'prints the appliance version' do
-      expect { command }.to output(/OneView appliance API version at .* = 300/).to_stdout_from_any_process
+      expect { command }.to output(/OneView appliance API version at .* = 500/).to_stdout_from_any_process
     end
 
     it 'requires the url to be set' do

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -84,10 +84,10 @@ RSpec.describe OneviewSDK::Client do
     end
 
     it 'warns if the api level is greater than the appliance api version' do
-      options = { url: 'https://oneview.example.com', token: 'token123', api_version: 400 }
+      options = { url: 'https://oneview.example.com', token: 'token123', api_version: 600 }
       client = nil
       expect { client = OneviewSDK::Client.new(options) }.to output(/is greater than the appliance API version/).to_stdout_from_any_process
-      expect(client.api_version).to eq(400)
+      expect(client.api_version).to eq(600)
     end
 
     it 'sets @print_wait_dots to false by default' do
@@ -139,34 +139,34 @@ RSpec.describe OneviewSDK::Client do
     include_context 'shared context'
 
     it 'allows the url to be re-set' do
-      @client.url = 'https://new-url.example.com'
-      expect(@client.url).to eq('https://new-url.example.com')
+      @client_200.url = 'https://new-url.example.com'
+      expect(@client_200.url).to eq('https://new-url.example.com')
     end
 
     it 'allows the user to be re-set' do
-      @client.user = 'updatedUser'
-      expect(@client.user).to eq('updatedUser')
+      @client_200.user = 'updatedUser'
+      expect(@client_200.user).to eq('updatedUser')
     end
 
     it 'allows the password to be re-set' do
-      @client.password = 'updatedPassword'
-      expect(@client.password).to eq('updatedPassword')
+      @client_200.password = 'updatedPassword'
+      expect(@client_200.password).to eq('updatedPassword')
     end
 
     it 'allows the token to be re-set' do
-      @client.token = 'updatedToken'
-      expect(@client.token).to eq('updatedToken')
+      @client_200.token = 'updatedToken'
+      expect(@client_200.token).to eq('updatedToken')
     end
 
     it 'allows the log level to be re-set' do
-      expect(@client.log_level).to_not eq(:error)
-      @client.log_level = :error
-      expect(@client.log_level).to eq(:error)
-      expect(@client.logger.level).to eq(Logger.const_get(:ERROR))
+      expect(@client_200.log_level).to_not eq(:error)
+      @client_200.log_level = :error
+      expect(@client_200.log_level).to eq(:error)
+      expect(@client_200.logger.level).to eq(Logger.const_get(:ERROR))
     end
 
     it 'does not allow the max_api_version to be set manually' do
-      expect { @client.max_api_version = 1 }.to raise_error(NoMethodError, /undefined method/)
+      expect { @client_200.max_api_version = 1 }.to raise_error(NoMethodError, /undefined method/)
     end
   end
 
@@ -219,27 +219,27 @@ RSpec.describe OneviewSDK::Client do
     include_context 'shared context'
 
     before :each do
-      @resource = OneviewSDK::Resource.new(@client)
+      @resource = OneviewSDK::Resource.new(@client_200)
     end
 
     it 'implements the #create method' do
       expect(@resource).to receive(:create)
-      @client.create(@resource)
+      @client_200.create(@resource)
     end
 
     it 'implements the #update method' do
       expect(@resource).to receive(:update)
-      @client.update(@resource, name: 'NewName')
+      @client_200.update(@resource, name: 'NewName')
     end
 
     it 'implements the #refresh method' do
       expect(@resource).to receive(:refresh)
-      @client.refresh(@resource)
+      @client_200.refresh(@resource)
     end
 
     it 'implements the #delete method' do
       expect(@resource).to receive(:delete)
-      @client.delete(@resource)
+      @client_200.delete(@resource)
     end
   end
 
@@ -247,30 +247,30 @@ RSpec.describe OneviewSDK::Client do
     include_context 'shared context'
 
     it "calls the correct resource's get_all method" do
-      expect(OneviewSDK::API200::ServerProfile).to receive(:get_all).with(@client)
-      @client.get_all('ServerProfiles')
+      expect(OneviewSDK::API200::ServerProfile).to receive(:get_all).with(@client_200)
+      @client_200.get_all('ServerProfiles')
     end
 
     it 'accepts API version and variant parameters' do
-      expect(OneviewSDK::API300::Synergy::ServerProfile).to receive(:get_all).with(@client)
-      @client.get_all('ServerProfiles', 300, 'Synergy')
+      expect(OneviewSDK::API300::Synergy::ServerProfile).to receive(:get_all).with(@client_200)
+      @client_200.get_all('ServerProfiles', 300, 'Synergy')
     end
 
     it 'accepts symbols instead of strings' do
-      expect(OneviewSDK::API300::Synergy::ServerProfile).to receive(:get_all).with(@client)
-      @client.get_all(:ServerProfiles, 300, :Synergy)
+      expect(OneviewSDK::API300::Synergy::ServerProfile).to receive(:get_all).with(@client_200)
+      @client_200.get_all(:ServerProfiles, 300, :Synergy)
     end
 
     it 'fails when a bogus resource type is given' do
-      expect { @client.get_all('BogusResources') }.to raise_error(TypeError, /Invalid resource type/)
+      expect { @client_200.get_all('BogusResources') }.to raise_error(TypeError, /Invalid resource type/)
     end
 
     it 'fails when a bogus API version is given' do
-      expect { @client.get_all('ServerProfiles', 100) }.to raise_error(OneviewSDK::UnsupportedVersion, /version 100 is not supported/)
+      expect { @client_200.get_all('ServerProfiles', 100) }.to raise_error(OneviewSDK::UnsupportedVersion, /version 100 is not supported/)
     end
 
     it 'fails when a bogus variant is given' do
-      expect { @client.get_all('ServerProfiles', 300, 'Bogus') }.to raise_error(/variant 'Bogus' is not supported/)
+      expect { @client_200.get_all('ServerProfiles', 300, 'Bogus') }.to raise_error(/variant 'Bogus' is not supported/)
     end
   end
 
@@ -278,11 +278,11 @@ RSpec.describe OneviewSDK::Client do
     include_context 'shared context'
 
     it 'refreshes the token and max_api_version' do
-      expect(@client).to receive(:appliance_api_version).and_return(250)
-      expect(@client).to receive(:login).and_return('newToken')
-      @client.refresh_login
-      expect(@client.max_api_version).to eq(250)
-      expect(@client.token).to eq('newToken')
+      expect(@client_200).to receive(:appliance_api_version).and_return(250)
+      expect(@client_200).to receive(:login).and_return('newToken')
+      @client_200.refresh_login
+      expect(@client_200.max_api_version).to eq(250)
+      expect(@client_200.token).to eq('newToken')
     end
   end
 
@@ -290,8 +290,8 @@ RSpec.describe OneviewSDK::Client do
     include_context 'shared context'
 
     it 'makes a REST call to destroy the session' do
-      expect(@client).to receive(:rest_delete).with('/rest/login-sessions').and_return(FakeResponse.new)
-      expect(@client.destroy_session).to eq(@client)
+      expect(@client_200).to receive(:rest_delete).with('/rest/login-sessions').and_return(FakeResponse.new)
+      expect(@client_200.destroy_session).to eq(@client_200)
     end
   end
 
@@ -299,13 +299,13 @@ RSpec.describe OneviewSDK::Client do
     include_context 'shared context'
 
     it 'requires a task_uri' do
-      expect { @client.wait_for('') }.to raise_error(ArgumentError, /Must specify a task_uri/)
+      expect { @client_200.wait_for('') }.to raise_error(ArgumentError, /Must specify a task_uri/)
     end
 
     it 'returns the response body for completed tasks' do
       fake_response = FakeResponse.new(taskState: 'Completed', name: 'NewName')
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(fake_response)
-      ret = @client.wait_for('/rest/tasks/1')
+      ret = @client_200.wait_for('/rest/tasks/1')
       expect(ret).to eq('taskState' => 'Completed', 'name' => 'NewName')
     end
 
@@ -313,7 +313,7 @@ RSpec.describe OneviewSDK::Client do
       fake_response = FakeResponse.new(taskState: 'Warning', taskErrors: 'Blah')
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(fake_response)
       ret = nil
-      expect { ret = @client.wait_for('/rest/tasks/1') }.to output(/ended with warning.*Blah/).to_stdout_from_any_process
+      expect { ret = @client_200.wait_for('/rest/tasks/1') }.to output(/ended with warning.*Blah/).to_stdout_from_any_process
       expect(ret).to eq('taskState' => 'Warning', 'taskErrors' => 'Blah')
     end
 
@@ -321,7 +321,7 @@ RSpec.describe OneviewSDK::Client do
       %w(Error Killed Terminated).each do |state|
         fake_response = FakeResponse.new(taskState: state, message: 'Blah')
         allow_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(fake_response)
-        expect { @client.wait_for('/rest/tasks/1') }.to raise_error(OneviewSDK::TaskError, /ended with bad state[\S\s]*Blah/)
+        expect { @client_200.wait_for('/rest/tasks/1') }.to raise_error(OneviewSDK::TaskError, /ended with bad state[\S\s]*Blah/)
       end
     end
 
@@ -329,7 +329,7 @@ RSpec.describe OneviewSDK::Client do
       %w(Error Killed Terminated).each do |state|
         fake_response = FakeResponse.new(taskState: state, taskErrors: { message: 'Blah' })
         allow_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(fake_response)
-        expect { @client.wait_for('/rest/tasks/1') }.to raise_error(OneviewSDK::TaskError, /ended with bad state[\S\s]*Blah/)
+        expect { @client_200.wait_for('/rest/tasks/1') }.to raise_error(OneviewSDK::TaskError, /ended with bad state[\S\s]*Blah/)
       end
     end
   end

--- a/spec/unit/resource/api200/connection_template_spec.rb
+++ b/spec/unit/resource/api200/connection_template_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe OneviewSDK::ConnectionTemplate do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      connection = OneviewSDK::ConnectionTemplate.new(@client)
+      connection = OneviewSDK::ConnectionTemplate.new(@client_200)
       expect(connection['bandwidth']).to eq({})
       expect(connection['type']).to eq('connection-template')
     end
 
     it 'sets maximum and typical bandwidth' do
-      connection = OneviewSDK::ConnectionTemplate.new(@client)
+      connection = OneviewSDK::ConnectionTemplate.new(@client_200)
       connection['bandwidth']['maximumBandwidth'] = 1000
       connection['bandwidth']['typicalBandwidth'] = 5000
       expect(connection['bandwidth']['maximumBandwidth']).to eq(1000)
@@ -21,22 +21,22 @@ RSpec.describe OneviewSDK::ConnectionTemplate do
 
   describe '#get_default' do
     it 'verify endpoint' do
-      expect(@client).to receive(:rest_get).with('/rest/connection-templates/defaultConnectionTemplate').and_return(FakeResponse.new({}))
-      connection = OneviewSDK::ConnectionTemplate.get_default(@client)
+      expect(@client_200).to receive(:rest_get).with('/rest/connection-templates/defaultConnectionTemplate').and_return(FakeResponse.new({}))
+      connection = OneviewSDK::ConnectionTemplate.get_default(@client_200)
       expect(connection).to be_an_instance_of OneviewSDK::ConnectionTemplate
     end
   end
 
   describe '#create' do
     it 'is unavailable' do
-      connection = OneviewSDK::ConnectionTemplate.new(@client)
+      connection = OneviewSDK::ConnectionTemplate.new(@client_200)
       expect { connection.create }.to raise_error(/The method #create is unavailable for this resource/)
     end
   end
 
   describe '#delete' do
     it 'is unavailable' do
-      connection = OneviewSDK::ConnectionTemplate.new(@client)
+      connection = OneviewSDK::ConnectionTemplate.new(@client_200)
       expect { connection.delete }.to raise_error(/The method #delete is unavailable for this resource/)
     end
   end

--- a/spec/unit/resource/api200/datacenter_spec.rb
+++ b/spec/unit/resource/api200/datacenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OneviewSDK::Datacenter do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      datacenter = OneviewSDK::Datacenter.new(@client)
+      datacenter = OneviewSDK::Datacenter.new(@client_200)
       expect(datacenter['contents']).to eq([])
     end
   end
@@ -28,8 +28,8 @@ RSpec.describe OneviewSDK::Datacenter do
         width: 5000,
         depth: 5000
       }
-      item = OneviewSDK::Datacenter.new(@client, options)
-      expect(@client).to receive(:rest_post).with(
+      item = OneviewSDK::Datacenter.new(@client_200, options)
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/datacenters',
         { 'body' => { 'name' => 'Datacenter', 'width' => 5000, 'depth' => 5000, 'contents' => [] } },
         item.api_version
@@ -40,15 +40,15 @@ RSpec.describe OneviewSDK::Datacenter do
 
   describe '#remove' do
     it 'Should support remove' do
-      datacenter = OneviewSDK::Datacenter.new(@client, uri: '/rest/datacenters/100')
-      expect(@client).to receive(:rest_delete).with('/rest/datacenters/100', {}, 200).and_return(FakeResponse.new({}))
+      datacenter = OneviewSDK::Datacenter.new(@client_200, uri: '/rest/datacenters/100')
+      expect(@client_200).to receive(:rest_delete).with('/rest/datacenters/100', {}, 200).and_return(FakeResponse.new({}))
       datacenter.remove
     end
   end
 
   describe '#add_rack' do
     before :each do
-      @datacenter = OneviewSDK::Datacenter.new(@client)
+      @datacenter = OneviewSDK::Datacenter.new(@client_200)
     end
 
     it 'Add one rack without rotation' do
@@ -75,7 +75,7 @@ RSpec.describe OneviewSDK::Datacenter do
 
   describe '#remove_rack' do
     before :each do
-      @datacenter = OneviewSDK::Datacenter.new(@client)
+      @datacenter = OneviewSDK::Datacenter.new(@client_200)
     end
 
     it 'Remove rack from empty list' do
@@ -97,12 +97,12 @@ RSpec.describe OneviewSDK::Datacenter do
 
   describe 'undefined methods' do
     it 'does not allow the create action' do
-      datacenter = OneviewSDK::Datacenter.new(@client)
+      datacenter = OneviewSDK::Datacenter.new(@client_200)
       expect { datacenter.create }.to raise_error(/The method #create is unavailable for this resource/)
     end
 
     it 'does not allow the delete action' do
-      datacenter = OneviewSDK::Datacenter.new(@client)
+      datacenter = OneviewSDK::Datacenter.new(@client_200)
       expect { datacenter.delete }.to raise_error(/The method #delete is unavailable for this resource/)
     end
   end

--- a/spec/unit/resource/api200/enclosure_group_spec.rb
+++ b/spec/unit/resource/api200/enclosure_group_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe klass do
   describe '#initialize' do
     context 'OneView 2.0' do
       it 'sets the defaults correctly' do
-        item = klass.new(@client)
+        item = klass.new(@client_200)
         expect(item[:type]).to eq('EnclosureGroupV200')
       end
     end
@@ -15,45 +15,45 @@ RSpec.describe klass do
 
   describe '#script' do
     it 'requires a uri' do
-      expect { klass.new(@client).get_script }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { klass.new(@client_200).get_script }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/script' do
-      item = klass.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/script', item.api_version).and_return(FakeResponse.new('Blah'))
-      expect(@client.logger).to receive(:warn).with(/Failed to parse JSON response/).and_return(true)
+      item = klass.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/script', item.api_version).and_return(FakeResponse.new('Blah'))
+      expect(@client_200.logger).to receive(:warn).with(/Failed to parse JSON response/).and_return(true)
       expect(item.get_script).to eq('Blah')
     end
   end
 
   describe '#set_script' do
     it 'requires a uri' do
-      expect { klass.new(@client).set_script('Blah') }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { klass.new(@client_200).set_script('Blah') }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to uri/script' do
-      item = klass.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_put).with('/rest/fake/script', { 'body' => 'Blah' }, item.api_version).and_return(FakeResponse.new('Blah'))
-      expect(@client.logger).to receive(:warn).with(/Failed to parse JSON response/).and_return(true)
+      item = klass.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/script', { 'body' => 'Blah' }, item.api_version).and_return(FakeResponse.new('Blah'))
+      expect(@client_200.logger).to receive(:warn).with(/Failed to parse JSON response/).and_return(true)
       expect(item.set_script('Blah')).to eq(true)
     end
   end
 
   describe '#create_interconnect_bay_mapping' do
     it 'creates entries for each bay' do
-      item = klass.new(@client, name: 'EG', enclosureCount: 3)
+      item = klass.new(@client_200, name: 'EG', enclosureCount: 3)
       expect(item['interconnectBayMappings'].size).to eq(8)
     end
   end
 
   describe '#add_logical_interconnect_group' do
     before :each do
-      @lig = OneviewSDK::API200::LogicalInterconnectGroup.new(@client, uri: '/fakelig')
+      @lig = OneviewSDK::API200::LogicalInterconnectGroup.new(@client_200, uri: '/fakelig')
       @lig['interconnectMapTemplate']['interconnectMapEntryTemplates'] = [
         { 'permittedInterconnectTypeUri' => '/fake', 'logicalLocation' => { 'locationEntries' => [{ 'type' => 'Bay', 'relativeValue' => 1 }] } },
         { 'permittedInterconnectTypeUri' => '/fake', 'logicalLocation' => { 'locationEntries' => [{ 'type' => 'Bay', 'relativeValue' => 4 }] } }
       ]
-      @item = klass.new(@client, name: 'EG', enclosureCount: 3)
+      @item = klass.new(@client_200, name: 'EG', enclosureCount: 3)
     end
 
     it 'it adds the LIG uri to each applicable bay' do

--- a/spec/unit/resource/api200/enclosure_spec.rb
+++ b/spec/unit/resource/api200/enclosure_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OneviewSDK::Enclosure do
   describe '#initialize' do
     context 'OneView 2.0' do
       it 'sets the defaults correctly' do
-        enclosure = OneviewSDK::Enclosure.new(@client)
+        enclosure = OneviewSDK::Enclosure.new(@client_200)
         expect(enclosure[:type]).to eq('EnclosureV200')
       end
     end
@@ -19,32 +19,32 @@ RSpec.describe OneviewSDK::Enclosure do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1', activeOaPreferredIP: 'aip1', standbyOaPreferredIP: 'sip1' },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2', activeOaPreferredIP: 'aip2', standbyOaPreferredIP: 'sip2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'retrieves by name' do
-      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
-      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client_200, name: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by uri' do
-      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
-      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client_200, uri: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by activeOaPreferredIP' do
-      expect(described_class.new(@client, activeOaPreferredIP: 'aip1').retrieve!).to be true
-      expect(described_class.new(@client, activeOaPreferredIP: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, activeOaPreferredIP: 'aip1').retrieve!).to be true
+      expect(described_class.new(@client_200, activeOaPreferredIP: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by standbyOaPreferredIP' do
-      expect(described_class.new(@client, standbyOaPreferredIP: 'sip1').retrieve!).to be true
-      expect(described_class.new(@client, standbyOaPreferredIP: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, standbyOaPreferredIP: 'sip1').retrieve!).to be true
+      expect(described_class.new(@client_200, standbyOaPreferredIP: 'fake').retrieve!).to be false
     end
   end
 
@@ -54,32 +54,32 @@ RSpec.describe OneviewSDK::Enclosure do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1', activeOaPreferredIP: 'aip1', standbyOaPreferredIP: 'sip1' },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2', activeOaPreferredIP: 'aip2', standbyOaPreferredIP: 'sip2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'finds it by name' do
-      expect(described_class.new(@client, name: 'name1').exists?).to be true
-      expect(described_class.new(@client, name: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, name: 'name1').exists?).to be true
+      expect(described_class.new(@client_200, name: 'fake').exists?).to be false
     end
 
     it 'finds it by uri' do
-      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
-      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client_200, uri: 'fake').exists?).to be false
     end
 
     it 'finds it by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').exists?).to be false
     end
 
     it 'finds it by activeOaPreferredIP' do
-      expect(described_class.new(@client, activeOaPreferredIP: 'aip1').exists?).to be true
-      expect(described_class.new(@client, activeOaPreferredIP: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, activeOaPreferredIP: 'aip1').exists?).to be true
+      expect(described_class.new(@client_200, activeOaPreferredIP: 'fake').exists?).to be false
     end
 
     it 'finds it by standbyOaPreferredIP' do
-      expect(described_class.new(@client, standbyOaPreferredIP: 'sip1').exists?).to be true
-      expect(described_class.new(@client, standbyOaPreferredIP: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, standbyOaPreferredIP: 'sip1').exists?).to be true
+      expect(described_class.new(@client_200, standbyOaPreferredIP: 'fake').exists?).to be false
     end
   end
 
@@ -99,11 +99,11 @@ RSpec.describe OneviewSDK::Enclosure do
           'licensingIntent' => 'OneView',
           'force' => true
         }
-        @enclosure = OneviewSDK::Enclosure.new(@client, @data)
+        @enclosure = OneviewSDK::Enclosure.new(@client_200, @data)
       end
 
       it 'only sends certain attributes on the POST' do
-        expect(@client).to receive(:rest_post).with('/rest/enclosures', { 'body' => @data.select { |k, _v| k != 'name' } }, anything)
+        expect(@client_200).to receive(:rest_post).with('/rest/enclosures', { 'body' => @data.select { |k, _v| k != 'name' } }, anything)
         @enclosure.add
       end
 
@@ -121,7 +121,7 @@ RSpec.describe OneviewSDK::Enclosure do
 
     context 'with invalid data' do
       it 'fails when certain attributes are not set' do
-        enclosure = OneviewSDK::Enclosure.new(@client, {})
+        enclosure = OneviewSDK::Enclosure.new(@client_200, {})
         expect { enclosure.add }.to raise_error(OneviewSDK::IncompleteResource, /Missing required attribute/)
       end
     end
@@ -129,32 +129,32 @@ RSpec.describe OneviewSDK::Enclosure do
 
   describe '#update' do
     before :each do
-      @item  = OneviewSDK::Enclosure.new(@client, name: 'E1', rackName: 'R1', uri: '/rest/fake')
-      @item2 = OneviewSDK::Enclosure.new(@client, name: 'E2', rackName: 'R1', uri: '/rest/fake2')
-      @item3 = OneviewSDK::Enclosure.new(@client, name: 'E1', rackName: 'R2', uri: '/rest/fake2')
+      @item  = OneviewSDK::Enclosure.new(@client_200, name: 'E1', rackName: 'R1', uri: '/rest/fake')
+      @item2 = OneviewSDK::Enclosure.new(@client_200, name: 'E2', rackName: 'R1', uri: '/rest/fake2')
+      @item3 = OneviewSDK::Enclosure.new(@client_200, name: 'E1', rackName: 'R2', uri: '/rest/fake2')
     end
 
     it 'requires a uri' do
-      expect { OneviewSDK::Enclosure.new(@client).update }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::Enclosure.new(@client_200).update }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does not send a PATCH request if the name and rackName are the same' do
-      expect(OneviewSDK::Enclosure).to receive(:find_by).with(@client, uri: @item['uri']).and_return([@item])
-      expect(@client).to_not receive(:rest_patch)
+      expect(OneviewSDK::Enclosure).to receive(:find_by).with(@client_200, uri: @item['uri']).and_return([@item])
+      expect(@client_200).to_not receive(:rest_patch)
       @item.update
     end
 
     it 'updates the server name with the local name' do
-      expect(OneviewSDK::Enclosure).to receive(:find_by).with(@client, uri: @item['uri']).and_return([@item2])
-      expect(@client).to receive(:rest_patch)
+      expect(OneviewSDK::Enclosure).to receive(:find_by).with(@client_200, uri: @item['uri']).and_return([@item2])
+      expect(@client_200).to receive(:rest_patch)
         .with(@item['uri'], { 'body' => [{ op: 'replace', path: '/name', value: @item['name'] }] }, @item.api_version)
         .and_return(FakeResponse.new)
       @item.update
     end
 
     it 'updates the server rackName with the local rackName' do
-      expect(OneviewSDK::Enclosure).to receive(:find_by).with(@client, uri: @item['uri']).and_return([@item3])
-      expect(@client).to receive(:rest_patch)
+      expect(OneviewSDK::Enclosure).to receive(:find_by).with(@client_200, uri: @item['uri']).and_return([@item3])
+      expect(@client_200).to receive(:rest_patch)
         .with(@item['uri'], { 'body' => [{ op: 'replace', path: '/rackName', value: @item['rackName'] }] }, @item.api_version)
         .and_return(FakeResponse.new)
       @item.update
@@ -163,20 +163,20 @@ RSpec.describe OneviewSDK::Enclosure do
 
   describe '#remove' do
     it 'removes enclosure' do
-      item = OneviewSDK::Enclosure.new(@client, name: 'E1', rackName: 'R1', uri: '/rest/enclosures/encl1')
-      expect(@client).to receive(:rest_delete).with('/rest/enclosures/encl1', {}, 200).and_return(FakeResponse.new({}))
+      item = OneviewSDK::Enclosure.new(@client_200, name: 'E1', rackName: 'R1', uri: '/rest/enclosures/encl1')
+      expect(@client_200).to receive(:rest_delete).with('/rest/enclosures/encl1', {}, 200).and_return(FakeResponse.new({}))
       item.remove
     end
   end
 
   describe '#configuration' do
     it 'requires a uri' do
-      expect { OneviewSDK::Enclosure.new(@client).configuration }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::Enclosure.new(@client_200).configuration }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to /uri/configuration and updates the attributes' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_put).with('/rest/fake/configuration', {}, item.api_version).and_return(FakeResponse.new(name: 'NewName'))
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/configuration', {}, item.api_version).and_return(FakeResponse.new(name: 'NewName'))
       item.configuration
       expect(item['name']).to eq('NewName')
     end
@@ -184,20 +184,20 @@ RSpec.describe OneviewSDK::Enclosure do
 
   describe '#set_refresh_state' do
     it 'requires a uri' do
-      expect { OneviewSDK::Enclosure.new(@client).set_refresh_state(:state) }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::Enclosure.new(@client_200).set_refresh_state(:state) }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to /refreshState' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake', refreshState: 'NotRefreshing')
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/refreshState', Hash, item.api_version)
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake', refreshState: 'NotRefreshing')
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/refreshState', Hash, item.api_version)
         .and_return(FakeResponse.new(refreshState: 'Refreshing'))
       item.set_refresh_state('Refreshing')
       expect(item['refreshState']).to eq('Refreshing')
     end
 
     it 'allows string or symbol refreshState values' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake', refreshState: 'NotRefreshing')
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/refreshState', Hash, item.api_version)
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake', refreshState: 'NotRefreshing')
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/refreshState', Hash, item.api_version)
         .and_return(FakeResponse.new(refreshState: 'Refreshing'))
       item.set_refresh_state(:Refreshing)
       expect(item['refreshState']).to eq('Refreshing')
@@ -206,33 +206,34 @@ RSpec.describe OneviewSDK::Enclosure do
 
   describe '#script' do
     it 'requires a uri' do
-      expect { OneviewSDK::Enclosure.new(@client).script }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::Enclosure.new(@client_200).script }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/script' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/script', item.api_version).and_return(FakeResponse.new('Blah'))
-      expect(@client.logger).to receive(:warn).with(/Failed to parse JSON response/).and_return(true)
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/script', item.api_version).and_return(FakeResponse.new('Blah'))
+      expect(@client_200.logger).to receive(:warn).with(/Failed to parse JSON response/).and_return(true)
       expect(item.script).to eq('Blah')
     end
   end
 
   describe '#environmentalConfiguration' do
     it 'requires a uri' do
-      expect { OneviewSDK::Enclosure.new(@client).environmental_configuration }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::Enclosure.new(@client_200).environmental_configuration }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/environmentalConfiguration' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/environmentalConfiguration', item.api_version).and_return(FakeResponse.new(key: 'val'))
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get)
+        .with('/rest/fake/environmentalConfiguration', item.api_version).and_return(FakeResponse.new(key: 'val'))
       expect(item.environmental_configuration).to eq('key' => 'val')
     end
   end
 
   describe '#set_environmental_configuration' do
     it 'sets the configuration' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_put).with('/rest/fake/environmentalConfiguration', 'body' => { calibratedMaxPower: 2500 })
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/environmentalConfiguration', 'body' => { calibratedMaxPower: 2500 })
         .and_return(FakeResponse.new({}))
       item.set_environmental_configuration(2500)
     end
@@ -240,33 +241,33 @@ RSpec.describe OneviewSDK::Enclosure do
 
   describe '#utilization' do
     it 'requires a uri' do
-      expect { OneviewSDK::Enclosure.new(@client).utilization }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::Enclosure.new(@client_200).utilization }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/utilization' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization', item.api_version).and_return(FakeResponse.new(key: 'val'))
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization', item.api_version).and_return(FakeResponse.new(key: 'val'))
       expect(item.utilization).to eq('key' => 'val')
     end
 
     it 'takes query parameters' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization?key=val', item.api_version)
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization?key=val', item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(item.utilization(key: :val)).to eq('key' => 'val')
     end
 
     it 'takes an array for the :fields query parameter' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization?fields=one,two,three', item.api_version)
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization?fields=one,two,three', item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(item.utilization(fields: %w(one two three))).to eq('key' => 'val')
     end
 
     it 'converts Time query parameters' do
       t = Time.now
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with("/rest/fake/utilization?filter=startDate=#{t.utc.iso8601(3)}", item.api_version)
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with("/rest/fake/utilization?filter=startDate=#{t.utc.iso8601(3)}", item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(item.utilization(startDate: t)).to eq('key' => 'val')
     end
@@ -274,21 +275,21 @@ RSpec.describe OneviewSDK::Enclosure do
 
   describe '#updateAttribute' do
     it 'requires a uri' do
-      expect { OneviewSDK::Enclosure.new(@client).patch(:op, :path, :val) }
+      expect { OneviewSDK::Enclosure.new(@client_200).patch(:op, :path, :val) }
         .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PATCH to the enclusre uri' do
-      item = OneviewSDK::Enclosure.new(@client, uri: '/rest/fake')
+      item = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake')
       data = { 'body' => [{ op: 'operation', path: '/path', value: 'val' }] }
-      expect(@client).to receive(:rest_patch).with('/rest/fake', data, item.api_version).and_return(FakeResponse.new(key: 'Val'))
+      expect(@client_200).to receive(:rest_patch).with('/rest/fake', data, item.api_version).and_return(FakeResponse.new(key: 'Val'))
       expect(item.patch('operation', '/path', 'val')).to eq('key' => 'Val')
     end
   end
 
   describe '#convert_time' do
     before :each do
-      @item = OneviewSDK::Enclosure.new(@client)
+      @item = OneviewSDK::Enclosure.new(@client_200)
       @t = Time.now
       @d = Date.today
     end
@@ -324,12 +325,12 @@ RSpec.describe OneviewSDK::Enclosure do
 
   describe 'undefined methods' do
     it 'does not allow the create action' do
-      enclosure = OneviewSDK::Enclosure.new(@client)
+      enclosure = OneviewSDK::Enclosure.new(@client_200)
       expect { enclosure.create }.to raise_error(OneviewSDK::MethodUnavailable, /The method #create is unavailable for this resource/)
     end
 
     it 'does not allow the delete action' do
-      enclosure = OneviewSDK::Enclosure.new(@client)
+      enclosure = OneviewSDK::Enclosure.new(@client_200)
       expect { enclosure.delete }.to raise_error(OneviewSDK::MethodUnavailable, /The method #delete is unavailable for this resource/)
     end
   end

--- a/spec/unit/resource/api200/ethernet_network_spec.rb
+++ b/spec/unit/resource/api200/ethernet_network_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::EthernetNetwork do
 
   describe '#initialize' do
     it 'sets the defaults correctly api_ver 200' do
-      item = OneviewSDK::EthernetNetwork.new(@client, {}, 200)
+      item = OneviewSDK::EthernetNetwork.new(@client_200, {}, 200)
       expect(item[:ethernetNetworkType]).to eq('Tagged')
       expect(item[:type]).to eq('ethernet-networkV3')
     end
@@ -13,13 +13,13 @@ RSpec.describe OneviewSDK::EthernetNetwork do
 
   describe '#get_associated_profiles' do
     it 'requires a uri' do
-      expect { OneviewSDK::EthernetNetwork.new(@client).get_associated_profiles }
+      expect { OneviewSDK::EthernetNetwork.new(@client_200).get_associated_profiles }
         .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'returns the response body from uri/associatedProfiles' do
-      item = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with("#{item['uri']}/associatedProfiles", item.api_version)
+      item = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with("#{item['uri']}/associatedProfiles", item.api_version)
         .and_return(FakeResponse.new('[]'))
       expect(item.get_associated_profiles).to eq('[]')
     end
@@ -27,13 +27,13 @@ RSpec.describe OneviewSDK::EthernetNetwork do
 
   describe '#get_associated_uplink_groups' do
     it 'requires a uri' do
-      expect { OneviewSDK::EthernetNetwork.new(@client).get_associated_uplink_groups }
+      expect { OneviewSDK::EthernetNetwork.new(@client_200).get_associated_uplink_groups }
         .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'returns the response body from uri/associatedUplinkGroups' do
-      item = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with("#{item['uri']}/associatedUplinkGroups", item.api_version)
+      item = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with("#{item['uri']}/associatedUplinkGroups", item.api_version)
         .and_return(FakeResponse.new('[]'))
       expect(item.get_associated_uplink_groups).to eq('[]')
     end
@@ -53,7 +53,7 @@ RSpec.describe OneviewSDK::EthernetNetwork do
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new(networks, 200))
       expect_any_instance_of(OneviewSDK::Client).to receive(:rest_post).and_return(FakeResponse.new({}, 202))
       expect_any_instance_of(OneviewSDK::Client).to receive(:wait_for).and_return({})
-      list = OneviewSDK::EthernetNetwork.bulk_create(@client, options)
+      list = OneviewSDK::EthernetNetwork.bulk_create(@client_200, options)
       expect(list.length).to eq(3)
     end
   end

--- a/spec/unit/resource/api200/fabric_spec.rb
+++ b/spec/unit/resource/api200/fabric_spec.rb
@@ -5,22 +5,22 @@ RSpec.describe OneviewSDK::Fabric do
 
   describe 'Unavaible methods' do
     it '#create' do
-      item = OneviewSDK::Fabric.new(@client, 'name' => 'unit_fabric')
+      item = OneviewSDK::Fabric.new(@client_200, 'name' => 'unit_fabric')
       expect { item.create }.to raise_error(OneviewSDK::MethodUnavailable, /unavailable for this resource/)
     end
 
     it '#update' do
-      item = OneviewSDK::Fabric.new(@client, 'name' => 'unit_fabric')
+      item = OneviewSDK::Fabric.new(@client_200, 'name' => 'unit_fabric')
       expect { item.update }.to raise_error(OneviewSDK::MethodUnavailable, /unavailable for this resource/)
     end
 
     it '#delete' do
-      item = OneviewSDK::Fabric.new(@client, 'name' => 'unit_fabric')
+      item = OneviewSDK::Fabric.new(@client_200, 'name' => 'unit_fabric')
       expect { item.delete }.to raise_error(OneviewSDK::MethodUnavailable, /unavailable for this resource/)
     end
 
     it '#refresh' do
-      item = OneviewSDK::Fabric.new(@client, 'name' => 'unit_fabric')
+      item = OneviewSDK::Fabric.new(@client_200, 'name' => 'unit_fabric')
       expect { item.refresh }.to raise_error(OneviewSDK::MethodUnavailable, /unavailable for this resource/)
     end
   end

--- a/spec/unit/resource/api200/fc_network_spec.rb
+++ b/spec/unit/resource/api200/fc_network_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::FCNetwork do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = OneviewSDK::FCNetwork.new(@client)
+      item = OneviewSDK::FCNetwork.new(@client_200)
       expect(item[:type]).to eq('fc-networkV2')
       expect(item[:autoLoginRedistribution]).to eq(false)
       expect(item[:linkStabilityTime]).to eq(30)

--- a/spec/unit/resource/api200/fcoe_network_spec.rb
+++ b/spec/unit/resource/api200/fcoe_network_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::FCoENetwork do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = described_class.new(@client)
+      item = described_class.new(@client_200)
       expect(item[:type]).to eq('fcoe-network')
       expect(item[:connectionTemplateUri]).to eq(nil)
     end

--- a/spec/unit/resource/api200/firmware_bundle_spec.rb
+++ b/spec/unit/resource/api200/firmware_bundle_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe OneviewSDK::FirmwareBundle do
 
   describe '#add' do
     it 'fails if the file does not exist' do
-      expect { described_class.add(@client, 'file.fake') }.to raise_error(OneviewSDK::NotFound, //)
+      expect { described_class.add(@client_200, 'file.fake') }.to raise_error(OneviewSDK::NotFound, //)
     end
 
     it 'returns a FirmwareDriver resource' do
       allow_any_instance_of(Net::HTTP).to receive(:request).and_return(FakeResponse.new({}, 200))
       allow_any_instance_of(Net::HTTP).to receive(:connect).and_return(true)
-      allow(@client).to receive(:response_handler).and_return(uri: '/rest/firmware-drivers/f1')
+      allow(@client_200).to receive(:response_handler).and_return(uri: '/rest/firmware-drivers/f1')
       allow(File).to receive(:file?).and_return(true)
       allow(File).to receive(:open).with('file.tar').and_yield('FAKE FILE CONTENT')
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
-      expect(OneviewSDK::FirmwareBundle.add(@client, 'file.tar').class).to eq(OneviewSDK::FirmwareDriver)
+      expect(OneviewSDK::FirmwareBundle.add(@client_200, 'file.tar').class).to eq(OneviewSDK::FirmwareDriver)
     end
 
     it 'should use default http read_timeout when new value is not passed as parameter' do
@@ -25,7 +25,7 @@ RSpec.describe OneviewSDK::FirmwareBundle do
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
       http_fake = spy('http')
       allow(Net::HTTP).to receive(:new).and_return(http_fake)
-      OneviewSDK::FirmwareBundle.add(@client, 'file.tar')
+      OneviewSDK::FirmwareBundle.add(@client_200, 'file.tar')
       expect(http_fake).to have_received(:read_timeout=).with(OneviewSDK::FirmwareBundle::READ_TIMEOUT)
     end
 
@@ -35,7 +35,7 @@ RSpec.describe OneviewSDK::FirmwareBundle do
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
       http_fake = spy('http')
       allow(Net::HTTP).to receive(:new).and_return(http_fake)
-      OneviewSDK::FirmwareBundle.add(@client, 'file.tar', 600)
+      OneviewSDK::FirmwareBundle.add(@client_200, 'file.tar', 600)
       expect(http_fake).to have_received(:read_timeout=).with(600)
     end
 
@@ -45,7 +45,7 @@ RSpec.describe OneviewSDK::FirmwareBundle do
       allow(File).to receive(:file?).and_return(true)
       allow(File).to receive(:open).with('file.tar').and_yield('FAKE FILE CONTENT')
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
-      expect { OneviewSDK::FirmwareBundle.add(@client, 'file.tar') }.to raise_error(/The connection was closed/)
+      expect { OneviewSDK::FirmwareBundle.add(@client_200, 'file.tar') }.to raise_error(/The connection was closed/)
     end
   end
 end

--- a/spec/unit/resource/api200/firmware_driver_spec.rb
+++ b/spec/unit/resource/api200/firmware_driver_spec.rb
@@ -5,20 +5,20 @@ RSpec.describe OneviewSDK::FirmwareDriver do
 
   describe '#remove' do
     it 'Should support remove' do
-      firmware = OneviewSDK::FirmwareDriver.new(@client, uri: '/rest/firmware-drivers/100')
-      expect(@client).to receive(:rest_delete).with('/rest/firmware-drivers/100', {}, 200).and_return(FakeResponse.new({}))
+      firmware = OneviewSDK::FirmwareDriver.new(@client_200, uri: '/rest/firmware-drivers/100')
+      expect(@client_200).to receive(:rest_delete).with('/rest/firmware-drivers/100', {}, 200).and_return(FakeResponse.new({}))
       firmware.remove
     end
   end
 
   describe 'undefined methods' do
     it 'does not allow the update action' do
-      item = OneviewSDK::FirmwareDriver.new(@client, {})
+      item = OneviewSDK::FirmwareDriver.new(@client_200, {})
       expect { item.update }.to raise_error(OneviewSDK::MethodUnavailable)
     end
 
     it 'does not allow the delete action' do
-      item = OneviewSDK::FirmwareDriver.new(@client, {})
+      item = OneviewSDK::FirmwareDriver.new(@client_200, {})
       expect { item.delete }.to raise_error(OneviewSDK::MethodUnavailable)
     end
   end

--- a/spec/unit/resource/api200/interconnect_spec.rb
+++ b/spec/unit/resource/api200/interconnect_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::Interconnect do
 
   describe 'undefined methods' do
     before :each do
-      @item = OneviewSDK::Interconnect.new(@client, {})
+      @item = OneviewSDK::Interconnect.new(@client_200, {})
     end
 
     it 'does not allow the create action' do
@@ -27,22 +27,22 @@ RSpec.describe OneviewSDK::Interconnect do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'retrieves by name' do
-      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
-      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client_200, name: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by uri' do
-      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
-      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client_200, uri: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').retrieve!).to be false
     end
   end
 
@@ -52,37 +52,37 @@ RSpec.describe OneviewSDK::Interconnect do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'finds it by name' do
-      expect(described_class.new(@client, name: 'name1').exists?).to be true
-      expect(described_class.new(@client, name: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, name: 'name1').exists?).to be true
+      expect(described_class.new(@client_200, name: 'fake').exists?).to be false
     end
 
     it 'finds it by uri' do
-      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
-      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client_200, uri: 'fake').exists?).to be false
     end
 
     it 'finds it by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').exists?).to be false
     end
   end
 
   describe 'statistics' do
     before :each do
-      @item = OneviewSDK::Interconnect.new(@client, {})
+      @item = OneviewSDK::Interconnect.new(@client_200, {})
     end
 
     it 'port' do
-      expect(@client).to receive(:rest_get).with('/statistics/p1').and_return(FakeResponse.new)
+      expect(@client_200).to receive(:rest_get).with('/statistics/p1').and_return(FakeResponse.new)
       @item.statistics('p1')
     end
 
     it 'port and subport' do
-      expect(@client).to receive(:rest_get).with('/statistics/p1/subport/sp1').and_return(FakeResponse.new)
+      expect(@client_200).to receive(:rest_get).with('/statistics/p1/subport/sp1').and_return(FakeResponse.new)
       @item.statistics('p1', 'sp1')
     end
   end
@@ -96,24 +96,24 @@ RSpec.describe OneviewSDK::Interconnect do
           { 'name' => 'interconnect_typeC', 'uri' => 'rest/fake/C' }
         ]
       )
-      expect(@client).to receive(:rest_get).with('/rest/interconnect-types').and_return(interconnect_type_type_list)
-      @item = OneviewSDK::Interconnect.get_type(@client, 'Theinterconnect_type')
+      expect(@client_200).to receive(:rest_get).with('/rest/interconnect-types').and_return(interconnect_type_type_list)
+      @item = OneviewSDK::Interconnect.get_type(@client_200, 'Theinterconnect_type')
       expect(@item['uri']).to eq('rest/fake/interconnect_type')
     end
   end
 
   describe '#name_servers' do
     it 'should get the name servers' do
-      item = OneviewSDK::Interconnect.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/nameServers').and_return(FakeResponse.new)
+      item = OneviewSDK::Interconnect.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/nameServers').and_return(FakeResponse.new)
       expect(item.name_servers).to be
     end
   end
 
   describe '#patch' do
     it 'sends a patch request to the interconnect' do
-      item = OneviewSDK::Interconnect.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_patch)
+      item = OneviewSDK::Interconnect.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_patch)
         .with(item['uri'], 'body' => [{ op: 'replace', path: '/uidState', value: 'On' }])
         .and_return(FakeResponse.new)
       expect(item.patch('replace', '/uidState', 'On')).to be
@@ -122,8 +122,8 @@ RSpec.describe OneviewSDK::Interconnect do
 
   describe '#reset_port_protection' do
     it 'sets the port protection' do
-      item = OneviewSDK::Interconnect.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_put).with('/rest/fake/resetportprotection').and_return(FakeResponse.new)
+      item = OneviewSDK::Interconnect.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/resetportprotection').and_return(FakeResponse.new)
       expect(item.reset_port_protection).to be
     end
   end
@@ -145,9 +145,9 @@ RSpec.describe OneviewSDK::Interconnect do
         'enabled' => false
       }
 
-      item = OneviewSDK::Interconnect.new(@client, options)
-      expect(@client).to receive(:rest_put).with('/rest/fake/ports', 'body' => options_2).and_return(true)
-      expect(@client).to receive(:response_handler).with(true).and_return(FakeResponse.new)
+      item = OneviewSDK::Interconnect.new(@client_200, options)
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/ports', 'body' => options_2).and_return(true)
+      expect(@client_200).to receive(:response_handler).with(true).and_return(FakeResponse.new)
       expect(item.update_port('port1', enabled: false)).to be
     end
   end

--- a/spec/unit/resource/api200/lig_uplink_set_spec.rb
+++ b/spec/unit/resource/api200/lig_uplink_set_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::LIGUplinkSet do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = OneviewSDK::LIGUplinkSet.new(@client, networkType: 'FibreChannel')
+      item = OneviewSDK::LIGUplinkSet.new(@client_200, networkType: 'FibreChannel')
       expect(item[:logicalPortConfigInfos]).to eq([])
       expect(item[:lacpTimer]).to eq('Short')
       expect(item[:mode]).to eq('Auto')
@@ -16,26 +16,26 @@ RSpec.describe OneviewSDK::LIGUplinkSet do
   describe 'adds' do
     def_options = { networkType: 'Ethernet', ethernetNetworkType: 'NotApplicable' }
     it 'Add empty network resource' do
-      upset = OneviewSDK::LIGUplinkSet.new(@client, def_options)
-      net = OneviewSDK::EthernetNetwork.new(@client, {})
+      upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+      net = OneviewSDK::EthernetNetwork.new(@client_200, {})
       expect { upset.add_network(net) }.to raise_error(OneviewSDK::IncompleteResource, /Must set/)
     end
     it 'Add retrieved network resource' do
       options = { networkType: 'Ethernet', ethernetNetworkType: 'NotApplicable' }
-      upset = OneviewSDK::LIGUplinkSet.new(@client, options)
-      net = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/ethernet-networks/65546B-A55F20-663390-CA96F5')
+      upset = OneviewSDK::LIGUplinkSet.new(@client_200, options)
+      net = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/65546B-A55F20-663390-CA96F5')
       expect { upset.add_network(net) }.not_to raise_error
     end
     it 'Add X7 port' do
-      upset = OneviewSDK::LIGUplinkSet.new(@client, def_options)
+      upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
       expect { upset.add_uplink(1, 'X7') }.not_to raise_error
     end
     it 'Add D5 port' do
-      upset = OneviewSDK::LIGUplinkSet.new(@client, def_options)
+      upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
       expect { upset.add_uplink(1, 'D5') }.not_to raise_error
     end
     it 'Add not supported port' do
-      upset = OneviewSDK::LIGUplinkSet.new(@client, def_options)
+      upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
       expect { upset.add_uplink(1, 'V5') }.to raise_error(OneviewSDK::InvalidResource, /Port not supported/)
     end
   end

--- a/spec/unit/resource/api200/logical_downlink_spec.rb
+++ b/spec/unit/resource/api200/logical_downlink_spec.rb
@@ -5,29 +5,29 @@ RSpec.describe OneviewSDK::LogicalDownlink do
 
   describe '#create' do
     it 'is unavailable' do
-      logical_downlink = OneviewSDK::LogicalDownlink.new(@client)
+      logical_downlink = OneviewSDK::LogicalDownlink.new(@client_200)
       expect { logical_downlink.create }.to raise_error(OneviewSDK::MethodUnavailable, /The method #create is unavailable for this resource/)
     end
   end
 
   describe '#delete' do
     it 'is unavailable' do
-      logical_downlink = OneviewSDK::LogicalDownlink.new(@client)
+      logical_downlink = OneviewSDK::LogicalDownlink.new(@client_200)
       expect { logical_downlink.delete }.to raise_error(OneviewSDK::MethodUnavailable, /The method #delete is unavailable for this resource/)
     end
   end
 
   describe '#update' do
     it 'is unavailable' do
-      logical_downlink = OneviewSDK::LogicalDownlink.new(@client)
+      logical_downlink = OneviewSDK::LogicalDownlink.new(@client_200)
       expect { logical_downlink.update }.to raise_error(OneviewSDK::MethodUnavailable, /The method #update is unavailable for this resource/)
     end
   end
 
   describe '#get_without_ethernet' do
     it 'retrieve logical downlinks without ethernet' do
-      expect(@client).to receive(:rest_get).with('/rest/logical-downlinks/ld1/withoutEthernet').and_return(FakeResponse.new({}))
-      logical_downlink = OneviewSDK::LogicalDownlink.new(@client, uri: '/rest/logical-downlinks/ld1')
+      expect(@client_200).to receive(:rest_get).with('/rest/logical-downlinks/ld1/withoutEthernet').and_return(FakeResponse.new({}))
+      logical_downlink = OneviewSDK::LogicalDownlink.new(@client_200, uri: '/rest/logical-downlinks/ld1')
       logical_downlink.get_without_ethernet
       expect(logical_downlink.class).to eq(described_class)
     end
@@ -35,8 +35,8 @@ RSpec.describe OneviewSDK::LogicalDownlink do
 
   describe '#self.get_without_ethernet' do
     it 'retrieve logical downlinks without ethernet' do
-      expect(@client).to receive(:rest_get).with('/rest/logical-downlinks/withoutEthernet').and_return(FakeResponse.new('members' => [{}]))
-      logical_downlinks = OneviewSDK::LogicalDownlink.get_without_ethernet(@client)
+      expect(@client_200).to receive(:rest_get).with('/rest/logical-downlinks/withoutEthernet').and_return(FakeResponse.new('members' => [{}]))
+      logical_downlinks = OneviewSDK::LogicalDownlink.get_without_ethernet(@client_200)
       expect(logical_downlinks.first.class).to eq(described_class)
     end
   end

--- a/spec/unit/resource/api200/logical_enclosure_spec.rb
+++ b/spec/unit/resource/api200/logical_enclosure_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe OneviewSDK::LogicalEnclosure do
 
   describe 'helper-methods' do
     before :each do
-      @item = OneviewSDK::LogicalEnclosure.new(@client, uri: '/rest/logical-enclosures/fake')
+      @item = OneviewSDK::LogicalEnclosure.new(@client_200, uri: '/rest/logical-enclosures/fake')
     end
 
     describe '#reconfigure' do
       it 'calls the /configuration uri' do
         allow_any_instance_of(OneviewSDK::Client).to receive(:rest_put).and_return(FakeResponse.new)
-        expect(@client).to receive(:rest_put).with('/rest/logical-enclosures/fake/configuration', {}, @client.api_version)
+        expect(@client_200).to receive(:rest_put).with('/rest/logical-enclosures/fake/configuration', {}, @client_200.api_version)
         @item.reconfigure
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe OneviewSDK::LogicalEnclosure do
     describe '#update_from_group' do
       it 'calls the /updateFromGroup uri' do
         allow_any_instance_of(OneviewSDK::Client).to receive(:rest_put).and_return(FakeResponse.new)
-        expect(@client).to receive(:rest_put).with('/rest/logical-enclosures/fake/updateFromGroup', {}, @client.api_version)
+        expect(@client_200).to receive(:rest_put).with('/rest/logical-enclosures/fake/updateFromGroup', {}, @client_200.api_version)
         @item.update_from_group
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe OneviewSDK::LogicalEnclosure do
     describe '#get_script' do
       it 'calls the /script uri' do
         allow_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new('Content'))
-        expect(@client).to receive(:rest_get).with('/rest/logical-enclosures/fake/script', @client.api_version)
+        expect(@client_200).to receive(:rest_get).with('/rest/logical-enclosures/fake/script', @client_200.api_version)
         expect(@item.get_script).to eq('Content')
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe OneviewSDK::LogicalEnclosure do
     describe '#set_script' do
       it 'calls the /script uri' do
         allow_any_instance_of(OneviewSDK::Client).to receive(:rest_put).and_return(FakeResponse.new)
-        expect(@client).to receive(:rest_put).with('/rest/logical-enclosures/fake/script', { 'body' => 'New' }, @client.api_version)
+        expect(@client_200).to receive(:rest_put).with('/rest/logical-enclosures/fake/script', { 'body' => 'New' }, @client_200.api_version)
         @item.set_script('New')
       end
     end
@@ -45,7 +45,7 @@ RSpec.describe OneviewSDK::LogicalEnclosure do
         dump = { errorCode: 'FakeDump', encrypt: false, excludeApplianceDump: false }
         allow_any_instance_of(OneviewSDK::Client).to receive(:rest_post).and_return(FakeResponse.new)
         allow_any_instance_of(OneviewSDK::Client).to receive(:wait_for).and_return(true)
-        expect(@client).to receive(:rest_post).with('/rest/logical-enclosures/fake/support-dumps', { 'body' => dump }, @client.api_version)
+        expect(@client_200).to receive(:rest_post).with('/rest/logical-enclosures/fake/support-dumps', { 'body' => dump }, @client_200.api_version)
         @item.support_dump(dump)
       end
     end

--- a/spec/unit/resource/api200/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api200/logical_interconnect_group_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = described_class.new(@client)
+      item = described_class.new(@client_200)
       expect(item['enclosureType']).to eq('C7000')
       expect(item['state']).to eq('Active')
       expect(item['uplinkSets']).to eq([])
@@ -18,20 +18,20 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
 
   describe '::get_default_settings' do
     it 'should get the default settings' do
-      expect(@client).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings', @client.api_version)
+      expect(@client_200).to receive(:rest_get).with('/rest/logical-interconnect-groups/defaultSettings', @client_200.api_version)
         .and_return(FakeResponse.new)
-      expect(OneviewSDK::LogicalInterconnectGroup.get_default_settings(@client)).to be
+      expect(OneviewSDK::LogicalInterconnectGroup.get_default_settings(@client_200)).to be
     end
   end
 
   describe '#add_interconnect' do
     before :each do
-      @item = described_class.new(@client)
+      @item = described_class.new(@client_200)
       @type = 'HP VC FlexFabric-20/40 F8 Module'
     end
 
     it 'adds a valid interconnect' do
-      expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client, @type)
+      expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client_200, @type)
         .and_return('uri' => '/rest/fake')
       @item.add_interconnect(3, @type)
       expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'][2]['permittedInterconnectTypeUri'])
@@ -39,7 +39,7 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
     end
 
     it 'raises an error if the interconnect is not found' do
-      expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client, @type)
+      expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client_200, @type)
         .and_return([])
       expect(OneviewSDK::Interconnect).to receive(:get_types).and_return([{ 'name' => '1' }, { 'name' => '2' }])
       expect { @item.add_interconnect(3, @type) }.to raise_error(/not found!/)
@@ -48,8 +48,8 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
 
   describe '#add_uplink_set' do
     it 'adds it to the \'uplinkSets\' data attribute' do
-      item = described_class.new(@client)
-      uplink = OneviewSDK::UplinkSet.new(@client)
+      item = described_class.new(@client_200)
+      uplink = OneviewSDK::UplinkSet.new(@client_200)
       item.add_uplink_set(uplink)
       expect(item['uplinkSets'].size).to eq(1)
       expect(item['uplinkSets'].first).to eq(uplink.data)
@@ -58,8 +58,8 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
 
   describe '#get_settings' do
     it 'should get the settings' do
-      item = described_class.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/settings', item.api_version)
+      item = described_class.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/settings', item.api_version)
         .and_return(FakeResponse.new)
       expect(item.get_settings).to be
     end

--- a/spec/unit/resource/api200/logical_interconnect_spec.rb
+++ b/spec/unit/resource/api200/logical_interconnect_spec.rb
@@ -9,37 +9,37 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
   let(:trap_sev) { %w(Normal Info Warning Critical Major Minor Unknown) }
 
   let(:fixture_path) { 'spec/support/fixtures/unit/resource/logical_interconnect_default.json' }
-  let(:log_int) { OneviewSDK::LogicalInterconnect.from_file(@client, fixture_path) }
+  let(:log_int) { OneviewSDK::LogicalInterconnect.from_file(@client_200, fixture_path) }
 
   describe '#initialize' do
     it 'requires the enclosure to have a uri value' do
-      item = OneviewSDK::LogicalInterconnect.new(@client)
+      item = OneviewSDK::LogicalInterconnect.new(@client_200)
       expect(item['type']).to eq('logical-interconnectV3')
     end
   end
 
   describe '#create' do
     it 'requires the enclosure to have a uri value' do
-      expect { log_int.create(1, OneviewSDK::Enclosure.new(@client)) }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { log_int.create(1, OneviewSDK::Enclosure.new(@client_200)) }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'makes a POST call to the base uri' do
-      expect(@client).to receive(:rest_post).with(log_int.class::LOCATION_URI, Hash, log_int.api_version)
+      expect(@client_200).to receive(:rest_post).with(log_int.class::LOCATION_URI, Hash, log_int.api_version)
         .and_return(FakeResponse.new)
-      log_int.create(1, OneviewSDK::Enclosure.new(@client, uri: '/rest/fake'))
+      log_int.create(1, OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake'))
     end
   end
 
   describe '#delete' do
     it 'requires the enclosure to have a uri value' do
-      expect { log_int.delete(1, OneviewSDK::Enclosure.new(@client)) }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { log_int.delete(1, OneviewSDK::Enclosure.new(@client_200)) }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'makes a DELETE call to the base uri' do
       uri = log_int.class::LOCATION_URI + '?location=Enclosure:/rest/fake,Bay:1'
-      expect(@client).to receive(:rest_delete).with(uri, {}, log_int.api_version)
+      expect(@client_200).to receive(:rest_delete).with(uri, {}, log_int.api_version)
         .and_return(FakeResponse.new)
-      log_int.delete(1, OneviewSDK::Enclosure.new(@client, uri: '/rest/fake'))
+      log_int.delete(1, OneviewSDK::Enclosure.new(@client_200, uri: '/rest/fake'))
     end
   end
 
@@ -53,7 +53,7 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
       body = {
         'body' => []
       }
-      expect(@client).to receive(:rest_put).with(@item['uri'] + '/internalNetworks', body)
+      expect(@client_200).to receive(:rest_put).with(@item['uri'] + '/internalNetworks', body)
         .and_return(FakeResponse.new(uri: 'fake'))
       @item.update_internal_networks
       expect(@item['uri']).to eq('fake')
@@ -63,8 +63,8 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
       body = {
         'body' => ['rest/fake/ethernet']
       }
-      et01 = OneviewSDK::EthernetNetwork.new(@client, uri: 'rest/fake/ethernet', name: 'et01')
-      expect(@client).to receive(:rest_put).with(@item['uri'] + '/internalNetworks', body)
+      et01 = OneviewSDK::EthernetNetwork.new(@client_200, uri: 'rest/fake/ethernet', name: 'et01')
+      expect(@client_200).to receive(:rest_put).with(@item['uri'] + '/internalNetworks', body)
         .and_return(FakeResponse.new(uri: 'fake'))
       @item.update_internal_networks(et01)
       expect(@item['uri']).to eq('fake')
@@ -84,8 +84,8 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
       allow_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(true)
       allow_any_instance_of(OneviewSDK::FCNetwork).to receive(:retrieve!).and_return(true)
       allow_any_instance_of(OneviewSDK::FCoENetwork).to receive(:retrieve!).and_return(true)
-      expect(@client).to receive(:rest_get).with("#{item['uri']}/internalVlans").and_return(true)
-      expect(@client).to receive(:response_handler).and_return(response)
+      expect(@client_200).to receive(:rest_get).with("#{item['uri']}/internalVlans").and_return(true)
+      expect(@client_200).to receive(:response_handler).and_return(response)
       result = item.list_vlan_networks
       expect(result).to_not be_empty
       expect(result[0]).to be_instance_of(OneviewSDK::EthernetNetwork)
@@ -99,18 +99,18 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#update_ethernet_settings' do
     it 'requires the uri to be set' do
-      expect { OneviewSDK::LogicalInterconnect.new(@client).update_ethernet_settings }
+      expect { OneviewSDK::LogicalInterconnect.new(@client_200).update_ethernet_settings }
         .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'requires the ethernetSettings attribute to be set' do
-      expect { OneviewSDK::LogicalInterconnect.new(@client, uri: '/rest/fake').update_ethernet_settings }
+      expect { OneviewSDK::LogicalInterconnect.new(@client_200, uri: '/rest/fake').update_ethernet_settings }
         .to raise_error(OneviewSDK::IncompleteResource, /Please retrieve/)
     end
 
     it 'does a PUT to uri/ethernetSettings & updates @data' do
       item = log_int
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/ethernetSettings', Hash, item.api_version)
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/ethernetSettings', Hash, item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       item.update_ethernet_settings
       expect(item['key']).to eq('val')
@@ -119,13 +119,13 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#update_settings' do
     it 'requires the uri to be set' do
-      expect { OneviewSDK::LogicalInterconnect.new(@client).update_ethernet_settings }
+      expect { OneviewSDK::LogicalInterconnect.new(@client_200).update_ethernet_settings }
         .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to uri/settings & updates @data' do
       item = log_int
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/settings', Hash, item.api_version)
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/settings', Hash, item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       item.update_settings
       expect(item['key']).to eq('val')
@@ -134,12 +134,12 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#compliance' do
     it 'requires the uri to be set' do
-      expect { OneviewSDK::LogicalInterconnect.new(@client).compliance }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::LogicalInterconnect.new(@client_200).compliance }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to uri/compliance & updates @data' do
       item = log_int
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/compliance', {}, item.api_version)
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/compliance', {}, item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       item.compliance
       expect(item['key']).to eq('val')
@@ -148,12 +148,12 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#configuration' do
     it 'requires the uri to be set' do
-      expect { OneviewSDK::LogicalInterconnect.new(@client).configuration }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::LogicalInterconnect.new(@client_200).configuration }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to uri/configuration & updates @data' do
       item = log_int
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/configuration', {}, item.api_version)
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/configuration', {}, item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       item.configuration
       expect(item['key']).to eq('val')
@@ -162,13 +162,13 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#get_unassigned_uplink_ports_for_port_monitor' do
     it 'requires the uri to be set' do
-      item = OneviewSDK::LogicalInterconnect.new(@client)
+      item = OneviewSDK::LogicalInterconnect.new(@client_200)
       expect { item.get_unassigned_uplink_ports_for_port_monitor }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'get_unassigned_uplink_ports_for_port_monitor' do
       item = log_int
-      expect(@client).to receive(:rest_get).with("#{item['uri']}/unassignedUplinkPortsForPortMonitor")
+      expect(@client_200).to receive(:rest_get).with("#{item['uri']}/unassignedUplinkPortsForPortMonitor")
         .and_return(FakeResponse.new(members: [{ interconnectName: 'p1' }, { interconnectName: 'p2' }]))
       results = item.get_unassigned_uplink_ports_for_port_monitor
       expect(results).to_not be_empty
@@ -179,20 +179,20 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#update_port_monitor' do
     it 'raises exception when is not passed the portMonitor' do
-      item = OneviewSDK::LogicalInterconnect.new(@client, uri: 'rest/fake')
+      item = OneviewSDK::LogicalInterconnect.new(@client_200, uri: 'rest/fake')
       expect { item.update_port_monitor }
         .to raise_error(OneviewSDK::IncompleteResource, /Please retrieve the Logical Interconnect before trying to update/)
     end
 
     it 'updates port monitor settings' do
-      item = OneviewSDK::LogicalInterconnect.new(@client, uri: 'rest/fake', portMonitor: 'rest/fake/d1')
+      item = OneviewSDK::LogicalInterconnect.new(@client_200, uri: 'rest/fake', portMonitor: 'rest/fake/d1')
       update_options = {
         'If-Match' =>  item['portMonitor'].delete('eTag'),
         'body' => item['portMonitor']
       }
-      expect(@client).to receive(:rest_put).with("#{item['uri']}/port-monitor", update_options, item.api_version)
+      expect(@client_200).to receive(:rest_put).with("#{item['uri']}/port-monitor", update_options, item.api_version)
         .and_return(true)
-      expect(@client).to receive(:response_handler).and_return(enablePortMonitor: true)
+      expect(@client_200).to receive(:response_handler).and_return(enablePortMonitor: true)
       expect { item.update_port_monitor }.to_not raise_error
       expect(item['enablePortMonitor']).to be true
     end
@@ -200,20 +200,20 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#update_qos_configuration' do
     it 'raises exception when is not passed the qosConfiguration' do
-      item = OneviewSDK::LogicalInterconnect.new(@client, uri: 'rest/fake')
+      item = OneviewSDK::LogicalInterconnect.new(@client_200, uri: 'rest/fake')
       expect { item.update_qos_configuration }
         .to raise_error(OneviewSDK::IncompleteResource, /Please retrieve the Logical Interconnect before trying to update/)
     end
 
     it 'updates QoS aggregated configuration' do
-      item = OneviewSDK::LogicalInterconnect.new(@client, uri: 'rest/fake', qosConfiguration: { type: 'qos-aggregated-configuration' })
+      item = OneviewSDK::LogicalInterconnect.new(@client_200, uri: 'rest/fake', qosConfiguration: { type: 'qos-aggregated-configuration' })
       update_options = {
         'If-Match' =>  item['qosConfiguration'].delete('eTag'),
         'body' => item['qosConfiguration']
       }
-      expect(@client).to receive(:rest_put).with("#{item['uri']}/qos-aggregated-configuration", update_options, item.api_version)
+      expect(@client_200).to receive(:rest_put).with("#{item['uri']}/qos-aggregated-configuration", update_options, item.api_version)
         .and_return(true)
-      expect(@client).to receive(:response_handler).and_return('activeQosConfig' => { 'type' => 'QosConfiguration' })
+      expect(@client_200).to receive(:response_handler).and_return('activeQosConfig' => { 'type' => 'QosConfiguration' })
       expect { item.update_qos_configuration }.to_not raise_error
       expect(item['activeQosConfig']['type']).to eq('QosConfiguration')
     end
@@ -221,20 +221,24 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#update_telemetry_configuration' do
     it 'raises exception when is not passed the telemetryConfiguration' do
-      item = OneviewSDK::LogicalInterconnect.new(@client, uri: 'rest/fake')
+      item = OneviewSDK::LogicalInterconnect.new(@client_200, uri: 'rest/fake')
       expect { item.update_telemetry_configuration }
         .to raise_error(OneviewSDK::IncompleteResource, /Please retrieve the Logical Interconnect before trying to update/)
     end
 
     it 'updates telemetry configuration' do
-      item = OneviewSDK::LogicalInterconnect.new(@client, uri: 'rest/fake', telemetryConfiguration: { uri: '/rest/telemetry-configurations/fake' })
+      options = {
+        uri: 'rest/fake',
+        telemetryConfiguration: { uri: '/rest/telemetry-configurations/fake' }
+      }
+      item = OneviewSDK::LogicalInterconnect.new(@client_200, options)
       update_options = {
         'If-Match' =>  item['telemetryConfiguration'].delete('eTag'),
         'body' => item['telemetryConfiguration']
       }
-      expect(@client).to receive(:rest_put).with(item['telemetryConfiguration']['uri'], update_options, item.api_version)
+      expect(@client_200).to receive(:rest_put).with(item['telemetryConfiguration']['uri'], update_options, item.api_version)
         .and_return(true)
-      expect(@client).to receive(:response_handler).and_return('telemetryConfiguration' => { 'sampleCount' => 0 })
+      expect(@client_200).to receive(:response_handler).and_return('telemetryConfiguration' => { 'sampleCount' => 0 })
       expect { item.update_telemetry_configuration }.to_not raise_error
       expect(item['telemetryConfiguration']['sampleCount']).to eq(0)
     end
@@ -271,20 +275,20 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
     end
 
     it 'raises exception when is not passed the snmpConfiguration' do
-      item = OneviewSDK::LogicalInterconnect.new(@client, uri: 'rest/fake')
+      item = OneviewSDK::LogicalInterconnect.new(@client_200, uri: 'rest/fake')
       expect { item.update_snmp_configuration }
         .to raise_error(OneviewSDK::IncompleteResource, /Please retrieve the Logical Interconnect before trying to update/)
     end
 
     it 'updates SNMP Configuration' do
-      item = OneviewSDK::LogicalInterconnect.new(@client, uri: 'rest/fake', snmpConfiguration: { type: 'snmp-configuration' })
+      item = OneviewSDK::LogicalInterconnect.new(@client_200, uri: 'rest/fake', snmpConfiguration: { type: 'snmp-configuration' })
       update_options = {
         'If-Match' =>  item['snmpConfiguration'].delete('eTag'),
         'body' => item['snmpConfiguration']
       }
-      expect(@client).to receive(:rest_put).with("#{item['uri']}/snmp-configuration", update_options, item.api_version)
+      expect(@client_200).to receive(:rest_put).with("#{item['uri']}/snmp-configuration", update_options, item.api_version)
         .and_return(true)
-      expect(@client).to receive(:response_handler).and_return(enabled: true)
+      expect(@client_200).to receive(:response_handler).and_return(enabled: true)
       expect { item.update_snmp_configuration }.to_not raise_error
       expect(item['enabled']).to be true
     end
@@ -292,24 +296,24 @@ RSpec.describe OneviewSDK::LogicalInterconnect do
 
   describe '#get_firmware' do
     it 'requires the uri to be set' do
-      expect { OneviewSDK::LogicalInterconnect.new(@client).get_firmware }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::LogicalInterconnect.new(@client_200).get_firmware }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/firmware & returns the result' do
-      expect(@client).to receive(:rest_get).with(log_int['uri'] + '/firmware').and_return(FakeResponse.new(key: 'val'))
+      expect(@client_200).to receive(:rest_get).with(log_int['uri'] + '/firmware').and_return(FakeResponse.new(key: 'val'))
       expect(log_int.get_firmware).to eq('key' => 'val')
     end
   end
 
   describe '#firmware_update' do
     it 'requires the uri to be set' do
-      expect { OneviewSDK::LogicalInterconnect.new(@client).firmware_update(:cmd, nil, {}) }
+      expect { OneviewSDK::LogicalInterconnect.new(@client_200).firmware_update(:cmd, nil, {}) }
         .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to uri/firmware & returns the result' do
-      expect(@client).to receive(:rest_put).with(log_int['uri'] + '/firmware', Hash).and_return(FakeResponse.new(key: 'val'))
-      driver = OneviewSDK::FirmwareDriver.new(@client, name: 'FW', uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_put).with(log_int['uri'] + '/firmware', Hash).and_return(FakeResponse.new(key: 'val'))
+      driver = OneviewSDK::FirmwareDriver.new(@client_200, name: 'FW', uri: '/rest/fake')
       expect(log_int.firmware_update('cmd', driver, {})).to eq('key' => 'val')
     end
   end

--- a/spec/unit/resource/api200/logical_switch_group_spec.rb
+++ b/spec/unit/resource/api200/logical_switch_group_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::LogicalSwitchGroup do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = OneviewSDK::LogicalSwitchGroup.new(@client)
+      item = OneviewSDK::LogicalSwitchGroup.new(@client_200)
       expect(item['category']).to eq('logical-switch-groups')
       expect(item['state']).to eq('Active')
       expect(item['type']).to eq('logical-switch-group')
@@ -15,12 +15,12 @@ RSpec.describe OneviewSDK::LogicalSwitchGroup do
 
   describe '#set_grouping_parameters' do
     before :each do
-      @item = OneviewSDK::LogicalSwitchGroup.new(@client)
+      @item = OneviewSDK::LogicalSwitchGroup.new(@client_200)
       @type = 'Cisco Nexus 55xx'
     end
 
     it 'defines a valid siwtch group' do
-      expect(OneviewSDK::Switch).to receive(:get_type).with(@client, @type)
+      expect(OneviewSDK::Switch).to receive(:get_type).with(@client_200, @type)
         .and_return('uri' => '/rest/fake')
       @item.set_grouping_parameters(1, @type)
       expect(@item['switchMapTemplate']['switchMapEntryTemplates'].first['permittedSwitchTypeUri'])
@@ -28,7 +28,7 @@ RSpec.describe OneviewSDK::LogicalSwitchGroup do
     end
 
     it 'raises an error if the switch is not found' do
-      expect(OneviewSDK::Switch).to receive(:get_type).with(@client, @type)
+      expect(OneviewSDK::Switch).to receive(:get_type).with(@client_200, @type)
         .and_return([])
       expect(OneviewSDK::Switch).to receive(:get_types).and_return([{ 'name' => '1' }, { 'name' => '2' }])
       expect { @item.set_grouping_parameters(1, @type) }.to raise_error(/not found!/)

--- a/spec/unit/resource/api200/logical_switch_spec.rb
+++ b/spec/unit/resource/api200/logical_switch_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OneviewSDK::LogicalSwitch do
   describe '#initialize' do
     context 'OneView 2.0' do
       it 'sets the defaults correctly' do
-        logical_switch = OneviewSDK::LogicalSwitch.new(@client)
+        logical_switch = OneviewSDK::LogicalSwitch.new(@client_200)
         expect(logical_switch[:type]).to eq('logical-switch')
       end
     end
@@ -40,8 +40,8 @@ RSpec.describe OneviewSDK::LogicalSwitch do
 
   describe '#refresh_state' do
     it 'Refresh logical switch' do
-      item = OneviewSDK::LogicalSwitch.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_put).with("#{item['uri']}/refresh").and_return(FakeResponse.new({}))
+      item = OneviewSDK::LogicalSwitch.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_put).with("#{item['uri']}/refresh").and_return(FakeResponse.new({}))
       item.refresh_state
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe OneviewSDK::LogicalSwitch do
   describe '#set_logical_switch_group' do
     it 'Valid logical switch group' do
       logical_switch_group = { 'uri' => '/rest/fake/logical-switch-groups' }
-      item = OneviewSDK::LogicalSwitch.new(@client)
+      item = OneviewSDK::LogicalSwitch.new(@client_200)
       item.set_logical_switch_group(logical_switch_group)
       expect(item['logicalSwitchGroupUri']).to eq('/rest/fake/logical-switch-groups')
     end
@@ -57,7 +57,7 @@ RSpec.describe OneviewSDK::LogicalSwitch do
 
   describe '#set_switch_credentials' do
     it 'Valid structure and host for SNMPv1' do
-      item = OneviewSDK::LogicalSwitch.new(@client)
+      item = OneviewSDK::LogicalSwitch.new(@client_200)
       ssh_credentials = OneviewSDK::LogicalSwitch::CredentialsSSH.new('ssh_user', 'ssh_password')
       snmp_v1 = OneviewSDK::LogicalSwitch::CredentialsSNMPV1.new(161, 'public')
       item.set_switch_credentials('127.0.0.1', ssh_credentials, snmp_v1)
@@ -66,7 +66,7 @@ RSpec.describe OneviewSDK::LogicalSwitch do
     end
 
     it 'Valid structure and host for SNMPv3' do
-      item = OneviewSDK::LogicalSwitch.new(@client)
+      item = OneviewSDK::LogicalSwitch.new(@client_200)
       ssh_credentials = OneviewSDK::LogicalSwitch::CredentialsSSH.new('ssh_user', 'ssh_password')
       snmp_v3 = OneviewSDK::LogicalSwitch::CredentialsSNMPV3.new(161, 'public', 'MD5', 'auth_password', 'AES128', 'privacy_password')
       item.set_switch_credentials('127.0.0.1', ssh_credentials, snmp_v3)
@@ -75,7 +75,7 @@ RSpec.describe OneviewSDK::LogicalSwitch do
     end
 
     it 'Invalid SSH crendential parameter' do
-      item = OneviewSDK::LogicalSwitch.new(@client)
+      item = OneviewSDK::LogicalSwitch.new(@client_200)
       SSHFake = Struct.new(:user, :password)
       ssh_credentials = SSHFake.new('ssh_user', 'ssh_password')
       snmp_v1 = OneviewSDK::LogicalSwitch::CredentialsSNMPV1.new(161, 'public')
@@ -85,7 +85,7 @@ RSpec.describe OneviewSDK::LogicalSwitch do
     end
 
     it 'Invalid SNMP credential parameter' do
-      item = OneviewSDK::LogicalSwitch.new(@client)
+      item = OneviewSDK::LogicalSwitch.new(@client_200)
       ssh_credentials = OneviewSDK::LogicalSwitch::CredentialsSSH.new('ssh_user', 'ssh_password')
       SNMPFake = Struct.new(:port, :community_string, :version) do
         def version
@@ -101,8 +101,8 @@ RSpec.describe OneviewSDK::LogicalSwitch do
 
   describe '#create' do
     it 'Basic structure' do
-      logical_switch = OneviewSDK::LogicalSwitch.new(@client)
-      expect(@client).to receive(:rest_post).with(
+      logical_switch = OneviewSDK::LogicalSwitch.new(@client_200)
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/logical-switches',
         {
           'body' => {
@@ -119,11 +119,11 @@ RSpec.describe OneviewSDK::LogicalSwitch do
     end
 
     it 'Adding SNMPv1 switch' do
-      logical_switch = OneviewSDK::LogicalSwitch.new(@client)
+      logical_switch = OneviewSDK::LogicalSwitch.new(@client_200)
       ssh_credentials = OneviewSDK::LogicalSwitch::CredentialsSSH.new('ssh_user', 'ssh_password')
       snmp_v1 = OneviewSDK::LogicalSwitch::CredentialsSNMPV1.new(161, 'public')
       logical_switch.set_switch_credentials('127.0.0.1', ssh_credentials, snmp_v1)
-      expect(@client).to receive(:rest_post).with(
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/logical-switches',
         {
           'body' => {
@@ -167,11 +167,11 @@ RSpec.describe OneviewSDK::LogicalSwitch do
     end
 
     it 'Adding SNMPv3 switch' do
-      logical_switch = OneviewSDK::LogicalSwitch.new(@client)
+      logical_switch = OneviewSDK::LogicalSwitch.new(@client_200)
       ssh_credentials = OneviewSDK::LogicalSwitch::CredentialsSSH.new('ssh_user', 'ssh_password')
       snmp_v3 = OneviewSDK::LogicalSwitch::CredentialsSNMPV3.new(161, 'user', 'MD5', 'auth_password', 'AES128', 'privacy_password')
       logical_switch.set_switch_credentials('127.0.0.1', ssh_credentials, snmp_v3)
-      expect(@client).to receive(:rest_post).with(
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/logical-switches',
         {
           'body' => {

--- a/spec/unit/resource/api200/managed_san_spec.rb
+++ b/spec/unit/resource/api200/managed_san_spec.rb
@@ -5,37 +5,37 @@ RSpec.describe OneviewSDK::ManagedSAN do
 
   describe '#create' do
     it 'is unavailable' do
-      san = OneviewSDK::ManagedSAN.new(@client)
+      san = OneviewSDK::ManagedSAN.new(@client_200)
       expect { san.create }.to raise_error(/The method #create is unavailable for this resource/)
     end
   end
 
   describe '#delete' do
     it 'is unavailable' do
-      san = OneviewSDK::ManagedSAN.new(@client)
+      san = OneviewSDK::ManagedSAN.new(@client_200)
       expect { san.delete }.to raise_error(/The method #delete is unavailable for this resource/)
     end
   end
 
   describe '#update' do
     it 'is unavailable' do
-      san = OneviewSDK::ManagedSAN.new(@client)
+      san = OneviewSDK::ManagedSAN.new(@client_200)
       expect { san.update }.to raise_error(/The method #update is unavailable for this resource/)
     end
   end
 
   describe '#get_endpoints' do
     it 'List endpoints' do
-      san = OneviewSDK::ManagedSAN.new(@client, uri: '/rest/fc-sans/managed-sans/100')
-      expect(@client).to receive(:rest_get).with('/rest/fc-sans/managed-sans/100/endpoints').and_return(FakeResponse.new({}))
+      san = OneviewSDK::ManagedSAN.new(@client_200, uri: '/rest/fc-sans/managed-sans/100')
+      expect(@client_200).to receive(:rest_get).with('/rest/fc-sans/managed-sans/100/endpoints').and_return(FakeResponse.new({}))
       expect { san.get_endpoints }.not_to raise_error
     end
   end
 
   describe '#set_refresh_state' do
     it 'Refresh managed SAN' do
-      san = OneviewSDK::ManagedSAN.new(@client, uri: '/rest/fc-sans/managed-sans/100')
-      expect(@client).to receive(:rest_put).with(
+      san = OneviewSDK::ManagedSAN.new(@client_200, uri: '/rest/fc-sans/managed-sans/100')
+      expect(@client_200).to receive(:rest_put).with(
         '/rest/fc-sans/managed-sans/100',
         'body' => { refreshState: 'RefreshPending' }
       ).and_return(FakeResponse.new({}))
@@ -53,8 +53,8 @@ RSpec.describe OneviewSDK::ManagedSAN do
           valueFormat: 'None'
         }
       ]
-      san = OneviewSDK::ManagedSAN.new(@client, uri: '/rest/fc-sans/managed-sans/100')
-      expect(@client).to receive(:rest_put).with(
+      san = OneviewSDK::ManagedSAN.new(@client_200, uri: '/rest/fc-sans/managed-sans/100')
+      expect(@client_200).to receive(:rest_put).with(
         '/rest/fc-sans/managed-sans/100',
         'body' => { publicAttributes: attributes }
       ).and_return(FakeResponse.new({}))
@@ -72,8 +72,8 @@ RSpec.describe OneviewSDK::ManagedSAN do
         targetNameFormat: '{storageSystemName}_{targetName}',
         targetGroupNameFormat: '{storageSystemName}_{targetGroupName}'
       }
-      san = OneviewSDK::ManagedSAN.new(@client, uri: '/rest/fc-sans/managed-sans/100')
-      expect(@client).to receive(:rest_put).with(
+      san = OneviewSDK::ManagedSAN.new(@client_200, uri: '/rest/fc-sans/managed-sans/100')
+      expect(@client_200).to receive(:rest_put).with(
         '/rest/fc-sans/managed-sans/100',
         'body' => { sanPolicy: policy }
       ).and_return(FakeResponse.new({}))
@@ -83,8 +83,8 @@ RSpec.describe OneviewSDK::ManagedSAN do
 
   describe '#get_zoning_report' do
     it 'Retrieve zoning report' do
-      san = OneviewSDK::ManagedSAN.new(@client, uri: '/rest/fc-sans/managed-sans/100')
-      expect(@client).to receive(:rest_post).with(
+      san = OneviewSDK::ManagedSAN.new(@client_200, uri: '/rest/fc-sans/managed-sans/100')
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/fc-sans/managed-sans/100/issues',
         'body' => {}
       ).and_return(FakeResponse.new({}))

--- a/spec/unit/resource/api200/network_set_spec.rb
+++ b/spec/unit/resource/api200/network_set_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::NetworkSet do
 
   describe '#initialize' do
     it 'sets the defaults correctly api_ver 200' do
-      item = OneviewSDK::NetworkSet.new(@client, {}, 200)
+      item = OneviewSDK::NetworkSet.new(@client_200, {}, 200)
       expect(item['connectionTemplateUri']).to eq(nil)
       expect(item['nativeNetworkUri']).to eq(nil)
       expect(item['networkUris']).to eq([])
@@ -15,8 +15,8 @@ RSpec.describe OneviewSDK::NetworkSet do
 
   describe '#set_native_network' do
     it 'sets native network for network set' do
-      eth1 = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/ethernet-networks/eth1')
-      item = OneviewSDK::NetworkSet.new(@client, {}, 200)
+      eth1 = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/eth1')
+      item = OneviewSDK::NetworkSet.new(@client_200, {}, 200)
       item.set_native_network(eth1)
       expect(item['nativeNetworkUri']).to eq(eth1['uri'])
     end
@@ -24,16 +24,16 @@ RSpec.describe OneviewSDK::NetworkSet do
 
   describe '#add_ethernet_network' do
     it 'add ethernet network to network set' do
-      eth1 = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/ethernet-networks/eth1')
-      item = OneviewSDK::NetworkSet.new(@client, {}, 200)
+      eth1 = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/eth1')
+      item = OneviewSDK::NetworkSet.new(@client_200, {}, 200)
       item.add_ethernet_network(eth1)
       expect(item['networkUris']).to include(eth1['uri'])
     end
 
     it 'add multiple ethernet networks to network set' do
-      eth1 = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/ethernet-networks/eth1')
-      eth2 = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/ethernet-networks/eth2')
-      item = OneviewSDK::NetworkSet.new(@client, {}, 200)
+      eth1 = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/eth1')
+      eth2 = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/eth2')
+      item = OneviewSDK::NetworkSet.new(@client_200, {}, 200)
       item.add_ethernet_network(eth1)
       item.add_ethernet_network(eth2)
       expect(item['networkUris']).to include(eth1['uri'])
@@ -43,8 +43,8 @@ RSpec.describe OneviewSDK::NetworkSet do
 
   describe '#remove_ethernet_network' do
     it 'remove ethernet network from network set' do
-      eth1 = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/ethernet-networks/eth1')
-      item = OneviewSDK::NetworkSet.new(@client, {}, 200)
+      eth1 = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/eth1')
+      item = OneviewSDK::NetworkSet.new(@client_200, {}, 200)
       item.add_ethernet_network(eth1)
       expect(item['networkUris']).to include(eth1['uri'])
       item.remove_ethernet_network(eth1)
@@ -52,9 +52,9 @@ RSpec.describe OneviewSDK::NetworkSet do
     end
 
     it 'remove multiple ethernet networks from network set' do
-      eth1 = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/ethernet-networks/eth1')
-      eth2 = OneviewSDK::EthernetNetwork.new(@client, uri: '/rest/ethernet-networks/eth2')
-      item = OneviewSDK::NetworkSet.new(@client, {}, 200)
+      eth1 = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/eth1')
+      eth2 = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/eth2')
+      item = OneviewSDK::NetworkSet.new(@client_200, {}, 200)
       item.add_ethernet_network(eth1)
       item.add_ethernet_network(eth2)
       expect(item['networkUris']).to include(eth1['uri'])
@@ -72,14 +72,14 @@ RSpec.describe OneviewSDK::NetworkSet do
 
   describe '#get_without_ethernet' do
     it 'instance get network set without ethernet' do
-      item = OneviewSDK::NetworkSet.new(@client, uri: '/rest/network-sets/nset1')
-      expect(@client).to receive(:rest_get).with('/rest/network-sets/nset1/withoutEthernet').and_return(FakeResponse.new({}))
+      item = OneviewSDK::NetworkSet.new(@client_200, uri: '/rest/network-sets/nset1')
+      expect(@client_200).to receive(:rest_get).with('/rest/network-sets/nset1/withoutEthernet').and_return(FakeResponse.new({}))
       item.get_without_ethernet
     end
 
     it 'class get network set without ethernet' do
-      expect(@client).to receive(:rest_get).with('/rest/network-sets/withoutEthernet').and_return(FakeResponse.new({}))
-      OneviewSDK::NetworkSet.get_without_ethernet(@client)
+      expect(@client_200).to receive(:rest_get).with('/rest/network-sets/withoutEthernet').and_return(FakeResponse.new({}))
+      OneviewSDK::NetworkSet.get_without_ethernet(@client_200)
     end
   end
 end

--- a/spec/unit/resource/api200/power_device_spec.rb
+++ b/spec/unit/resource/api200/power_device_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OneviewSDK::PowerDevice do
   include_context 'shared context'
 
   before :each do
-    @item = OneviewSDK::PowerDevice.new(@client, uri: '/rest/fake')
+    @item = OneviewSDK::PowerDevice.new(@client_200, uri: '/rest/fake')
   end
 
   describe '#initialize' do
@@ -74,7 +74,7 @@ RSpec.describe OneviewSDK::PowerDevice do
 
   describe '#add' do
     it 'Should support add' do
-      power_device = OneviewSDK::PowerDevice.new(@client, name: 'power_device', ratedCapacity: 500)
+      power_device = OneviewSDK::PowerDevice.new(@client_200, name: 'power_device', ratedCapacity: 500)
       expected_request_body = {
         'name' => 'power_device',
         'ratedCapacity' => 500,
@@ -82,7 +82,7 @@ RSpec.describe OneviewSDK::PowerDevice do
         'phaseType' => 'Unknown',
         'powerConnections' => []
       }
-      expect(@client).to receive(:rest_post).with('/rest/power-devices', { 'body' => expected_request_body }, 200)
+      expect(@client_200).to receive(:rest_post).with('/rest/power-devices', { 'body' => expected_request_body }, 200)
         .and_return(FakeResponse.new({}))
       power_device.add
     end
@@ -90,22 +90,22 @@ RSpec.describe OneviewSDK::PowerDevice do
 
   describe '#remove' do
     it 'Should support remove' do
-      power_device = OneviewSDK::PowerDevice.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_delete).with('/rest/fake', {}, 200).and_return(FakeResponse.new({}))
+      power_device = OneviewSDK::PowerDevice.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_delete).with('/rest/fake', {}, 200).and_return(FakeResponse.new({}))
       power_device.remove
     end
   end
 
   describe '#create' do
     it 'Should raise error if used' do
-      power_device = OneviewSDK::PowerDevice.new(@client)
+      power_device = OneviewSDK::PowerDevice.new(@client_200)
       expect { power_device.create }.to raise_error(OneviewSDK::MethodUnavailable)
     end
   end
 
   describe '#delete' do
     it 'Should raise error if used' do
-      power_device = OneviewSDK::PowerDevice.new(@client)
+      power_device = OneviewSDK::PowerDevice.new(@client_200)
       expect { power_device.delete }.to raise_error(OneviewSDK::MethodUnavailable)
     end
   end
@@ -118,15 +118,15 @@ RSpec.describe OneviewSDK::PowerDevice do
         password: 'pass',
         hostname: '/rest/fake'
       }
-      expect(@client).to receive(:rest_post).with('/rest/power-devices/discover', 'body' => options)
+      expect(@client_200).to receive(:rest_post).with('/rest/power-devices/discover', 'body' => options)
         .and_return(FakeResponse.new({}))
-      expect { OneviewSDK::PowerDevice.discover(@client, options) }.not_to raise_error
+      expect { OneviewSDK::PowerDevice.discover(@client_200, options) }.not_to raise_error
     end
   end
 
   describe '#get_power_state' do
     it 'powerState' do
-      expect(@client).to receive(:rest_get).with('/rest/fake/powerState')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/powerState')
         .and_return(FakeResponse.new({}))
       expect { @item.get_power_state }.not_to raise_error
     end
@@ -134,7 +134,7 @@ RSpec.describe OneviewSDK::PowerDevice do
 
   describe '#set_power_state' do
     it 'On|Off state given' do
-      expect(@client).to receive(:rest_put).with('/rest/fake/powerState', 'body' => { powerState: 'On' })
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/powerState', 'body' => { powerState: 'On' })
         .and_return(FakeResponse.new({}))
       expect { @item.set_power_state('On') }.not_to raise_error
     end
@@ -142,14 +142,14 @@ RSpec.describe OneviewSDK::PowerDevice do
 
   describe '#set_refresh_state' do
     it 'Refresh without changing username and password' do
-      expect(@client).to receive(:rest_put).with('/rest/fake/refreshState', 'body' => { refreshState: 'RefreshPending' })
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/refreshState', 'body' => { refreshState: 'RefreshPending' })
         .and_return(FakeResponse.new({}))
       expect { @item.set_refresh_state(refreshState: 'RefreshPending') }.not_to raise_error
     end
 
     it 'Refresh providing username/password' do
       options = { refreshState: 'RefreshPending', username: 'user', password: 'pass' }
-      expect(@client).to receive(:rest_put).with('/rest/fake/refreshState', 'body' => options)
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/refreshState', 'body' => options)
         .and_return(FakeResponse.new({}))
       expect { @item.set_refresh_state(refreshState: 'RefreshPending', username: 'user', password: 'pass') }.not_to raise_error
     end
@@ -157,7 +157,7 @@ RSpec.describe OneviewSDK::PowerDevice do
 
   describe '#get_uid_state' do
     it 'uidState' do
-      expect(@client).to receive(:rest_get).with('/rest/fake/uidState')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/uidState')
         .and_return(FakeResponse.new({}))
       expect { @item.get_uid_state }.not_to raise_error
     end
@@ -165,7 +165,7 @@ RSpec.describe OneviewSDK::PowerDevice do
 
   describe '#set_uid_state' do
     it 'On|Off state' do
-      expect(@client).to receive(:rest_put).with('/rest/fake/uidState', 'body' => { uidState: 'On' })
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/uidState', 'body' => { uidState: 'On' })
         .and_return(FakeResponse.new({}))
       expect { @item.set_uid_state('On') }.not_to raise_error
     end
@@ -173,29 +173,29 @@ RSpec.describe OneviewSDK::PowerDevice do
 
   describe '#utilization' do
     it 'requires a uri' do
-      expect { OneviewSDK::PowerDevice.new(@client).utilization }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::PowerDevice.new(@client_200).utilization }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/utilization' do
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization', @item.api_version).and_return(FakeResponse.new(key: 'val'))
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization', @item.api_version).and_return(FakeResponse.new(key: 'val'))
       expect(@item.utilization).to eq('key' => 'val')
     end
 
     it 'takes query parameters' do
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization?key=val', @item.api_version)
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization?key=val', @item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(@item.utilization(key: :val)).to eq('key' => 'val')
     end
 
     it 'takes an array for the :fields query parameter' do
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization?fields=one,two,three', @item.api_version)
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization?fields=one,two,three', @item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(@item.utilization(fields: %w(one two three))).to eq('key' => 'val')
     end
 
     it 'converts Time query parameters' do
       t = Time.now
-      expect(@client).to receive(:rest_get).with("/rest/fake/utilization?filter=startDate=#{t.utc.iso8601(3)}", @item.api_version)
+      expect(@client_200).to receive(:rest_get).with("/rest/fake/utilization?filter=startDate=#{t.utc.iso8601(3)}", @item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(@item.utilization(startDate: t)).to eq('key' => 'val')
     end

--- a/spec/unit/resource/api200/rack_spec.rb
+++ b/spec/unit/resource/api200/rack_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OneviewSDK::Rack do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      rack = OneviewSDK::Rack.new(@client)
+      rack = OneviewSDK::Rack.new(@client_200)
       expect(rack['rackMounts']).to eq([])
     end
   end
@@ -27,22 +27,22 @@ RSpec.describe OneviewSDK::Rack do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'retrieves by name' do
-      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
-      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client_200, name: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by uri' do
-      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
-      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client_200, uri: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').retrieve!).to be false
     end
   end
 
@@ -52,29 +52,29 @@ RSpec.describe OneviewSDK::Rack do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'finds it by name' do
-      expect(described_class.new(@client, name: 'name1').exists?).to be true
-      expect(described_class.new(@client, name: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, name: 'name1').exists?).to be true
+      expect(described_class.new(@client_200, name: 'fake').exists?).to be false
     end
 
     it 'finds it by uri' do
-      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
-      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client_200, uri: 'fake').exists?).to be false
     end
 
     it 'finds it by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').exists?).to be false
     end
   end
 
   describe '#add' do
     it 'Should support add' do
-      rack = OneviewSDK::Rack.new(@client, uri: '/rest/racks')
-      expect(@client).to receive(:rest_post).with('/rest/racks', { 'body' => { 'uri' => '/rest/racks', 'rackMounts' => [] } }, 200)
+      rack = OneviewSDK::Rack.new(@client_200, uri: '/rest/racks')
+      expect(@client_200).to receive(:rest_post).with('/rest/racks', { 'body' => { 'uri' => '/rest/racks', 'rackMounts' => [] } }, 200)
         .and_return(FakeResponse.new({}))
       rack.add
     end
@@ -82,26 +82,26 @@ RSpec.describe OneviewSDK::Rack do
 
   describe '#remove' do
     it 'Should support remove' do
-      rack = OneviewSDK::Rack.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_delete).with('/rest/fake', {}, 200).and_return(FakeResponse.new({}))
+      rack = OneviewSDK::Rack.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_delete).with('/rest/fake', {}, 200).and_return(FakeResponse.new({}))
       rack.remove
     end
   end
 
   describe '#add_rack_resource' do
     before :each do
-      @rack = OneviewSDK::Rack.new(@client)
+      @rack = OneviewSDK::Rack.new(@client_200)
     end
 
     it 'Add one resource' do
-      enclosure1 = OneviewSDK::Enclosure.new(@client, uri: '/rest/enclosures/fake')
+      enclosure1 = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/enclosures/fake')
       @rack.add_rack_resource(enclosure1)
       expect(@rack['rackMounts'].first['mountUri']).to eq(enclosure1['uri'])
       expect(@rack['rackMounts'].first['location']).to eq('CenterFront')
     end
 
     it 'Add one resource with options' do
-      enclosure1 = OneviewSDK::Enclosure.new(@client, uri: '/rest/enclosures/fake')
+      enclosure1 = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/enclosures/fake')
       @rack.add_rack_resource(enclosure1, location: 'Left', topUSlot: 20, uHeight: 10)
       expect(@rack['rackMounts'].first['mountUri']).to eq(enclosure1['uri'])
       expect(@rack['rackMounts'].first['location']).to eq('Left')
@@ -110,7 +110,7 @@ RSpec.describe OneviewSDK::Rack do
     end
 
     it 'Add existing resource and update attributes' do
-      enclosure1 = OneviewSDK::Enclosure.new(@client, uri: '/rest/enclosures/fake')
+      enclosure1 = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/enclosures/fake')
       @rack.add_rack_resource(enclosure1, location: 'Left', topUSlot: 20, uHeight: 10)
       expect(@rack['rackMounts'].first['mountUri']).to eq(enclosure1['uri'])
       expect(@rack['rackMounts'].first['location']).to eq('Left')
@@ -128,8 +128,8 @@ RSpec.describe OneviewSDK::Rack do
     end
 
     it 'Add multiple resources' do
-      enclosure1 = OneviewSDK::Enclosure.new(@client, uri: '/rest/enclosures/fake1')
-      enclosure2 = OneviewSDK::Enclosure.new(@client, uri: '/rest/enclosures/fake2')
+      enclosure1 = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/enclosures/fake1')
+      enclosure2 = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/enclosures/fake2')
       @rack.add_rack_resource(enclosure1)
       @rack.add_rack_resource(enclosure2)
 
@@ -142,17 +142,17 @@ RSpec.describe OneviewSDK::Rack do
 
   describe '#remove_rack_resource' do
     before :each do
-      @rack = OneviewSDK::Rack.new(@client)
+      @rack = OneviewSDK::Rack.new(@client_200)
     end
 
     it 'Remove one resource' do
-      enclosure1 = OneviewSDK::Enclosure.new(@client, uri: '/rest/enclosures/fake')
+      enclosure1 = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/enclosures/fake')
       @rack.add_rack_resource(enclosure1)
     end
 
     it 'Remove only one resource' do
-      enclosure1 = OneviewSDK::Enclosure.new(@client, uri: '/rest/enclosures/fake1')
-      enclosure2 = OneviewSDK::Enclosure.new(@client, uri: '/rest/enclosures/fake2')
+      enclosure1 = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/enclosures/fake1')
+      enclosure2 = OneviewSDK::Enclosure.new(@client_200, uri: '/rest/enclosures/fake2')
       @rack.add_rack_resource(enclosure1)
       @rack.add_rack_resource(enclosure2)
       @rack.remove_rack_resource(enclosure2)
@@ -166,22 +166,22 @@ RSpec.describe OneviewSDK::Rack do
 
   describe '#create' do
     it 'Should raise error if used' do
-      rack = OneviewSDK::Rack.new(@client)
+      rack = OneviewSDK::Rack.new(@client_200)
       expect { rack.create }.to raise_error(/The method #create is unavailable for this resource/)
     end
   end
 
   describe '#delete' do
     it 'Should raise error if used' do
-      rack = OneviewSDK::Rack.new(@client)
+      rack = OneviewSDK::Rack.new(@client_200)
       expect { rack.delete }.to raise_error(/The method #delete is unavailable for this resource/)
     end
   end
 
   describe '#get_device_topology' do
     it 'Device topology' do
-      rack = OneviewSDK::Rack.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/deviceTopology').and_return(FakeResponse.new({}))
+      rack = OneviewSDK::Rack.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/deviceTopology').and_return(FakeResponse.new({}))
       rack.get_device_topology
     end
   end

--- a/spec/unit/resource/api200/san_manager_spec.rb
+++ b/spec/unit/resource/api200/san_manager_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OneviewSDK::SANManager do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      san_manager = OneviewSDK::SANManager.new(@client)
+      san_manager = OneviewSDK::SANManager.new(@client_200)
       expect(san_manager['type']).to eq('FCDeviceManagerV2')
     end
   end
@@ -24,12 +24,12 @@ RSpec.describe OneviewSDK::SANManager do
   describe '#add' do
     it 'Should support add' do
       san_manager = OneviewSDK::SANManager.new(
-        @client,
+        @client_200,
         name: 'san_manager_1',
         providerDisplayName: 'Brocade',
         providerUri: '/rest/fc-sans/providers/100'
       )
-      expect(@client).to receive(:rest_post).with(
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/fc-sans/providers/100/device-managers',
         {
           'body' => {
@@ -47,29 +47,29 @@ RSpec.describe OneviewSDK::SANManager do
 
   describe '#remove' do
     it 'Should support remove' do
-      san_manager = OneviewSDK::SANManager.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_delete).with('/rest/fake', {}, 200).and_return(FakeResponse.new({}))
+      san_manager = OneviewSDK::SANManager.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_delete).with('/rest/fake', {}, 200).and_return(FakeResponse.new({}))
       san_manager.remove
     end
   end
 
   describe '#create' do
     it 'Should raise error if used' do
-      san_manager = OneviewSDK::SANManager.new(@client)
+      san_manager = OneviewSDK::SANManager.new(@client_200)
       expect { san_manager.create }.to raise_error(/The method #create is unavailable for this resource/)
     end
   end
 
   describe '#delete' do
     it 'Should raise error if used' do
-      san_manager = OneviewSDK::SANManager.new(@client)
+      san_manager = OneviewSDK::SANManager.new(@client_200)
       expect { san_manager.delete }.to raise_error(/The method #delete is unavailable for this resource/)
     end
   end
 
   describe '#self.get_default_connection_info' do
     it 'Get default connection info' do
-      expect(@client).to receive(:rest_get).with('/rest/fc-sans/providers').and_return(
+      expect(@client_200).to receive(:rest_get).with('/rest/fc-sans/providers').and_return(
         FakeResponse.new(
           'members' => [
             {
@@ -89,7 +89,7 @@ RSpec.describe OneviewSDK::SANManager do
           ]
         )
       )
-      default_connection = OneviewSDK::SANManager.get_default_connection_info(@client, 'FCProvider_01')
+      default_connection = OneviewSDK::SANManager.get_default_connection_info(@client_200, 'FCProvider_01')
       expect(default_connection.first['name']).to eq('Host')
       expect(default_connection.first['value']).to eq('san01.hpe.com')
       expect(default_connection.last['name']).to eq('Username')

--- a/spec/unit/resource/api200/server_hardware_spec.rb
+++ b/spec/unit/resource/api200/server_hardware_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      server_hardware = OneviewSDK::ServerHardware.new(@client)
+      server_hardware = OneviewSDK::ServerHardware.new(@client_200)
       expect(server_hardware[:type]).to eq('server-hardware-4')
     end
   end
@@ -17,38 +17,38 @@ RSpec.describe OneviewSDK::ServerHardware do
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2', virtualSerialNumber: 'vsn2', serverProfileUri: 'sp2' },
         { name: 'name3', uri: 'uri2', mpHostInfo: { 'mpHostName' => 'h1' } }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'retrieves by name' do
-      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
-      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client_200, name: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by uri' do
-      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
-      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client_200, uri: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by virtualSerialNumber' do
-      expect(described_class.new(@client, virtualSerialNumber: 'vsn1').retrieve!).to be true
-      expect(described_class.new(@client, virtualSerialNumber: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, virtualSerialNumber: 'vsn1').retrieve!).to be true
+      expect(described_class.new(@client_200, virtualSerialNumber: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serverProfileUri' do
-      expect(described_class.new(@client, serverProfileUri: 'sp1').retrieve!).to be true
-      expect(described_class.new(@client, serverProfileUri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serverProfileUri: 'sp1').retrieve!).to be true
+      expect(described_class.new(@client_200, serverProfileUri: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by hostname' do
-      expect(described_class.new(@client, hostname: 'h1').retrieve!).to be true
-      expect(described_class.new(@client, mpHostInfo: { 'mpHostName' => 'h1' }).retrieve!).to be true
-      expect(described_class.new(@client, hostname: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, hostname: 'h1').retrieve!).to be true
+      expect(described_class.new(@client_200, mpHostInfo: { 'mpHostName' => 'h1' }).retrieve!).to be true
+      expect(described_class.new(@client_200, hostname: 'fake').retrieve!).to be false
     end
   end
 
@@ -59,45 +59,45 @@ RSpec.describe OneviewSDK::ServerHardware do
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2', virtualSerialNumber: 'vsn2', serverProfileUri: 'sp2' },
         { name: 'name3', uri: 'uri2', mpHostInfo: { 'mpHostName' => 'h1' } }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'finds it by name' do
-      expect(described_class.new(@client, name: 'name1').exists?).to be true
-      expect(described_class.new(@client, name: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, name: 'name1').exists?).to be true
+      expect(described_class.new(@client_200, name: 'fake').exists?).to be false
     end
 
     it 'finds it by uri' do
-      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
-      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client_200, uri: 'fake').exists?).to be false
     end
 
     it 'finds it by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').exists?).to be false
     end
 
     it 'finds it by virtualSerialNumber' do
-      expect(described_class.new(@client, virtualSerialNumber: 'vsn1').exists?).to be true
-      expect(described_class.new(@client, virtualSerialNumber: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, virtualSerialNumber: 'vsn1').exists?).to be true
+      expect(described_class.new(@client_200, virtualSerialNumber: 'fake').exists?).to be false
     end
 
     it 'finds it by serverProfileUri' do
-      expect(described_class.new(@client, serverProfileUri: 'sp1').exists?).to be true
-      expect(described_class.new(@client, serverProfileUri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serverProfileUri: 'sp1').exists?).to be true
+      expect(described_class.new(@client_200, serverProfileUri: 'fake').exists?).to be false
     end
 
     it 'finds it by hostname' do
-      expect(described_class.new(@client, hostname: 'h1').exists?).to be true
-      expect(described_class.new(@client, mpHostInfo: { 'mpHostName' => 'h1' }).exists?).to be true
-      expect(described_class.new(@client, hostname: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, hostname: 'h1').exists?).to be true
+      expect(described_class.new(@client_200, mpHostInfo: { 'mpHostName' => 'h1' }).exists?).to be true
+      expect(described_class.new(@client_200, hostname: 'fake').exists?).to be false
     end
   end
 
   describe '#update_ilo_firmware' do
     it '' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/mpFirmwareVersion')
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/mpFirmwareVersion')
         .and_return(FakeResponse.new({}))
       item.update_ilo_firmware
     end
@@ -105,8 +105,8 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#get_bios' do
     it '' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with(item['uri'] + '/bios')
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with(item['uri'] + '/bios')
         .and_return(FakeResponse.new({}))
       item.get_bios
     end
@@ -114,8 +114,8 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#get_remote_console_url' do
     it '' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with(item['uri'] + '/remoteConsoleUrl')
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with(item['uri'] + '/remoteConsoleUrl')
         .and_return(FakeResponse.new({}))
       item.get_remote_console_url
     end
@@ -123,8 +123,8 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#get_ilo_sso_url' do
     it '' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with(item['uri'] + '/iloSsoUrl')
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with(item['uri'] + '/iloSsoUrl')
         .and_return(FakeResponse.new({}))
       item.get_ilo_sso_url
     end
@@ -132,8 +132,8 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#get_java_remote_sso_url' do
     it '' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with(item['uri'] + '/javaRemoteConsoleUrl')
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with(item['uri'] + '/javaRemoteConsoleUrl')
         .and_return(FakeResponse.new({}))
       item.get_java_remote_sso_url
     end
@@ -141,20 +141,21 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#set_refresh_state' do
     it 'requires a uri' do
-      expect { OneviewSDK::ServerHardware.new(@client).set_refresh_state(:state) }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::ServerHardware.new(@client_200).set_refresh_state(:state) }
+        .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'does a PUT to /refreshState' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake', refreshState: 'NotRefreshing')
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/refreshState', Hash, item.api_version)
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake', refreshState: 'NotRefreshing')
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/refreshState', Hash, item.api_version)
         .and_return(FakeResponse.new(refreshState: 'Refreshing'))
       item.set_refresh_state('Refreshing')
       expect(item['refreshState']).to eq('Refreshing')
     end
 
     it 'allows string or symbol refreshState values' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake', refreshState: 'NotRefreshing')
-      expect(@client).to receive(:rest_put).with(item['uri'] + '/refreshState', Hash, item.api_version)
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake', refreshState: 'NotRefreshing')
+      expect(@client_200).to receive(:rest_put).with(item['uri'] + '/refreshState', Hash, item.api_version)
         .and_return(FakeResponse.new(refreshState: 'Refreshing'))
       item.set_refresh_state(:Refreshing)
       expect(item['refreshState']).to eq('Refreshing')
@@ -163,45 +164,47 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#environmentalConfiguration' do
     it 'requires a uri' do
-      expect { OneviewSDK::ServerHardware.new(@client).environmental_configuration }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::ServerHardware.new(@client_200).environmental_configuration }
+        .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/environmentalConfiguration' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/environmentalConfiguration', item.api_version).and_return(FakeResponse.new(key: 'val'))
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/environmentalConfiguration', item.api_version)
+        .and_return(FakeResponse.new(key: 'val'))
       expect(item.environmental_configuration).to eq('key' => 'val')
     end
   end
 
   describe '#utilization' do
     it 'requires a uri' do
-      expect { OneviewSDK::ServerHardware.new(@client).utilization }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::ServerHardware.new(@client_200).utilization }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/utilization' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization', item.api_version).and_return(FakeResponse.new(key: 'val'))
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization', item.api_version).and_return(FakeResponse.new(key: 'val'))
       expect(item.utilization).to eq('key' => 'val')
     end
 
     it 'takes query parameters' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization?key=val', item.api_version)
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization?key=val', item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(item.utilization(key: :val)).to eq('key' => 'val')
     end
 
     it 'takes an array for the :fields query parameter' do
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/utilization?fields=one,two,three', item.api_version)
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/utilization?fields=one,two,three', item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(item.utilization(fields: %w(one two three))).to eq('key' => 'val')
     end
 
     it 'converts Time query parameters' do
       t = Time.now
-      item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with("/rest/fake/utilization?filter=startDate=#{t.utc.iso8601(3)}", item.api_version)
+      item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with("/rest/fake/utilization?filter=startDate=#{t.utc.iso8601(3)}", item.api_version)
         .and_return(FakeResponse.new(key: 'val'))
       expect(item.utilization(startDate: t)).to eq('key' => 'val')
     end
@@ -222,19 +225,19 @@ RSpec.describe OneviewSDK::ServerHardware do
           'force' => true,
           'other' => 'blah'
         }
-        @server_hardware = OneviewSDK::ServerHardware.new(@client, @data)
+        @server_hardware = OneviewSDK::ServerHardware.new(@client_200, @data)
       end
 
       it 'only sends certain attributes on the POST' do
         data = @data.select { |k, _v| k != 'other' }
-        expect(@client).to receive(:rest_post).with('/rest/server-hardware', { 'body' => data }, anything)
+        expect(@client_200).to receive(:rest_post).with('/rest/server-hardware', { 'body' => data }, anything)
         @server_hardware.add
       end
     end
 
     context 'with invalid data' do
       it 'fails when certain attributes are not set' do
-        server_hardware = OneviewSDK::ServerHardware.new(@client, {})
+        server_hardware = OneviewSDK::ServerHardware.new(@client_200, {})
         expect { server_hardware.add }.to raise_error(OneviewSDK::IncompleteResource, /Missing required attribute/)
       end
     end
@@ -242,13 +245,13 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#power_on' do
     it 'calls #set_power_state' do
-      item = OneviewSDK::ServerHardware.new(@client)
+      item = OneviewSDK::ServerHardware.new(@client_200)
       expect(item).to receive(:set_power_state).with('on', false).and_return(true)
       item.power_on
     end
 
     it 'passes the force value' do
-      item = OneviewSDK::ServerHardware.new(@client)
+      item = OneviewSDK::ServerHardware.new(@client_200)
       expect(item).to receive(:set_power_state).with('on', true).and_return(true)
       item.power_on(true)
     end
@@ -256,13 +259,13 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#power_off' do
     it 'calls #set_power_state' do
-      item = OneviewSDK::ServerHardware.new(@client)
+      item = OneviewSDK::ServerHardware.new(@client_200)
       expect(item).to receive(:set_power_state).with('off', false).and_return(true)
       item.power_off
     end
 
     it 'passes the force value' do
-      item = OneviewSDK::ServerHardware.new(@client)
+      item = OneviewSDK::ServerHardware.new(@client_200)
       expect(item).to receive(:set_power_state).with('off', true).and_return(true)
       item.power_off(true)
     end
@@ -270,8 +273,8 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe '#set_power_state' do
     before :each do
-      @item = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake', powerState: 'on')
-      @item2 = OneviewSDK::ServerHardware.new(@client, uri: '/rest/fake', powerState: 'off')
+      @item = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake', powerState: 'on')
+      @item2 = OneviewSDK::ServerHardware.new(@client_200, uri: '/rest/fake', powerState: 'off')
       allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:refresh).and_return(true)
     end
 
@@ -281,7 +284,7 @@ RSpec.describe OneviewSDK::ServerHardware do
     end
 
     it 'does a PUT to uri/powerState and updates @data' do
-      expect(@client).to receive(:rest_put).with(@item['uri'] + '/powerState', 'body' => { powerState: 'Off', powerControl: 'MomentaryPress' })
+      expect(@client_200).to receive(:rest_put).with(@item['uri'] + '/powerState', 'body' => { powerState: 'Off', powerControl: 'MomentaryPress' })
         .and_return(FakeResponse.new(powerState: 'Off'))
       expect(@item.power_off).to eq(true)
       expect(@item['powerState']).to eq('Off')
@@ -289,7 +292,7 @@ RSpec.describe OneviewSDK::ServerHardware do
 
     it 'powering on does a ColdBoot for servers in an Unknown state' do
       @item['powerState'] = 'Unknown'
-      expect(@client).to receive(:rest_put).with(@item['uri'] + '/powerState', 'body' => { powerState: 'On', powerControl: 'ColdBoot' })
+      expect(@client_200).to receive(:rest_put).with(@item['uri'] + '/powerState', 'body' => { powerState: 'On', powerControl: 'ColdBoot' })
         .and_return(FakeResponse.new(powerState: 'On'))
       expect(@item.power_on).to eq(true)
       expect(@item['powerState']).to eq('On')
@@ -297,7 +300,7 @@ RSpec.describe OneviewSDK::ServerHardware do
 
     it 'powering off does a PressAndHold for servers in an Unknown state' do
       @item['powerState'] = 'Unknown'
-      expect(@client).to receive(:rest_put).with(@item['uri'] + '/powerState', 'body' => { powerState: 'Off', powerControl: 'PressAndHold' })
+      expect(@client_200).to receive(:rest_put).with(@item['uri'] + '/powerState', 'body' => { powerState: 'Off', powerControl: 'PressAndHold' })
         .and_return(FakeResponse.new(powerState: 'Off'))
       expect(@item.power_off).to eq(true)
       expect(@item['powerState']).to eq('Off')
@@ -305,7 +308,7 @@ RSpec.describe OneviewSDK::ServerHardware do
 
     it 'powering off does a PressAndHold for servers in a Resetting state' do
       @item['powerState'] = 'Resetting'
-      expect(@client).to receive(:rest_put).with(@item['uri'] + '/powerState', 'body' => { powerState: 'Off', powerControl: 'PressAndHold' })
+      expect(@client_200).to receive(:rest_put).with(@item['uri'] + '/powerState', 'body' => { powerState: 'Off', powerControl: 'PressAndHold' })
         .and_return(FakeResponse.new(powerState: 'Off'))
       expect(@item.power_off).to eq(true)
       expect(@item['powerState']).to eq('Off')
@@ -315,7 +318,7 @@ RSpec.describe OneviewSDK::ServerHardware do
 
   describe 'undefined methods' do
     it 'does not allow the create action' do
-      server_hardware = OneviewSDK::ServerHardware.new(@client)
+      server_hardware = OneviewSDK::ServerHardware.new(@client_200)
       expect { server_hardware.create }.to raise_error(
         OneviewSDK::MethodUnavailable,
         /The method #create is unavailable for this resource/
@@ -323,7 +326,7 @@ RSpec.describe OneviewSDK::ServerHardware do
     end
 
     it 'does not allow the update action' do
-      server_hardware = OneviewSDK::ServerHardware.new(@client)
+      server_hardware = OneviewSDK::ServerHardware.new(@client_200)
       expect { server_hardware.update }.to raise_error(
         OneviewSDK::MethodUnavailable,
         /The method #update is unavailable for this resource/
@@ -331,7 +334,7 @@ RSpec.describe OneviewSDK::ServerHardware do
     end
 
     it 'does not allow the delete action' do
-      server_hardware = OneviewSDK::ServerHardware.new(@client)
+      server_hardware = OneviewSDK::ServerHardware.new(@client_200)
       expect { server_hardware.delete }.to raise_error(
         OneviewSDK::MethodUnavailable,
         /The method #delete is unavailable for this resource/

--- a/spec/unit/resource/api200/server_hardware_type_spec.rb
+++ b/spec/unit/resource/api200/server_hardware_type_spec.rb
@@ -5,40 +5,40 @@ RSpec.describe OneviewSDK::ServerHardwareType do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = OneviewSDK::ServerHardwareType.new(@client)
+      item = OneviewSDK::ServerHardwareType.new(@client_200)
       expect(item[:type]).to eq('server-hardware-type-4')
     end
   end
 
   describe '#update' do
     it 'requires a uri' do
-      expect { OneviewSDK::ServerHardwareType.new(@client).update }.to raise_error(/Please set uri/)
+      expect { OneviewSDK::ServerHardwareType.new(@client_200).update }.to raise_error(/Please set uri/)
     end
 
     it 'only includes the name and description in the PUT' do
-      item = OneviewSDK::ServerHardwareType.new(@client, uri: '/rest/fake', name: 'Name', description: 'Desc', key: 'Val')
+      item = OneviewSDK::ServerHardwareType.new(@client_200, uri: '/rest/fake', name: 'Name', description: 'Desc', key: 'Val')
       data = { 'body' => { 'name' => 'Name', 'description' => 'Desc' } }
-      expect(@client).to receive(:rest_put).with('/rest/fake', data, item.api_version).and_return(FakeResponse.new)
+      expect(@client_200).to receive(:rest_put).with('/rest/fake', data, item.api_version).and_return(FakeResponse.new)
       item.update
     end
   end
 
   describe '#remove' do
     it 'removes server hardware type' do
-      item = OneviewSDK::ServerHardwareType.new(@client, uri: '/rest/server-hardware-types/100')
-      expect(@client).to receive(:rest_delete).with('/rest/server-hardware-types/100', {}, item.api_version).and_return(FakeResponse.new)
+      item = OneviewSDK::ServerHardwareType.new(@client_200, uri: '/rest/server-hardware-types/100')
+      expect(@client_200).to receive(:rest_delete).with('/rest/server-hardware-types/100', {}, item.api_version).and_return(FakeResponse.new)
       item.remove
     end
   end
 
   describe 'undefined methods' do
     it 'does not allow the create action' do
-      server_hardware_type = OneviewSDK::ServerHardwareType.new(@client)
+      server_hardware_type = OneviewSDK::ServerHardwareType.new(@client_200)
       expect { server_hardware_type.create }.to raise_error(OneviewSDK::MethodUnavailable, /The method #create is unavailable for this resource/)
     end
 
     it 'does not allow the delete action' do
-      server_hardware_type = OneviewSDK::ServerHardwareType.new(@client)
+      server_hardware_type = OneviewSDK::ServerHardwareType.new(@client_200)
       expect { server_hardware_type.delete }.to raise_error(OneviewSDK::MethodUnavailable, /The method #delete is unavailable for this resource/)
     end
   end

--- a/spec/unit/resource/api200/server_profile_spec.rb
+++ b/spec/unit/resource/api200/server_profile_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe OneviewSDK::ServerProfile do
   include_context 'shared context'
 
   before :each do
-    @item = described_class.new(@client, name: 'unit_server_profile', uri: 'rest/server-profiles/fake')
+    @item = described_class.new(@client_200, name: 'unit_server_profile', uri: 'rest/server-profiles/fake')
   end
 
   describe '#initialize' do
     it 'sets the type correctly' do
-      profile = OneviewSDK::ServerProfile.new(@client)
+      profile = OneviewSDK::ServerProfile.new(@client_200)
       expect(profile[:type]).to eq('ServerProfileV5')
     end
   end
@@ -20,32 +20,32 @@ RSpec.describe OneviewSDK::ServerProfile do
         { name: 'name1', uri: 'uri1', associatedServer: 'as1', serialNumber: 'sn1', serverHardwareUri: 'sh1' },
         { name: 'name2', uri: 'uri2', associatedServer: 'as2', serialNumber: 'sn2', serverHardwareUri: 'sh2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'retrieves by name' do
-      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
-      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client_200, name: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by uri' do
-      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
-      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client_200, uri: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by associatedServer' do
-      expect(described_class.new(@client, associatedServer: 'as1').retrieve!).to be true
-      expect(described_class.new(@client, associatedServer: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, associatedServer: 'as1').retrieve!).to be true
+      expect(described_class.new(@client_200, associatedServer: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serverHardwareUri' do
-      expect(described_class.new(@client, serverHardwareUri: 'sh1').retrieve!).to be true
-      expect(described_class.new(@client, serverHardwareUri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serverHardwareUri: 'sh1').retrieve!).to be true
+      expect(described_class.new(@client_200, serverHardwareUri: 'fake').retrieve!).to be false
     end
   end
 
@@ -55,38 +55,38 @@ RSpec.describe OneviewSDK::ServerProfile do
         { name: 'name1', uri: 'uri1', associatedServer: 'as1', serialNumber: 'sn1', serverHardwareUri: 'sh1' },
         { name: 'name2', uri: 'uri2', associatedServer: 'as2', serialNumber: 'sn2', serverHardwareUri: 'sh2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'finds it by name' do
-      expect(described_class.new(@client, name: 'name1').exists?).to be true
-      expect(described_class.new(@client, name: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, name: 'name1').exists?).to be true
+      expect(described_class.new(@client_200, name: 'fake').exists?).to be false
     end
 
     it 'finds it by uri' do
-      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
-      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client_200, uri: 'fake').exists?).to be false
     end
 
     it 'finds it by associatedServer' do
-      expect(described_class.new(@client, associatedServer: 'as1').exists?).to be true
-      expect(described_class.new(@client, associatedServer: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, associatedServer: 'as1').exists?).to be true
+      expect(described_class.new(@client_200, associatedServer: 'fake').exists?).to be false
     end
 
     it 'finds it by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').exists?).to be false
     end
 
     it 'finds it by serverHardwareUri' do
-      expect(described_class.new(@client, serverHardwareUri: 'sh1').exists?).to be true
-      expect(described_class.new(@client, serverHardwareUri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serverHardwareUri: 'sh1').exists?).to be true
+      expect(described_class.new(@client_200, serverHardwareUri: 'fake').exists?).to be false
     end
   end
 
   describe '#set_server_hardware' do
     before :each do
-      @server_hardware = OneviewSDK::ServerHardware.new(@client, name: 'server_hardware')
+      @server_hardware = OneviewSDK::ServerHardware.new(@client_200, name: 'server_hardware')
       @server_hardware_uri = '/rest/fake/server-hardwares/test'
     end
 
@@ -97,7 +97,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'will retrieve and set the serverHardwareUri correctly' do
-      expect(@client).to receive(:rest_get).with('/rest/server-hardware')
+      expect(@client_200).to receive(:rest_get).with('/rest/server-hardware')
         .and_return(FakeResponse.new(members: [
             { name: 'server_hardware', uri: @server_hardware_uri },
             { name: 'wrong_server_hardware', uri: 'wrong_uri' }
@@ -107,7 +107,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'will fail to put serverHardwareUri since the resource does not exists' do
-      expect(@client).to receive(:rest_get).with('/rest/server-hardware')
+      expect(@client_200).to receive(:rest_get).with('/rest/server-hardware')
         .and_return(FakeResponse.new(members: [
             { name: 'wrong_server_hardware', uri: 'wrong_uri' }
           ]))
@@ -117,7 +117,7 @@ RSpec.describe OneviewSDK::ServerProfile do
 
   describe '#set_server_hardware_type' do
     before :each do
-      @server_hardware_type = OneviewSDK::ServerHardwareType.new(@client, name: 'server_hardware_type')
+      @server_hardware_type = OneviewSDK::ServerHardwareType.new(@client_200, name: 'server_hardware_type')
       @server_hardware_type_uri = '/rest/fake/server-hardware-types/test'
     end
 
@@ -128,7 +128,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'will retrieve and set the serverHardwareTypeUri correctly' do
-      expect(@client).to receive(:rest_get).with('/rest/server-hardware-types')
+      expect(@client_200).to receive(:rest_get).with('/rest/server-hardware-types')
         .and_return(FakeResponse.new(members: [
             { name: 'server_hardware_type', uri: @server_hardware_type_uri },
             { name: 'wrong_server_hardware_type', uri: 'wrong_uri' }
@@ -138,7 +138,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'will fail to put serverHardwareTypeUri since the resource does not exists' do
-      expect(@client).to receive(:rest_get).with('/rest/server-hardware-types')
+      expect(@client_200).to receive(:rest_get).with('/rest/server-hardware-types')
         .and_return(FakeResponse.new(members: [
             { name: 'wrong_server_hardware_type', uri: 'wrong_uri' }
           ]))
@@ -148,7 +148,7 @@ RSpec.describe OneviewSDK::ServerProfile do
 
   describe '#set_enclosure_group' do
     before :each do
-      @enclosure_group = OneviewSDK::EnclosureGroup.new(@client, name: 'enclosure_group')
+      @enclosure_group = OneviewSDK::EnclosureGroup.new(@client_200, name: 'enclosure_group')
       @enclosure_group_uri = '/rest/fake/enclosure-groups/test'
     end
 
@@ -159,7 +159,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'will retrieve and set the enclosureGroupUri correctly' do
-      expect(@client).to receive(:rest_get).with('/rest/enclosure-groups')
+      expect(@client_200).to receive(:rest_get).with('/rest/enclosure-groups')
         .and_return(FakeResponse.new(members: [
             { name: 'enclosure_group', uri: @enclosure_group_uri },
             { name: 'wrong_enclosure_group', uri: 'wrong_uri' }
@@ -169,7 +169,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'will fail to put enclosureGroupUri since the resource does not exists' do
-      expect(@client).to receive(:rest_get).with('/rest/enclosure-groups')
+      expect(@client_200).to receive(:rest_get).with('/rest/enclosure-groups')
         .and_return(FakeResponse.new(members: [
             { name: 'wrong_enclosure_group', uri: 'wrong_uri' }
           ]))
@@ -179,7 +179,7 @@ RSpec.describe OneviewSDK::ServerProfile do
 
   describe '#set_enclosure' do
     before :each do
-      @enclosure = OneviewSDK::Enclosure.new(@client, name: 'enclosure')
+      @enclosure = OneviewSDK::Enclosure.new(@client_200, name: 'enclosure')
       @enclosure_uri = '/rest/fake/enclosures/test'
     end
 
@@ -190,7 +190,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'will retrieve and set the enclosureUri correctly' do
-      expect(@client).to receive(:rest_get).with('/rest/enclosures')
+      expect(@client_200).to receive(:rest_get).with('/rest/enclosures')
         .and_return(FakeResponse.new(members: [
             { name: 'enclosure', uri: @enclosure_uri },
             { name: 'wrong_enclosure', uri: 'wrong_uri' }
@@ -200,7 +200,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'will fail to put enclosureUri since the resource does not exists' do
-      expect(@client).to receive(:rest_get).with('/rest/enclosures')
+      expect(@client_200).to receive(:rest_get).with('/rest/enclosures')
         .and_return(FakeResponse.new(members: [
             { name: 'wrong_enclosure', uri: 'wrong_uri' }
           ]))
@@ -211,7 +211,7 @@ RSpec.describe OneviewSDK::ServerProfile do
   describe '#set_firmware_driver' do
     before :each do
       @firmware_uri = '/rest/fake/firmware-drivers/unit'
-      @firmware = OneviewSDK::FirmwareDriver.new(@client, name: 'unit_firmware_driver', uri: @firmware_uri)
+      @firmware = OneviewSDK::FirmwareDriver.new(@client_200, name: 'unit_firmware_driver', uri: @firmware_uri)
     end
 
     it 'will set the FirmwareDriver with options correctly' do
@@ -223,7 +223,7 @@ RSpec.describe OneviewSDK::ServerProfile do
 
   describe '#self.get_available_networks' do
     it 'returns all the available networks' do
-      expect(@client).to receive(:rest_get).with("#{OneviewSDK::ServerProfile::BASE_URI}/available-networks?view=unit")
+      expect(@client_200).to receive(:rest_get).with("#{OneviewSDK::ServerProfile::BASE_URI}/available-networks?view=unit")
         .and_return(FakeResponse.new(
                       'ethernetNetworks' => [
                         { 'name' => 'ethernet_network_1', 'uri' => 'fake1', 'vlan' => 1 },
@@ -239,7 +239,7 @@ RSpec.describe OneviewSDK::ServerProfile do
                       'type' => 'fakeType'
         ))
 
-      returned_set = OneviewSDK::ServerProfile.get_available_networks(@client, 'view' => 'unit')
+      returned_set = OneviewSDK::ServerProfile.get_available_networks(@client_200, 'view' => 'unit')
       expect(returned_set['ethernetNetworks'].size).to eq(2)
       returned_set['ethernetNetworks'].each { |net| expect(net['name']).to match(/ethernet_network/) }
       expect(returned_set['fcNetworks'].size).to eq(2)
@@ -253,11 +253,11 @@ RSpec.describe OneviewSDK::ServerProfile do
   describe '#self.get_available_servers' do
     it 'retrieves available servers based on a query' do
       server_profile_uri = 'rest/fake/server-profiles/unit'
-      server_profile = OneviewSDK::ServerProfile.new(@client, name: 'unit_server_profile', uri: server_profile_uri)
-      expect(@client).to receive(:rest_get)
+      server_profile = OneviewSDK::ServerProfile.new(@client_200, name: 'unit_server_profile', uri: server_profile_uri)
+      expect(@client_200).to receive(:rest_get)
         .with("#{OneviewSDK::ServerProfile::BASE_URI}/available-servers?profileUri=#{server_profile_uri}")
         .and_return(FakeResponse.new('it' => 'works'))
-      expect(OneviewSDK::ServerProfile.get_available_servers(@client, 'server_profile' => server_profile)['it'])
+      expect(OneviewSDK::ServerProfile.get_available_servers(@client_200, 'server_profile' => server_profile)['it'])
         .to eq('works')
     end
   end
@@ -265,45 +265,45 @@ RSpec.describe OneviewSDK::ServerProfile do
   describe '#self.get_available_storage_system' do
     it 'retrieves available storage system based on a query' do
       storage_system_uri = 'rest/fake/storage-systems/unit'
-      storage_system = OneviewSDK::StorageSystem.new(@client, name: 'unit_storage_system', uri: storage_system_uri)
-      expect(@client).to receive(:rest_get)
+      storage_system = OneviewSDK::StorageSystem.new(@client_200, name: 'unit_storage_system', uri: storage_system_uri)
+      expect(@client_200).to receive(:rest_get)
         .with("#{OneviewSDK::ServerProfile::BASE_URI}/available-storage-system?storageSystemId=unit")
         .and_return(FakeResponse.new('it' => 'works'))
-      expect(OneviewSDK::ServerProfile.get_available_storage_system(@client, 'storage_system' => storage_system)['it'])
+      expect(OneviewSDK::ServerProfile.get_available_storage_system(@client_200, 'storage_system' => storage_system)['it'])
         .to eq('works')
     end
   end
 
   describe '#self.get_available_storage_systems' do
     it 'retrieves available storage system based on a query' do
-      expect(@client).to receive(:rest_get)
+      expect(@client_200).to receive(:rest_get)
         .with("#{OneviewSDK::ServerProfile::BASE_URI}/available-storage-systems")
         .and_return(FakeResponse.new('it' => 'works'))
-      expect(OneviewSDK::ServerProfile.get_available_storage_systems(@client)['it']).to eq('works')
+      expect(OneviewSDK::ServerProfile.get_available_storage_systems(@client_200)['it']).to eq('works')
     end
   end
 
   describe '#self.get_available_targets' do
     it 'retrieves available targets based on a query' do
-      expect(@client).to receive(:rest_get)
+      expect(@client_200).to receive(:rest_get)
         .with("#{OneviewSDK::ServerProfile::BASE_URI}/available-targets")
         .and_return(FakeResponse.new('it' => 'works'))
-      expect(OneviewSDK::ServerProfile.get_available_targets(@client)['it']).to eq('works')
+      expect(OneviewSDK::ServerProfile.get_available_targets(@client_200)['it']).to eq('works')
     end
   end
 
   describe '#self.get_profile_ports' do
     it 'retrieves profile ports based on a query' do
-      expect(@client).to receive(:rest_get)
+      expect(@client_200).to receive(:rest_get)
         .with("#{OneviewSDK::ServerProfile::BASE_URI}/profile-ports")
         .and_return(FakeResponse.new('it' => 'works'))
-      expect(OneviewSDK::ServerProfile.get_profile_ports(@client)['it']).to eq('works')
+      expect(OneviewSDK::ServerProfile.get_profile_ports(@client_200)['it']).to eq('works')
     end
   end
 
   describe '#get_compliance_preview' do
     it 'shows compliance preview' do
-      expect(@client).to receive(:rest_get).with("#{@item['uri']}/compliance-preview")
+      expect(@client_200).to receive(:rest_get).with("#{@item['uri']}/compliance-preview")
         .and_return(FakeResponse.new('it' => 'works'))
       expect(@item.get_compliance_preview['it']).to eq('works')
     end
@@ -311,7 +311,7 @@ RSpec.describe OneviewSDK::ServerProfile do
 
   describe '#get_messages' do
     it 'shows messages' do
-      expect(@client).to receive(:rest_get).with("#{@item['uri']}/messages")
+      expect(@client_200).to receive(:rest_get).with("#{@item['uri']}/messages")
         .and_return(FakeResponse.new('it' => 'works'))
       expect(@item.get_messages['it']).to eq('works')
     end
@@ -319,7 +319,7 @@ RSpec.describe OneviewSDK::ServerProfile do
 
   describe '#get_transformation' do
     it 'transforms an existing profile' do
-      expect(@client).to receive(:rest_get).with("#{@item['uri']}/transformation?queryTest=Test")
+      expect(@client_200).to receive(:rest_get).with("#{@item['uri']}/transformation?queryTest=Test")
         .and_return(FakeResponse.new('it' => 'works'))
       expect(@item.get_transformation('query_test' => 'Test')['it']).to eq('works')
     end
@@ -332,7 +332,7 @@ RSpec.describe OneviewSDK::ServerProfile do
         'If-Match' => @item['eTag'],
         'body' => patch_ops
       }
-      expect(@client).to receive(:rest_patch)
+      expect(@client_200).to receive(:rest_patch)
         .with(@item['uri'], request)
         .and_return(FakeResponse.new)
       expect { @item.update_from_template }.to_not raise_error
@@ -342,7 +342,7 @@ RSpec.describe OneviewSDK::ServerProfile do
   describe '#add_connection' do
     before :each do
       @item['connections'] = []
-      @network = OneviewSDK::EthernetNetwork.new(@client, name: 'unit_ethernet_network', uri: 'rest/fake/ethernet-networks/unit')
+      @network = OneviewSDK::EthernetNetwork.new(@client_200, name: 'unit_ethernet_network', uri: 'rest/fake/ethernet-networks/unit')
     end
 
     it 'adds simple connection' do
@@ -368,7 +368,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     describe '#remove_connection' do
       before :each do
         @item['connections'] = []
-        @network = OneviewSDK::EthernetNetwork.new(@client, name: 'unit_ethernet_network', uri: 'rest/fake/ethernet-networks/unit')
+        @network = OneviewSDK::EthernetNetwork.new(@client_200, name: 'unit_ethernet_network', uri: 'rest/fake/ethernet-networks/unit')
         base_uri = @network['uri']
         1.upto(5) do |count|
           @network['uri'] = "#{@network['uri']}_#{count}"
@@ -411,48 +411,49 @@ RSpec.describe OneviewSDK::ServerProfile do
 
   describe '#get_server_hardware' do
     it 'returns nil if no hardware is assigned' do
-      hw = OneviewSDK::ServerProfile.new(@client).get_server_hardware
+      hw = OneviewSDK::ServerProfile.new(@client_200).get_server_hardware
       expect(hw).to be_nil
     end
 
     it 'retrieves and returns the hardware if it is assigned' do
       expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:retrieve!).and_return(true)
-      hw = OneviewSDK::ServerProfile.new(@client, serverHardwareUri: '/rest/fake').get_server_hardware
+      hw = OneviewSDK::ServerProfile.new(@client_200, serverHardwareUri: '/rest/fake').get_server_hardware
       expect(hw).to be_a(OneviewSDK::ServerHardware)
     end
   end
 
   describe '#get_available_networks' do
     it 'calls the #get_available_networks class method' do
-      p = OneviewSDK::ServerProfile.new(@client, enclosureGroupUri: '/rest/fake', serverHardwareTypeUri: '/rest/fake2')
+      p = OneviewSDK::ServerProfile.new(@client_200, enclosureGroupUri: '/rest/fake', serverHardwareTypeUri: '/rest/fake2')
       query = { enclosure_group_uri: p['enclosureGroupUri'], server_hardware_type_uri: p['serverHardwareTypeUri'] }
-      expect(OneviewSDK::ServerProfile).to receive(:get_available_networks).with(@client, query).and_return([])
+      expect(OneviewSDK::ServerProfile).to receive(:get_available_networks).with(@client_200, query).and_return([])
       expect(p.get_available_networks).to eq([])
     end
   end
 
   describe '#available_hardware' do
     it 'requires the serverHardwareTypeUri value to be set' do
-      expect { OneviewSDK::ServerProfile.new(@client).get_available_hardware }
+      expect { OneviewSDK::ServerProfile.new(@client_200).get_available_hardware }
         .to raise_error(OneviewSDK::IncompleteResource, /Must set.*serverHardwareTypeUri/)
     end
 
     it 'requires the enclosureGroupUri value to be set' do
-      expect { OneviewSDK::ServerProfile.new(@client, serverHardwareTypeUri: '/rest/fake').get_available_hardware }
+      expect { OneviewSDK::ServerProfile.new(@client_200, serverHardwareTypeUri: '/rest/fake').get_available_hardware }
         .to raise_error(OneviewSDK::IncompleteResource, /Must set.*enclosureGroupUri/)
     end
 
     it 'calls #find_by with the serverHardwareTypeUri and enclosureGroupUri' do
-      @item = OneviewSDK::ServerProfile.new(@client, serverHardwareTypeUri: '/rest/fake', enclosureGroupUri: '/rest/fake2')
+      @item = OneviewSDK::ServerProfile.new(@client_200, serverHardwareTypeUri: '/rest/fake', enclosureGroupUri: '/rest/fake2')
       params = { state: 'NoProfileApplied', serverHardwareTypeUri: @item['serverHardwareTypeUri'], serverGroupUri: @item['enclosureGroupUri'] }
-      expect(OneviewSDK::ServerHardware).to receive(:find_by).with(@client, params).and_return([])
+      expect(OneviewSDK::ServerHardware).to receive(:find_by).with(@client_200, params).and_return([])
       expect(@item.get_available_hardware).to eq([])
     end
   end
 
   describe 'Volume attachment operations' do
     it 'can call the #add_volume_attachment using a specific already created Volume' do
-      volume = OneviewSDK::Volume.new(@client, uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system')
+      options = { uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system' }
+      volume = OneviewSDK::Volume.new(@client_200, options)
       @item.add_volume_attachment(volume)
 
       expect(@item['sanStorage']['volumeAttachments'].size).to eq(1)
@@ -464,7 +465,8 @@ RSpec.describe OneviewSDK::ServerProfile do
 
     describe 'can call #remove_volume_attachment' do
       it 'and remove attachment with id 0' do
-        volume = OneviewSDK::Volume.new(@client, uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system')
+        options = { uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system' }
+        volume = OneviewSDK::Volume.new(@client_200, options)
         @item.add_volume_attachment(volume, 'id' => 7)
         expect(@item['sanStorage']['volumeAttachments'].size).to eq(1)
         va = @item.remove_volume_attachment(7)
@@ -475,7 +477,8 @@ RSpec.describe OneviewSDK::ServerProfile do
       end
 
       it 'and return nil if no attachment found' do
-        volume = OneviewSDK::Volume.new(@client, uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system')
+        options = { uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system' }
+        volume = OneviewSDK::Volume.new(@client_200, options)
         @item.add_volume_attachment(volume, 'id' => 7)
         expect(@item['sanStorage']['volumeAttachments'].size).to eq(1)
         va = @item.remove_volume_attachment(5)
@@ -492,7 +495,7 @@ RSpec.describe OneviewSDK::ServerProfile do
     end
 
     it 'can call #create_volume_with_attachment and generate the data required for a new Volume with attachment' do
-      storage_pool = OneviewSDK::StoragePool.new(@client, uri: 'fake/storage-pool')
+      storage_pool = OneviewSDK::StoragePool.new(@client_200, uri: 'fake/storage-pool')
       volume_options = {
         name: 'TestVolume',
         description: 'Test Volume for Server Profile Volume Attachment',

--- a/spec/unit/resource/api200/server_profile_template_spec.rb
+++ b/spec/unit/resource/api200/server_profile_template_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
   include_context 'shared context'
 
   before(:each) do
-    @item = OneviewSDK::ServerProfileTemplate.new(@client, name: 'server_profile_template')
+    @item = OneviewSDK::ServerProfileTemplate.new(@client_200, name: 'server_profile_template')
   end
 
   describe '#initialize' do
@@ -15,7 +15,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
 
   describe '#set_server_hardware_type' do
     before :each do
-      @server_hardware_type = OneviewSDK::ServerHardwareType.new(@client, name: 'server_hardware_type')
+      @server_hardware_type = OneviewSDK::ServerHardwareType.new(@client_200, name: 'server_hardware_type')
       @server_hardware_type_uri = '/rest/fake/server-hardware-types/test'
     end
 
@@ -26,7 +26,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
     end
 
     it 'will retrieve and set the serverHardwareTypeUri correctly' do
-      expect(@client).to receive(:rest_get).with('/rest/server-hardware-types')
+      expect(@client_200).to receive(:rest_get).with('/rest/server-hardware-types')
         .and_return(FakeResponse.new(members: [
             { name: 'server_hardware_type', uri: @server_hardware_type_uri },
             { name: 'wrong_server_hardware_type', uri: 'wrong_uri' }
@@ -36,7 +36,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
     end
 
     it 'will fail to put serverHardwareTypeUri since the resource does not exists' do
-      expect(@client).to receive(:rest_get).with('/rest/server-hardware-types')
+      expect(@client_200).to receive(:rest_get).with('/rest/server-hardware-types')
         .and_return(FakeResponse.new(members: [
             { name: 'wrong_server_hardware_type', uri: 'wrong_uri' }
           ]))
@@ -46,7 +46,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
 
   describe '#set_enclosure_group' do
     before :each do
-      @enclosure_group = OneviewSDK::EnclosureGroup.new(@client, name: 'enclosure_group')
+      @enclosure_group = OneviewSDK::EnclosureGroup.new(@client_200, name: 'enclosure_group')
       @enclosure_group_uri = '/rest/fake/enclosure-groups/test'
     end
 
@@ -57,7 +57,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
     end
 
     it 'will retrieve and set the enclosureGroupUri correctly' do
-      expect(@client).to receive(:rest_get).with('/rest/enclosure-groups')
+      expect(@client_200).to receive(:rest_get).with('/rest/enclosure-groups')
         .and_return(FakeResponse.new(members: [
             { name: 'enclosure_group', uri: @enclosure_group_uri },
             { name: 'wrong_enclosure_group', uri: 'wrong_uri' }
@@ -67,7 +67,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
     end
 
     it 'will fail to put enclosureGroupUri since the resource does not exists' do
-      expect(@client).to receive(:rest_get).with('/rest/enclosure-groups')
+      expect(@client_200).to receive(:rest_get).with('/rest/enclosure-groups')
         .and_return(FakeResponse.new(members: [
             { name: 'wrong_enclosure_group', uri: 'wrong_uri' }
           ]))
@@ -78,7 +78,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
   describe '#set_firmware_driver' do
     before :each do
       @firmware_uri = '/rest/fake/firmware-drivers/unit'
-      @firmware = OneviewSDK::FirmwareDriver.new(@client, name: 'unit_firmware_driver', uri: @firmware_uri)
+      @firmware = OneviewSDK::FirmwareDriver.new(@client_200, name: 'unit_firmware_driver', uri: @firmware_uri)
     end
 
     it 'will set the FirmwareDriver with options correctly' do
@@ -91,7 +91,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
   describe '#add_connection' do
     before :each do
       @item['connections'] = []
-      @network = OneviewSDK::EthernetNetwork.new(@client, name: 'unit_ethernet_network', uri: 'rest/fake/ethernet-networks/unit')
+      @network = OneviewSDK::EthernetNetwork.new(@client_200, name: 'unit_ethernet_network', uri: 'rest/fake/ethernet-networks/unit')
     end
 
     it 'adds simple connection' do
@@ -117,7 +117,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
     describe '#remove_connection' do
       before :each do
         @item['connections'] = []
-        @network = OneviewSDK::EthernetNetwork.new(@client, name: 'unit_ethernet_network', uri: 'rest/fake/ethernet-networks/unit')
+        @network = OneviewSDK::EthernetNetwork.new(@client_200, name: 'unit_ethernet_network', uri: 'rest/fake/ethernet-networks/unit')
         base_uri = @network['uri']
         1.upto(5) do |count|
           @network['uri'] = "#{@network['uri']}_#{count}"
@@ -160,19 +160,19 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
 
   describe '#available_hardware' do
     it 'requires the serverHardwareTypeUri value to be set' do
-      expect { OneviewSDK::ServerProfileTemplate.new(@client).get_available_hardware }
+      expect { OneviewSDK::ServerProfileTemplate.new(@client_200).get_available_hardware }
         .to raise_error(OneviewSDK::IncompleteResource, /Must set.*serverHardwareTypeUri/)
     end
 
     it 'requires the enclosureGroupUri value to be set' do
-      expect { OneviewSDK::ServerProfileTemplate.new(@client, serverHardwareTypeUri: '/rest/fake').get_available_hardware }
+      expect { OneviewSDK::ServerProfileTemplate.new(@client_200, serverHardwareTypeUri: '/rest/fake').get_available_hardware }
         .to raise_error(OneviewSDK::IncompleteResource, /Must set.*enclosureGroupUri/)
     end
 
     it 'calls #find_by with the serverHardwareTypeUri and enclosureGroupUri' do
-      @item = OneviewSDK::ServerProfileTemplate.new(@client, serverHardwareTypeUri: '/rest/fake', enclosureGroupUri: '/rest/fake2')
+      @item = OneviewSDK::ServerProfileTemplate.new(@client_200, serverHardwareTypeUri: '/rest/fake', enclosureGroupUri: '/rest/fake2')
       params = { state: 'NoProfileApplied', serverHardwareTypeUri: @item['serverHardwareTypeUri'], serverGroupUri: @item['enclosureGroupUri'] }
-      expect(OneviewSDK::ServerHardware).to receive(:find_by).with(@client, params).and_return([])
+      expect(OneviewSDK::ServerHardware).to receive(:find_by).with(@client_200, params).and_return([])
       expect(@item.get_available_hardware).to eq([])
     end
   end
@@ -180,8 +180,8 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
   describe '#new_profile' do
     it 'returns a profile' do
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new(name: 'NewProfile'))
-      expect(@client).to receive(:rest_get).with('/rest/server-profile-templates/fake/new-profile')
-      template = OneviewSDK::ServerProfileTemplate.new(@client, name: 'unit_server_profile_template')
+      expect(@client_200).to receive(:rest_get).with('/rest/server-profile-templates/fake/new-profile')
+      template = OneviewSDK::ServerProfileTemplate.new(@client_200, name: 'unit_server_profile_template')
       template['uri'] = '/rest/server-profile-templates/fake'
       profile = template.new_profile
       expect(profile.class).to eq(OneviewSDK::ServerProfile)
@@ -190,7 +190,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
 
     it 'can set the name of a new profile' do
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_get).and_return(FakeResponse.new(name: 'NewProfile'))
-      template = OneviewSDK::ServerProfileTemplate.new(@client, uri: '/rest/server-profile-templates/fake')
+      template = OneviewSDK::ServerProfileTemplate.new(@client_200, uri: '/rest/server-profile-templates/fake')
       profile = template.new_profile('NewName')
       expect(profile[:name]).to eq('NewName')
     end
@@ -198,7 +198,8 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
 
   describe 'Volume attachment operations' do
     it 'can call the #add_volume_attachment using a specific already created Volume' do
-      volume = OneviewSDK::Volume.new(@client, uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system')
+      options = { uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system' }
+      volume = OneviewSDK::Volume.new(@client_200, options)
       @item.add_volume_attachment(volume)
 
       expect(@item['sanStorage']['volumeAttachments'].size).to eq(1)
@@ -210,7 +211,8 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
 
     describe 'can call #remove_volume_attachment' do
       it 'and remove attachment with id 0' do
-        volume = OneviewSDK::Volume.new(@client, uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system')
+        options = { uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system' }
+        volume = OneviewSDK::Volume.new(@client_200, options)
         @item.add_volume_attachment(volume, 'id' => 7)
         expect(@item['sanStorage']['volumeAttachments'].size).to eq(1)
         va = @item.remove_volume_attachment(7)
@@ -221,7 +223,8 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
       end
 
       it 'and return nil if no attachment found' do
-        volume = OneviewSDK::Volume.new(@client, uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system')
+        options = { uri: '/fake/volume', storagePoolUri: '/fake/storage-pool', storageSystemUri: '/fake/storage-system' }
+        volume = OneviewSDK::Volume.new(@client_200, options)
         @item.add_volume_attachment(volume, 'id' => 7)
         expect(@item['sanStorage']['volumeAttachments'].size).to eq(1)
         va = @item.remove_volume_attachment(5)
@@ -238,7 +241,7 @@ RSpec.describe OneviewSDK::ServerProfileTemplate do
     end
 
     it 'can call #create_volume_with_attachment and generate the data required for a new Volume with attachment' do
-      storage_pool = OneviewSDK::StoragePool.new(@client, uri: 'fake/storage-pool')
+      storage_pool = OneviewSDK::StoragePool.new(@client_200, uri: 'fake/storage-pool')
       volume_options = {
         name: 'TestVolume',
         description: 'Test Volume for Server Profile Volume Attachment',

--- a/spec/unit/resource/api200/storage_pool_spec.rb
+++ b/spec/unit/resource/api200/storage_pool_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe OneviewSDK::StoragePool do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      pool = OneviewSDK::StoragePool.new(@client)
+      pool = OneviewSDK::StoragePool.new(@client_200)
       expect(pool['type']).to eq('StoragePoolV2')
     end
   end
 
   describe '#add' do
     it 'Should support add' do
-      pool = OneviewSDK::StoragePool.new(@client, name: 'StoragePool_1')
-      expect(@client).to receive(:rest_post).with(
+      pool = OneviewSDK::StoragePool.new(@client_200, name: 'StoragePool_1')
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/storage-pools',
         { 'body' => { 'name' => 'StoragePool_1', 'type' => 'StoragePoolV2' } },
         200
@@ -24,33 +24,33 @@ RSpec.describe OneviewSDK::StoragePool do
 
   describe '#remove' do
     it 'Should support remove' do
-      pool = OneviewSDK::StoragePool.new(@client, uri: '/rest/storage-pools/100')
-      expect(@client).to receive(:rest_delete).with('/rest/storage-pools/100', {}, 200).and_return(FakeResponse.new({}))
+      pool = OneviewSDK::StoragePool.new(@client_200, uri: '/rest/storage-pools/100')
+      expect(@client_200).to receive(:rest_delete).with('/rest/storage-pools/100', {}, 200).and_return(FakeResponse.new({}))
       pool.remove
     end
   end
 
   describe '#set_storage_system' do
     it 'sets the storageSystemUri value' do
-      item = OneviewSDK::StoragePool.new(@client)
-      item.set_storage_system(OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake'))
+      item = OneviewSDK::StoragePool.new(@client_200)
+      item.set_storage_system(OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake'))
       expect(item['storageSystemUri']).to eq('/rest/fake')
     end
 
     it 'requires a storage_system with a uri' do
-      item = OneviewSDK::StoragePool.new(@client)
-      expect { item.set_storage_system(OneviewSDK::StorageSystem.new(@client)) }.to raise_error(OneviewSDK::IncompleteResource, /Please set/)
+      item = OneviewSDK::StoragePool.new(@client_200)
+      expect { item.set_storage_system(OneviewSDK::StorageSystem.new(@client_200)) }.to raise_error(OneviewSDK::IncompleteResource, /Please set/)
     end
   end
 
   describe '#retrieve!' do
     it 'requires the name attribute to be set' do
-      storage_pool = OneviewSDK::StoragePool.new(@client)
+      storage_pool = OneviewSDK::StoragePool.new(@client_200)
       expect { storage_pool.retrieve! }.to raise_error(OneviewSDK::IncompleteResource, /Must set resource name or uri before trying to retrieve!/)
     end
 
     it 'requires the storageSystemUri attribute to be set' do
-      storage_pool = OneviewSDK::StoragePool.new(@client, name: 'StoragePoolName')
+      storage_pool = OneviewSDK::StoragePool.new(@client_200, name: 'StoragePoolName')
       expect { storage_pool.retrieve! }.to raise_error(
         OneviewSDK::IncompleteResource,
         /Must set resource storageSystemUri before trying to retrieve!/
@@ -58,17 +58,17 @@ RSpec.describe OneviewSDK::StoragePool do
     end
 
     it 'uses the uri attribute when the name is not set' do
-      res = OneviewSDK::StoragePool.new(@client, uri: '/rest/fake')
-      res.set_storage_system(OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake'))
-      expect(OneviewSDK::StoragePool).to receive(:find_by).with(@client, uri: res['uri'], storageSystemUri: '/rest/fake').and_return([])
+      res = OneviewSDK::StoragePool.new(@client_200, uri: '/rest/fake')
+      res.set_storage_system(OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake'))
+      expect(OneviewSDK::StoragePool).to receive(:find_by).with(@client_200, uri: res['uri'], storageSystemUri: '/rest/fake').and_return([])
       expect(res.exists?).to eq(false)
     end
 
     it 'sets the data if the resource is found' do
-      res = OneviewSDK::StoragePool.new(@client, name: 'ResourceName')
-      res.set_storage_system(OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake'))
+      res = OneviewSDK::StoragePool.new(@client_200, name: 'ResourceName')
+      res.set_storage_system(OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake'))
       allow(OneviewSDK::StoragePool).to receive(:find_by).and_return([
-        OneviewSDK::StoragePool.new(@client, res.data.merge(uri: '/rest/fake', storageSystemUri: '/rest/fake', description: 'Blah'))
+        OneviewSDK::StoragePool.new(@client_200, res.data.merge(uri: '/rest/fake', storageSystemUri: '/rest/fake', description: 'Blah'))
       ])
       res.retrieve!
       expect(res['uri']).to eq('/rest/fake')
@@ -77,58 +77,58 @@ RSpec.describe OneviewSDK::StoragePool do
 
     it 'returns false when the resource is not found' do
       allow(OneviewSDK::StoragePool).to receive(:find_by).and_return([])
-      res = OneviewSDK::StoragePool.new(@client, name: 'ResourceName')
-      res.set_storage_system(OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake'))
+      res = OneviewSDK::StoragePool.new(@client_200, name: 'ResourceName')
+      res.set_storage_system(OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake'))
       expect(res.retrieve!).to eq(false)
     end
   end
 
   describe '#exists?' do
     it 'requires the name attribute to be set' do
-      storage_pool = OneviewSDK::StoragePool.new(@client)
+      storage_pool = OneviewSDK::StoragePool.new(@client_200)
       expect { storage_pool.exists? }.to raise_error(OneviewSDK::IncompleteResource, /Must set resource name or uri before trying to exists?/)
     end
 
     it 'requires the storageSystemUri attribute to be set' do
-      storage_pool = OneviewSDK::StoragePool.new(@client, name: 'StoragePoolName')
+      storage_pool = OneviewSDK::StoragePool.new(@client_200, name: 'StoragePoolName')
       expect { storage_pool.exists? }.to raise_error(OneviewSDK::IncompleteResource, /Must set resource storageSystemUri before trying to exists?/)
     end
 
     it 'uses the uri attribute when the name is not set' do
-      res = OneviewSDK::StoragePool.new(@client, uri: '/rest/fake')
-      res.set_storage_system(OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake'))
-      expect(OneviewSDK::StoragePool).to receive(:find_by).with(@client, storageSystemUri: '/rest/fake', uri: res['uri']).and_return([])
+      res = OneviewSDK::StoragePool.new(@client_200, uri: '/rest/fake')
+      res.set_storage_system(OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake'))
+      expect(OneviewSDK::StoragePool).to receive(:find_by).with(@client_200, storageSystemUri: '/rest/fake', uri: res['uri']).and_return([])
       expect(res.exists?).to eq(false)
     end
 
     it 'returns true when the resource is found' do
-      res = OneviewSDK::StoragePool.new(@client, name: 'ResourceName')
-      res.set_storage_system(OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake'))
-      expect(OneviewSDK::StoragePool).to receive(:find_by).with(@client, name: res['name'], storageSystemUri: '/rest/fake').and_return([res])
+      res = OneviewSDK::StoragePool.new(@client_200, name: 'ResourceName')
+      res.set_storage_system(OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake'))
+      expect(OneviewSDK::StoragePool).to receive(:find_by).with(@client_200, name: res['name'], storageSystemUri: '/rest/fake').and_return([res])
       expect(res.exists?).to eq(true)
     end
 
     it 'returns false when the resource is not found' do
-      res = OneviewSDK::StoragePool.new(@client, uri: '/rest/fake')
-      res.set_storage_system(OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake'))
-      expect(OneviewSDK::StoragePool).to receive(:find_by).with(@client, uri: res['uri'], storageSystemUri: '/rest/fake').and_return([])
+      res = OneviewSDK::StoragePool.new(@client_200, uri: '/rest/fake')
+      res.set_storage_system(OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake'))
+      expect(OneviewSDK::StoragePool).to receive(:find_by).with(@client_200, uri: res['uri'], storageSystemUri: '/rest/fake').and_return([])
       expect(res.exists?).to eq(false)
     end
   end
 
   describe 'undefined methods' do
     it 'does not allow the create action' do
-      pool = OneviewSDK::StoragePool.new(@client)
+      pool = OneviewSDK::StoragePool.new(@client_200)
       expect { pool.create }.to raise_error(/The method #create is unavailable for this resource/)
     end
 
     it 'does not allow the update action' do
-      storage_pool = OneviewSDK::StoragePool.new(@client)
+      storage_pool = OneviewSDK::StoragePool.new(@client_200)
       expect { storage_pool.update }.to raise_error(OneviewSDK::MethodUnavailable, /The method #update is unavailable for this resource/)
     end
 
     it 'does not allow the delete action' do
-      pool = OneviewSDK::StoragePool.new(@client)
+      pool = OneviewSDK::StoragePool.new(@client_200)
       expect { pool.delete }.to raise_error(/The method #delete is unavailable for this resource/)
     end
   end

--- a/spec/unit/resource/api200/storage_system_spec.rb
+++ b/spec/unit/resource/api200/storage_system_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe OneviewSDK::StorageSystem do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      item = OneviewSDK::StorageSystem.new(@client)
+      item = OneviewSDK::StorageSystem.new(@client_200)
       expect(item[:type]).to eq('StorageSystemV3')
     end
   end
 
   describe '#add' do
     it 'sends just the credentials hash, then the rest of the data' do
-      item = OneviewSDK::StorageSystem.new(@client, name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin', password: 'secret' })
-      expect(@client).to receive(:rest_post).with('/rest/storage-systems', { 'body' => item['credentials'] }, item.api_version)
+      item = OneviewSDK::StorageSystem.new(@client_200, name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin', password: 'secret' })
+      expect(@client_200).to receive(:rest_post).with('/rest/storage-systems', { 'body' => item['credentials'] }, item.api_version)
         .and_return(FakeResponse.new('uri' => '/rest/task/fake'))
-      allow(@client).to receive(:wait_for).and_return(FakeResponse.new(nil, 200, 'associatedResource' => { 'resourceUri' => '/rest/fake' }))
+      allow(@client_200).to receive(:wait_for).and_return(FakeResponse.new(nil, 200, 'associatedResource' => { 'resourceUri' => '/rest/fake' }))
       expect(item).to receive(:refresh).and_return(true)
       expect(item).to receive(:update).with('name' => 'Fake', 'type' => 'StorageSystemV3').and_return(true)
       item.add
@@ -24,8 +24,8 @@ RSpec.describe OneviewSDK::StorageSystem do
 
   describe '#remove' do
     it 'Should support remove' do
-      storage = OneviewSDK::StorageSystem.new(@client, uri: '/rest/storage-systems/100')
-      expect(@client).to receive(:rest_delete).with('/rest/storage-systems/100', {}, 200).and_return(FakeResponse.new({}))
+      storage = OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/storage-systems/100')
+      expect(@client_200).to receive(:rest_delete).with('/rest/storage-systems/100', {}, 200).and_return(FakeResponse.new({}))
       storage.remove
     end
   end
@@ -36,36 +36,36 @@ RSpec.describe OneviewSDK::StorageSystem do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1', wwn: 'wwn1', credentials: { ip_hostname: 'ip1' } },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2', wwn: 'wwn2', credentials: { ip_hostname: 'ip2' } }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'retrieves by name' do
-      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
-      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client_200, name: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by uri' do
-      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
-      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client_200, uri: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by wwn' do
-      expect(described_class.new(@client, wwn: 'wwn1').retrieve!).to be true
-      expect(described_class.new(@client, wwn: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, wwn: 'wwn1').retrieve!).to be true
+      expect(described_class.new(@client_200, wwn: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by credentials' do
-      expect(described_class.new(@client, credentials: { ip_hostname: 'ip1' }).retrieve!).to be true
-      expect(described_class.new(@client, credentials: { ip_hostname: 'fake' }).retrieve!).to be false
+      expect(described_class.new(@client_200, credentials: { ip_hostname: 'ip1' }).retrieve!).to be true
+      expect(described_class.new(@client_200, credentials: { ip_hostname: 'fake' }).retrieve!).to be false
     end
 
     it 'raises an exception if no identifiers are given' do
-      item = OneviewSDK::StorageSystem.new(@client, {})
+      item = OneviewSDK::StorageSystem.new(@client_200, {})
       expect { item.retrieve! }.to raise_error(OneviewSDK::IncompleteResource)
     end
   end
@@ -76,36 +76,36 @@ RSpec.describe OneviewSDK::StorageSystem do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1', wwn: 'wwn1', credentials: { ip_hostname: 'ip1' } },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2', wwn: 'wwn2', credentials: { ip_hostname: 'ip2' } }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'finds it by name' do
-      expect(described_class.new(@client, name: 'name1').exists?).to be true
-      expect(described_class.new(@client, name: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, name: 'name1').exists?).to be true
+      expect(described_class.new(@client_200, name: 'fake').exists?).to be false
     end
 
     it 'finds it by uri' do
-      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
-      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client_200, uri: 'fake').exists?).to be false
     end
 
     it 'finds it by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').exists?).to be false
     end
 
     it 'finds it by wwn' do
-      expect(described_class.new(@client, wwn: 'wwn1').exists?).to be true
-      expect(described_class.new(@client, wwn: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, wwn: 'wwn1').exists?).to be true
+      expect(described_class.new(@client_200, wwn: 'fake').exists?).to be false
     end
 
     it 'finds it by credentials' do
-      expect(described_class.new(@client, credentials: { ip_hostname: 'ip1' }).exists?).to be true
-      expect(described_class.new(@client, credentials: { ip_hostname: 'fake' }).exists?).to be false
+      expect(described_class.new(@client_200, credentials: { ip_hostname: 'ip1' }).exists?).to be true
+      expect(described_class.new(@client_200, credentials: { ip_hostname: 'fake' }).exists?).to be false
     end
 
     it 'raises an exception if no identifiers are given' do
-      item = OneviewSDK::StorageSystem.new(@client, {})
+      item = OneviewSDK::StorageSystem.new(@client_200, {})
       expect { item.exists? }.to raise_error(OneviewSDK::IncompleteResource)
     end
   end
@@ -122,7 +122,7 @@ RSpec.describe OneviewSDK::StorageSystem do
         state: 'Configured'
       }
       item = OneviewSDK::StorageSystem.new(
-        @client,
+        @client_200,
         name: 'StorageSystemName',
         credentials: {
           'ip_hostname' => '127.0.0.1',
@@ -144,7 +144,7 @@ RSpec.describe OneviewSDK::StorageSystem do
         'state' => 'Configured'
       }
       item = OneviewSDK::StorageSystem.new(
-        @client,
+        @client_200,
         'name' => 'StorageSystemName',
         'credentials' => {
           'ip_hostname' => '127.0.0.1',
@@ -156,53 +156,53 @@ RSpec.describe OneviewSDK::StorageSystem do
     end
 
     it 'must not compare storage system credentials with password when compares resources' do
-      item1 = OneviewSDK::StorageSystem.new(@client, name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin' })
-      item2 = OneviewSDK::StorageSystem.new(@client, name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin', password: 'secret' })
+      item1 = OneviewSDK::StorageSystem.new(@client_200, name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin' })
+      item2 = OneviewSDK::StorageSystem.new(@client_200, name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin', password: 'secret' })
       expect(item1.like?(item2)).to eq(true)
     end
 
     it 'must not compare storage system with invalid data types' do
-      item1 = OneviewSDK::StorageSystem.new(@client, name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin' })
+      item1 = OneviewSDK::StorageSystem.new(@client_200, name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin' })
       expect(item1.like?(credentials: true)).to eq(false)
     end
   end
 
   describe '#host-types' do
     it 'List Host Types' do
-      expect(@client).to receive(:rest_get).with('/rest/storage-systems/host-types').and_return(FakeResponse.new({}))
-      expect { OneviewSDK::StorageSystem.get_host_types(@client) }.not_to raise_error
+      expect(@client_200).to receive(:rest_get).with('/rest/storage-systems/host-types').and_return(FakeResponse.new({}))
+      expect { OneviewSDK::StorageSystem.get_host_types(@client_200) }.not_to raise_error
     end
   end
 
   describe '#storage pools' do
     it 'List Storage Pools' do
-      item = OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/storage-pools').and_return(FakeResponse.new({}))
+      item = OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/storage-pools').and_return(FakeResponse.new({}))
       expect { item.get_storage_pools }.not_to raise_error
     end
   end
 
   describe '#get_managed_ports' do
     it 'No port given' do
-      item = OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/managedPorts').and_return(FakeResponse.new({}))
+      item = OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/managedPorts').and_return(FakeResponse.new({}))
       item.get_managed_ports
     end
     it 'With port given' do
-      item = OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/managedPorts/100').and_return(FakeResponse.new({}))
+      item = OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/managedPorts/100').and_return(FakeResponse.new({}))
       item.get_managed_ports(100)
     end
   end
 
   describe 'undefined methods' do
     it 'does not allow the create action' do
-      storage = OneviewSDK::StorageSystem.new(@client)
+      storage = OneviewSDK::StorageSystem.new(@client_200)
       expect { storage.create }.to raise_error(/The method #create is unavailable for this resource/)
     end
 
     it 'does not allow the delete action' do
-      storage = OneviewSDK::StorageSystem.new(@client)
+      storage = OneviewSDK::StorageSystem.new(@client_200)
       expect { storage.delete }.to raise_error(/The method #delete is unavailable for this resource/)
     end
   end
@@ -217,8 +217,8 @@ RSpec.describe OneviewSDK::StorageSystem do
         uri: '/rest/storage-systems/100',
         refreshState: 'RefreshPending'
       }
-      storage = OneviewSDK::StorageSystem.new(@client_300, options)
-      storage_updated = OneviewSDK::StorageSystem.new(@client_300, options_update)
+      storage = OneviewSDK::StorageSystem.new(@client_200, options)
+      storage_updated = OneviewSDK::StorageSystem.new(@client_200, options_update)
       allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:update).and_return(FakeResponse.new(storage_updated))
       expect { storage.set_refresh_state('RefreshPending') }.not_to raise_error
       expect(storage['refreshState']).to eq('RefreshPending')

--- a/spec/unit/resource/api200/switch_spec.rb
+++ b/spec/unit/resource/api200/switch_spec.rb
@@ -9,22 +9,22 @@ RSpec.describe OneviewSDK::Switch do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'retrieves by name' do
-      expect(described_class.new(@client, name: 'name1').retrieve!).to be true
-      expect(described_class.new(@client, name: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, name: 'name1').retrieve!).to be true
+      expect(described_class.new(@client_200, name: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by uri' do
-      expect(described_class.new(@client, uri: 'uri1').retrieve!).to be true
-      expect(described_class.new(@client, uri: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').retrieve!).to be true
+      expect(described_class.new(@client_200, uri: 'fake').retrieve!).to be false
     end
 
     it 'retrieves by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').retrieve!).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').retrieve!).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').retrieve!).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').retrieve!).to be false
     end
   end
 
@@ -34,29 +34,29 @@ RSpec.describe OneviewSDK::Switch do
         { name: 'name1', uri: 'uri1', serialNumber: 'sn1' },
         { name: 'name2', uri: 'uri2', serialNumber: 'sn2' }
       ])
-      allow(@client).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
+      allow(@client_200).to receive(:rest_get).with(described_class::BASE_URI).and_return(resp)
     end
 
     it 'finds it by name' do
-      expect(described_class.new(@client, name: 'name1').exists?).to be true
-      expect(described_class.new(@client, name: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, name: 'name1').exists?).to be true
+      expect(described_class.new(@client_200, name: 'fake').exists?).to be false
     end
 
     it 'finds it by uri' do
-      expect(described_class.new(@client, uri: 'uri1').exists?).to be true
-      expect(described_class.new(@client, uri: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, uri: 'uri1').exists?).to be true
+      expect(described_class.new(@client_200, uri: 'fake').exists?).to be false
     end
 
     it 'finds it by serialNumber' do
-      expect(described_class.new(@client, serialNumber: 'sn1').exists?).to be true
-      expect(described_class.new(@client, serialNumber: 'fake').exists?).to be false
+      expect(described_class.new(@client_200, serialNumber: 'sn1').exists?).to be true
+      expect(described_class.new(@client_200, serialNumber: 'fake').exists?).to be false
     end
   end
 
   describe '#remove' do
     it 'Should support remove' do
-      switch = OneviewSDK::Switch.new(@client, uri: '/rest/switches/100')
-      expect(@client).to receive(:rest_delete).with('/rest/switches/100', {}, 200).and_return(FakeResponse.new({}))
+      switch = OneviewSDK::Switch.new(@client_200, uri: '/rest/switches/100')
+      expect(@client_200).to receive(:rest_delete).with('/rest/switches/100', {}, 200).and_return(FakeResponse.new({}))
       switch.remove
     end
   end
@@ -70,46 +70,46 @@ RSpec.describe OneviewSDK::Switch do
           { 'name' => 'SwitchC', 'uri' => 'rest/fake/C' }
         ]
       )
-      expect(@client).to receive(:rest_get).with('/rest/switch-types').and_return(switch_type_list)
-      @item = OneviewSDK::Switch.get_type(@client, 'TheSwitch')
+      expect(@client_200).to receive(:rest_get).with('/rest/switch-types').and_return(switch_type_list)
+      @item = OneviewSDK::Switch.get_type(@client_200, 'TheSwitch')
       expect(@item['uri']).to eq('rest/fake/switch')
     end
   end
 
   describe 'statistics' do
     before :each do
-      @item = OneviewSDK::Switch.new(@client, {})
+      @item = OneviewSDK::Switch.new(@client_200, {})
     end
 
     it 'port' do
-      expect(@client).to receive(:rest_get).with('/statistics/p1').and_return(FakeResponse.new)
+      expect(@client_200).to receive(:rest_get).with('/statistics/p1').and_return(FakeResponse.new)
       @item.statistics('p1')
     end
 
     it 'port and subport' do
-      expect(@client).to receive(:rest_get).with('/statistics/p1/subport/sp1').and_return(FakeResponse.new)
+      expect(@client_200).to receive(:rest_get).with('/statistics/p1/subport/sp1').and_return(FakeResponse.new)
       @item.statistics('p1', 'sp1')
     end
   end
 
   describe 'undefined methods' do
     it 'does not allow the create action' do
-      switch = OneviewSDK::Switch.new(@client)
+      switch = OneviewSDK::Switch.new(@client_200)
       expect { switch.create }.to raise_error(OneviewSDK::MethodUnavailable, /The method #create is unavailable for this resource/)
     end
 
     it 'does not allow the update action' do
-      switch = OneviewSDK::Switch.new(@client)
+      switch = OneviewSDK::Switch.new(@client_200)
       expect { switch.update }.to raise_error(OneviewSDK::MethodUnavailable, /The method #update is unavailable for this resource/)
     end
 
     it 'does not allow the refresh action' do
-      switch = OneviewSDK::Switch.new(@client)
+      switch = OneviewSDK::Switch.new(@client_200)
       expect { switch.refresh }.to raise_error(OneviewSDK::MethodUnavailable, /The method #refresh is unavailable for this resource/)
     end
 
     it 'does not allow the delete action' do
-      switch = OneviewSDK::Switch.new(@client)
+      switch = OneviewSDK::Switch.new(@client_200)
       expect { switch.delete }.to raise_error(OneviewSDK::MethodUnavailable, /The method #delete is unavailable for this resource/)
     end
   end

--- a/spec/unit/resource/api200/unmanaged_device_spec.rb
+++ b/spec/unit/resource/api200/unmanaged_device_spec.rb
@@ -16,15 +16,15 @@ RSpec.describe OneviewSDK::UnmanagedDevice do
 
   describe '#self.get_devices' do
     it 'Get unmanaged devices' do
-      expect(@client).to receive(:rest_get).with('/rest/unmanaged-devices').and_return(FakeResponse.new({}))
-      expect { OneviewSDK::UnmanagedDevice.get_devices(@client) }.not_to raise_error
+      expect(@client_200).to receive(:rest_get).with('/rest/unmanaged-devices').and_return(FakeResponse.new({}))
+      expect { OneviewSDK::UnmanagedDevice.get_devices(@client_200) }.not_to raise_error
     end
   end
 
   describe '#add' do
     it 'Should support add' do
-      device = OneviewSDK::UnmanagedDevice.new(@client, name: 'UnmanagedDevice_1')
-      expect(@client).to receive(:rest_post).with('/rest/unmanaged-devices', { 'body' => { 'name' => 'UnmanagedDevice_1' } }, 200)
+      device = OneviewSDK::UnmanagedDevice.new(@client_200, name: 'UnmanagedDevice_1')
+      expect(@client_200).to receive(:rest_post).with('/rest/unmanaged-devices', { 'body' => { 'name' => 'UnmanagedDevice_1' } }, 200)
         .and_return(FakeResponse.new({}))
       expect { device.add }.not_to raise_error
     end
@@ -32,35 +32,35 @@ RSpec.describe OneviewSDK::UnmanagedDevice do
 
   describe '#remove' do
     it 'Should support remove' do
-      device = OneviewSDK::UnmanagedDevice.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_delete).with('/rest/fake', {}, 200).and_return(FakeResponse.new({}))
+      device = OneviewSDK::UnmanagedDevice.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_delete).with('/rest/fake', {}, 200).and_return(FakeResponse.new({}))
       expect { device.remove }.not_to raise_error
     end
   end
 
   describe '#create' do
     it 'Should raise error if used' do
-      device = OneviewSDK::UnmanagedDevice.new(@client)
+      device = OneviewSDK::UnmanagedDevice.new(@client_200)
       expect { device.create }.to raise_error(OneviewSDK::MethodUnavailable)
     end
   end
 
   describe '#delete' do
     it 'Should raise error if used' do
-      device = OneviewSDK::UnmanagedDevice.new(@client)
+      device = OneviewSDK::UnmanagedDevice.new(@client_200)
       expect { device.delete }.to raise_error(OneviewSDK::MethodUnavailable)
     end
   end
 
   describe '#environmentalConfiguration' do
     it 'requires a uri' do
-      expect { OneviewSDK::UnmanagedDevice.new(@client).environmental_configuration }
+      expect { OneviewSDK::UnmanagedDevice.new(@client_200).environmental_configuration }
         .to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'gets uri/environmentalConfiguration' do
-      item = OneviewSDK::UnmanagedDevice.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_get).with('/rest/fake/environmentalConfiguration').and_return(FakeResponse.new({}))
+      item = OneviewSDK::UnmanagedDevice.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_get).with('/rest/fake/environmentalConfiguration').and_return(FakeResponse.new({}))
       expect { item.environmental_configuration }.not_to raise_error
     end
   end

--- a/spec/unit/resource/api200/uplink_set_spec.rb
+++ b/spec/unit/resource/api200/uplink_set_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::UplinkSet do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      profile = OneviewSDK::UplinkSet.new(@client)
+      profile = OneviewSDK::UplinkSet.new(@client_200)
       expect(profile[:type]).to eq('uplink-setV3')
       expect(profile[:portConfigInfos]).to eq([])
       expect(profile[:networkUris]).to eq([])
@@ -17,7 +17,7 @@ RSpec.describe OneviewSDK::UplinkSet do
 
   describe '#add_port_config' do
     it 'updates the portConfigInfos value' do
-      item = OneviewSDK::UplinkSet.new(@client)
+      item = OneviewSDK::UplinkSet.new(@client_200)
       item.add_port_config('/rest/fake', 1000, [{ 'value' => '1', 'type' => 'Bay' }, { 'value' => '/rest/fake2', 'type' => 'Enclosure' }])
       expect(item['portConfigInfos'].size).to eq(1)
       expect(item['portConfigInfos'].first['portUri']).to eq('/rest/fake')
@@ -29,7 +29,7 @@ RSpec.describe OneviewSDK::UplinkSet do
   describe 'add elements' do
     context 'networks' do
       it 'Valid' do
-        uplink = OneviewSDK::UplinkSet.new(@client)
+        uplink = OneviewSDK::UplinkSet.new(@client_200)
         uplink.add_network(uri: '/rest/ethernet-networks')
         uplink.add_fcnetwork(uri: '/rest/fc-networks')
         uplink.add_fcoenetwork(uri: '/rest/fcoe-networks')
@@ -39,7 +39,7 @@ RSpec.describe OneviewSDK::UplinkSet do
       end
 
       it 'Incorrect' do
-        uplink = OneviewSDK::UplinkSet.new(@client)
+        uplink = OneviewSDK::UplinkSet.new(@client_200)
         expect { uplink.add_network({}) }.to raise_error(OneviewSDK::IncompleteResource, /Must set/)
         expect { uplink.add_fcnetwork({}) }.to raise_error(OneviewSDK::IncompleteResource, /Must set/)
         expect { uplink.add_fcoenetwork({}) }.to raise_error(OneviewSDK::IncompleteResource, /Must set/)
@@ -48,13 +48,13 @@ RSpec.describe OneviewSDK::UplinkSet do
 
     context 'logical interconnects' do
       it 'Valid' do
-        uplink = OneviewSDK::UplinkSet.new(@client)
+        uplink = OneviewSDK::UplinkSet.new(@client_200)
         uplink.set_logical_interconnect(uri: '/rest/logical-interconnects')
         expect(uplink[:logicalInterconnectUri]).to eq('/rest/logical-interconnects')
       end
 
       it 'Incorrect' do
-        uplink = OneviewSDK::UplinkSet.new(@client)
+        uplink = OneviewSDK::UplinkSet.new(@client_200)
         expect { uplink.set_logical_interconnect({}) }.to raise_error(OneviewSDK::IncompleteResource, /Invalid object/)
       end
     end

--- a/spec/unit/resource/api200/user_spec.rb
+++ b/spec/unit/resource/api200/user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe klass do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      res = klass.new(@client)
+      res = klass.new(@client_200)
       expect(res[:type]).to eq('UserAndRoles')
       expect(res[:enabled]).to eq(true)
       expect(res[:roles]).to eq(['Read only'])
@@ -16,9 +16,9 @@ RSpec.describe klass do
   describe '#create' do
     before :each do
       @data = { userName: 'test', password: 'secret123' }
-      @res = klass.new(@client, @data)
+      @res = klass.new(@client_200, @data)
       fake_response = FakeResponse.new(uri: '/rest/fake')
-      allow(@client).to receive(:rest_post).and_return(fake_response)
+      allow(@client_200).to receive(:rest_post).and_return(fake_response)
     end
 
     it 'sets the data returned in the reponse' do
@@ -35,7 +35,7 @@ RSpec.describe klass do
   describe '#update' do
     before :each do
       @data = { 'userName' => 'test', 'uri' => '/rest/fake', 'roles' => ['Read only'] }
-      @res = klass.new(@client, @data)
+      @res = klass.new(@client_200, @data)
     end
 
     it 'requires the client to be set' do
@@ -51,14 +51,14 @@ RSpec.describe klass do
     it 'removes the roles attribute from the PUT request' do
       fake_response = FakeResponse.new(roles: ['Read only'])
       data2 = { 'body' => @res.data.delete_if { |k, _v| k.to_s == 'roles' } }
-      expect(@client).to receive(:rest_put).with(klass::BASE_URI, data2, 200).and_return(fake_response)
+      expect(@client_200).to receive(:rest_put).with(klass::BASE_URI, data2, 200).and_return(fake_response)
       @res.update
     end
 
     it 'sets the roles if they do not match the response' do
       fake_response = FakeResponse.new(roles: ['Network administrator'])
       data2 = { 'body' => @res.data.select { |k, _v| k.to_s != 'roles' } }
-      expect(@client).to receive(:rest_put).with(klass::BASE_URI, data2, 200).and_return(fake_response)
+      expect(@client_200).to receive(:rest_put).with(klass::BASE_URI, data2, 200).and_return(fake_response)
       expect(@res).to receive(:set_roles).with(@res['roles']).and_return(fake_response)
       @res.update
     end
@@ -67,7 +67,7 @@ RSpec.describe klass do
   describe '#update' do
     before :each do
       @data = { 'userName' => 'test', 'uri' => '/rest/fake', 'roles' => ['Read only'] }
-      @res = klass.new(@client, @data)
+      @res = klass.new(@client_200, @data)
     end
 
     it 'requires a roles parameter' do
@@ -88,7 +88,7 @@ RSpec.describe klass do
     it 'makes a PUT call with the role data and sets the data attribute' do
       fake_response = FakeResponse.new([{ 'roleName' => 'Network administrator' }])
       data = { 'body' => [{ roleName: 'Network administrator', type: 'RoleNameDtoV2' }] }
-      expect(@client).to receive(:rest_put).with("#{@data['uri']}/roles?multiResource=true", data, 200)
+      expect(@client_200).to receive(:rest_put).with("#{@data['uri']}/roles?multiResource=true", data, 200)
         .and_return(fake_response)
       expect(@res['roles']).to eq(['Read only']) # Before
       @res.set_roles(['Network administrator'])

--- a/spec/unit/resource/api200/volume_attachment_spec.rb
+++ b/spec/unit/resource/api200/volume_attachment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OneviewSDK::VolumeAttachment do
 
   describe '#initialize' do
     it 'sets the defaults correctly api_ver 200' do
-      item = OneviewSDK::VolumeAttachment.new(@client)
+      item = OneviewSDK::VolumeAttachment.new(@client_200)
       expect(item[:type]).to eq('StorageVolumeAttachment')
     end
   end
@@ -13,48 +13,48 @@ RSpec.describe OneviewSDK::VolumeAttachment do
   describe 'Unmanaged Storage volumes' do
     it 'remove' do
       options = { type: 'ExtraUnmanagedStorageVolumes', resourceUri: '/rest/server-profiles/1' }
-      expect(@client).to receive(:rest_post).with(
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/storage-volume-attachments/repair',
         { 'Accept-Language' => 'en_US', 'body' => options },
-        @client.api_version
+        @client_200.api_version
       ).and_return(FakeResponse.new({}))
-      OneviewSDK::VolumeAttachment.remove_extra_unmanaged_volume(@client, 'uri' => '/rest/server-profiles/1')
+      OneviewSDK::VolumeAttachment.remove_extra_unmanaged_volume(@client_200, 'uri' => '/rest/server-profiles/1')
     end
 
     it 'list' do
-      expect(@client).to receive(:rest_get).with('/rest/storage-volume-attachments/repair?alertFixType=ExtraUnmanagedStorageVolumes')
+      expect(@client_200).to receive(:rest_get).with('/rest/storage-volume-attachments/repair?alertFixType=ExtraUnmanagedStorageVolumes')
         .and_return(FakeResponse.new({}))
-      OneviewSDK::VolumeAttachment.get_extra_unmanaged_volumes(@client)
+      OneviewSDK::VolumeAttachment.get_extra_unmanaged_volumes(@client_200)
     end
   end
 
   describe '#path' do
     it 'retrieve by id' do
-      expect(@client).to receive(:rest_get).with('/rest/storage-volume-attachments/volume_attach_1/paths/volume_path_1')
+      expect(@client_200).to receive(:rest_get).with('/rest/storage-volume-attachments/volume_attach_1/paths/volume_path_1')
         .and_return(FakeResponse.new({}))
-      item = OneviewSDK::VolumeAttachment.new(@client, uri: '/rest/storage-volume-attachments/volume_attach_1')
+      item = OneviewSDK::VolumeAttachment.new(@client_200, uri: '/rest/storage-volume-attachments/volume_attach_1')
       item.get_path('volume_path_1')
     end
 
     it 'get list' do
-      expect(@client).to receive(:rest_get).with('/rest/storage-volume-attachments/volume_attach_1/paths')
+      expect(@client_200).to receive(:rest_get).with('/rest/storage-volume-attachments/volume_attach_1/paths')
         .and_return(FakeResponse.new({}))
-      item = OneviewSDK::VolumeAttachment.new(@client, uri: '/rest/storage-volume-attachments/volume_attach_1')
+      item = OneviewSDK::VolumeAttachment.new(@client_200, uri: '/rest/storage-volume-attachments/volume_attach_1')
       item.get_paths
     end
   end
 
   describe 'unavailable methods' do
     it 'create' do
-      item = OneviewSDK::VolumeAttachment.new(@client, uri: '/rest/storage-volume-attachments/volume_attach_1')
+      item = OneviewSDK::VolumeAttachment.new(@client_200, uri: '/rest/storage-volume-attachments/volume_attach_1')
       expect { item.create }.to raise_error(/The method #create is unavailable for this resource/)
     end
     it 'update' do
-      item = OneviewSDK::VolumeAttachment.new(@client, uri: '/rest/storage-volume-attachments/volume_attach_1')
+      item = OneviewSDK::VolumeAttachment.new(@client_200, uri: '/rest/storage-volume-attachments/volume_attach_1')
       expect { item.update }.to raise_error(/The method #update is unavailable for this resource/)
     end
     it 'delete' do
-      item = OneviewSDK::VolumeAttachment.new(@client, uri: '/rest/storage-volume-attachments/volume_attach_1')
+      item = OneviewSDK::VolumeAttachment.new(@client_200, uri: '/rest/storage-volume-attachments/volume_attach_1')
       expect { item.delete }.to raise_error(/The method #delete is unavailable for this resource/)
     end
   end

--- a/spec/unit/resource/api200/volume_snapshot_spec.rb
+++ b/spec/unit/resource/api200/volume_snapshot_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe OneviewSDK::VolumeSnapshot do
 
   describe '#initialize' do
     it 'sets the type correctly' do
-      template = OneviewSDK::VolumeSnapshot.new(@client)
+      template = OneviewSDK::VolumeSnapshot.new(@client_200)
       expect(template[:type]).to eq('Snapshot')
     end
   end
 
   describe 'undefined methods' do
     before :each do
-      @item = OneviewSDK::VolumeSnapshot.new(@client, {})
+      @item = OneviewSDK::VolumeSnapshot.new(@client_200, {})
     end
 
     it 'does not allow the create action' do
@@ -35,17 +35,17 @@ RSpec.describe OneviewSDK::VolumeSnapshot do
 
   describe 'helpers' do
     before :each do
-      @item = OneviewSDK::VolumeSnapshot.new(@client, options)
+      @item = OneviewSDK::VolumeSnapshot.new(@client_200, options)
     end
 
     describe '#set_volume' do
       it 'sets the storageVolumeUri' do
-        @item.set_volume(OneviewSDK::Volume.new(@client, uri: '/rest/storage-volumes/fake'))
+        @item.set_volume(OneviewSDK::Volume.new(@client_200, uri: '/rest/storage-volumes/fake'))
         expect(@item['storageVolumeUri']).to eq('/rest/storage-volumes/fake')
       end
 
       it 'requires a storage_volume with a uri' do
-        vol = OneviewSDK::Volume.new(@client)
+        vol = OneviewSDK::Volume.new(@client_200)
         expect { @item.set_volume(vol) }.to raise_error(OneviewSDK::IncompleteResource, /Must set/)
       end
     end

--- a/spec/unit/resource/api200/volume_spec.rb
+++ b/spec/unit/resource/api200/volume_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OneviewSDK::Volume do
         storagePoolUri: provisioning_parameters[:storagePoolUri],
         uri: '/rest/fake'
       )
-      item = OneviewSDK::Volume.new(@client, name: volume_name)
+      item = OneviewSDK::Volume.new(@client_200, name: volume_name)
       item['provisioningParameters'] = provisioning_parameters
       item.create
       expect(item['provisionType']).to eq(provisioning_parameters[:provisionType])
@@ -38,41 +38,41 @@ RSpec.describe OneviewSDK::Volume do
   describe '#delete' do
     it 'passes an extra header' do
       allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return(true)
-      item = OneviewSDK::Volume.new(@client, uri: '/rest/fake')
-      expect(@client).to receive(:rest_api).with(:delete, '/rest/fake', { 'exportOnly' => true }, item.api_version)
+      item = OneviewSDK::Volume.new(@client_200, uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_api).with(:delete, '/rest/fake', { 'exportOnly' => true }, item.api_version)
       item.delete(:oneview)
     end
   end
 
   describe 'helpers' do
     before :each do
-      @item = OneviewSDK::Volume.new(@client, name: volume_name)
+      @item = OneviewSDK::Volume.new(@client_200, name: volume_name)
     end
 
     describe '#set_storage_system' do
       it 'sets the storageSystemUri' do
-        @item.set_storage_system(OneviewSDK::StorageSystem.new(@client, uri: '/rest/fake'))
+        @item.set_storage_system(OneviewSDK::StorageSystem.new(@client_200, uri: '/rest/fake'))
         expect(@item['storageSystemUri']).to eq('/rest/fake')
       end
     end
 
     describe '#set_storage_pool' do
       it 'sets the storagePoolUri' do
-        @item.set_storage_pool(OneviewSDK::StoragePool.new(@client, uri: '/rest/fake'))
+        @item.set_storage_pool(OneviewSDK::StoragePool.new(@client_200, uri: '/rest/fake'))
         expect(@item['provisioningParameters']['storagePoolUri']).to eq('/rest/fake')
       end
     end
 
     describe '#set_storage_volume_template' do
       it 'sets the templateUri' do
-        @item.set_storage_volume_template(OneviewSDK::Resource.new(@client, uri: '/rest/fake'))
+        @item.set_storage_volume_template(OneviewSDK::Resource.new(@client_200, uri: '/rest/fake'))
         expect(@item['templateUri']).to eq('/rest/fake')
       end
     end
 
     describe '#set_snapshot_pool' do
       it 'sets the snapshotPoolUri' do
-        @item.set_snapshot_pool(OneviewSDK::StoragePool.new(@client, uri: '/rest/fake'))
+        @item.set_snapshot_pool(OneviewSDK::StoragePool.new(@client_200, uri: '/rest/fake'))
         expect(@item['snapshotPoolUri']).to eq('/rest/fake')
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe OneviewSDK::Volume do
         }
         @item['uri'] = '/rest/storage-volumes/fake'
         allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return(true)
-        expect(@client).to receive(:rest_post).with("#{@item['uri']}/snapshots", { 'body' => @snapshot_options }, @item.api_version)
+        expect(@client_200).to receive(:rest_post).with("#{@item['uri']}/snapshots", { 'body' => @snapshot_options }, @item.api_version)
       end
 
       it 'creates the snapshot' do
@@ -98,9 +98,9 @@ RSpec.describe OneviewSDK::Volume do
       it 'gets an array of snapshots' do
         @item['uri'] = '/rest/storage-volumes/fake'
         snapshot_options = { 'type' => 'Snapshot', 'name' => 'Vol1_Snapshot1', 'description' => 'New Snapshot' }
-        snapshots = [OneviewSDK::VolumeSnapshot.new(@client, snapshot_options)]
+        snapshots = [OneviewSDK::VolumeSnapshot.new(@client_200, snapshot_options)]
         allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return('members' => snapshots)
-        expect(@client).to receive(:rest_get).with("#{@item['uri']}/snapshots", @item.api_version)
+        expect(@client_200).to receive(:rest_get).with("#{@item['uri']}/snapshots", @item.api_version)
         snapshots = @item.get_snapshots
         expect(snapshots.class).to eq(Array)
         expect(snapshots.size).to eq(1)
@@ -112,9 +112,9 @@ RSpec.describe OneviewSDK::Volume do
       it 'get snapshot by name' do
         @item['uri'] = '/rest/storage-volumes/fake'
         snapshot_options = { 'type' => 'Snapshot', 'name' => 'Vol1_Snapshot1', 'description' => 'New Snapshot' }
-        snapshots = [OneviewSDK::VolumeSnapshot.new(@client, snapshot_options)]
+        snapshots = [OneviewSDK::VolumeSnapshot.new(@client_200, snapshot_options)]
         allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return('members' => snapshots)
-        expect(@client).to receive(:rest_get).with("#{@item['uri']}/snapshots", @item.api_version)
+        expect(@client_200).to receive(:rest_get).with("#{@item['uri']}/snapshots", @item.api_version)
         snapshot = @item.get_snapshot('Vol1_Snapshot1')
         expect(snapshot['type']).to eq('Snapshot')
         expect(snapshot['name']).to eq('Vol1_Snapshot1')
@@ -126,10 +126,10 @@ RSpec.describe OneviewSDK::Volume do
       it 'Deletes a snapshot of the volume' do
         @item['uri'] = '/rest/storage-volumes/fake'
         snapshot_options = { 'uri' => '/rest/fake', 'type' => 'Snapshot', 'name' => 'Vol1_Snapshot1', 'description' => 'New Snapshot' }
-        snapshots = [OneviewSDK::VolumeSnapshot.new(@client, snapshot_options)]
+        snapshots = [OneviewSDK::VolumeSnapshot.new(@client_200, snapshot_options)]
         allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return('members' => snapshots)
-        expect(@client).to receive(:rest_get).with("#{@item['uri']}/snapshots", @item.api_version)
-        expect(@client).to receive(:rest_api).with(:delete, '/rest/fake', {}, @item.api_version)
+        expect(@client_200).to receive(:rest_get).with("#{@item['uri']}/snapshots", @item.api_version)
+        expect(@client_200).to receive(:rest_api).with(:delete, '/rest/fake', {}, @item.api_version)
         result = @item.delete_snapshot('Vol1_Snapshot1')
         expect(result).to eq(true)
       end
@@ -139,8 +139,8 @@ RSpec.describe OneviewSDK::Volume do
       it 'returns an array of available volumes' do
         volumes = [@item]
         allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return('members' => volumes)
-        expect(@client).to receive(:rest_get).with('/rest/storage-volumes/attachable-volumes')
-        items = OneviewSDK::Volume.get_attachable_volumes(@client)
+        expect(@client_200).to receive(:rest_get).with('/rest/storage-volumes/attachable-volumes')
+        items = OneviewSDK::Volume.get_attachable_volumes(@client_200)
         expect(items.class).to eq(Array)
         expect(items.size).to eq(1)
         expect(items.first['name']).to eq('volume_name')
@@ -151,8 +151,8 @@ RSpec.describe OneviewSDK::Volume do
       it 'gets the list of extra managed storage volume paths' do
         paths = ['%fake1', '%fake2']
         allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return('members' => paths)
-        expect(@client).to receive(:rest_get).with('/rest/storage-volumes/repair?alertFixType=ExtraManagedStorageVolumePaths')
-        results = OneviewSDK::Volume.get_extra_managed_volume_paths(@client)
+        expect(@client_200).to receive(:rest_get).with('/rest/storage-volumes/repair?alertFixType=ExtraManagedStorageVolumePaths')
+        results = OneviewSDK::Volume.get_extra_managed_volume_paths(@client_200)
         expect(results['members']).to eq(paths)
       end
     end
@@ -163,9 +163,9 @@ RSpec.describe OneviewSDK::Volume do
           resourceUri: '/rest/storage-volumes',
           type: 'ExtraManagedStorageVolumePaths'
         }
-        item = OneviewSDK::Volume.new(@client, uri: '/rest/storage-volumes')
+        item = OneviewSDK::Volume.new(@client_200, uri: '/rest/storage-volumes')
         allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return('response' => 'fake')
-        expect(@client).to receive(:rest_post).with("#{item['uri']}/repair", 'body' => body).and_return(true)
+        expect(@client_200).to receive(:rest_post).with("#{item['uri']}/repair", 'body' => body).and_return(true)
         response = item.repair
         expect(response['response']).to eq('fake')
       end

--- a/spec/unit/resource/api200/volume_template_spec.rb
+++ b/spec/unit/resource/api200/volume_template_spec.rb
@@ -27,17 +27,17 @@ RSpec.describe OneviewSDK::VolumeTemplate do
 
   describe '#initialize' do
     it 'sets the defaults correctly' do
-      profile = OneviewSDK::VolumeTemplate.new(@client)
+      profile = OneviewSDK::VolumeTemplate.new(@client_200)
       expect(profile[:type]).to eq('StorageVolumeTemplateV3')
     end
   end
 
   describe '#create' do
     it 'adds a language header to the request' do
-      item = OneviewSDK::VolumeTemplate.new(@client, name: 'Fake')
+      item = OneviewSDK::VolumeTemplate.new(@client_200, name: 'Fake')
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_post).and_return(true)
       allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return(uri: '/rest/fake')
-      expect(@client).to receive(:rest_post).with(
+      expect(@client_200).to receive(:rest_post).with(
         '/rest/storage-volume-templates',
         { 'Accept-Language' => 'en_US', 'body' => item.data },
         item.api_version
@@ -49,14 +49,14 @@ RSpec.describe OneviewSDK::VolumeTemplate do
 
   describe '#update' do
     it 'requires a uri' do
-      expect { OneviewSDK::VolumeTemplate.new(@client).update }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+      expect { OneviewSDK::VolumeTemplate.new(@client_200).update }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
     end
 
     it 'updates the name of the volume template' do
-      item = OneviewSDK::VolumeTemplate.new(@client, uri: '/rest/fake', name: 'Fake')
+      item = OneviewSDK::VolumeTemplate.new(@client_200, uri: '/rest/fake', name: 'Fake')
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_put).and_return(true)
       allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).with(true).and_return(item['name'] = 'Fake2')
-      expect(@client).to receive(:rest_put).with(
+      expect(@client_200).to receive(:rest_put).with(
         '/rest/fake',
         { 'Accept-Language' => 'en_US', 'body' => item.data },
         item.api_version
@@ -69,10 +69,10 @@ RSpec.describe OneviewSDK::VolumeTemplate do
 
   describe '#delete' do
     it 'adds a language header to the request' do
-      item = OneviewSDK::VolumeTemplate.new(@client, name: 'Fake', uri: '/rest/fake')
+      item = OneviewSDK::VolumeTemplate.new(@client_200, name: 'Fake', uri: '/rest/fake')
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_delete).and_return(true)
       allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return(true)
-      expect(@client).to receive(:rest_delete).with(
+      expect(@client_200).to receive(:rest_delete).with(
         '/rest/fake',
         { 'Accept-Language' => 'en_US' },
         item.api_version
@@ -84,7 +84,7 @@ RSpec.describe OneviewSDK::VolumeTemplate do
   describe '#set' do
     context 'provisioning' do
       it 'Attributes' do
-        volume_template = OneviewSDK::VolumeTemplate.new(@client)
+        volume_template = OneviewSDK::VolumeTemplate.new(@client_200)
         volume_template.set_provisioning(true, 'Thin', '10737418240', fake_storage_pool)
         expect(volume_template['provisioning']['shareable']).to eq(true)
         expect(volume_template['provisioning']['provisionType']).to eq('Thin')
@@ -95,13 +95,13 @@ RSpec.describe OneviewSDK::VolumeTemplate do
 
     context 'data' do
       it 'storage system' do
-        volume_template = OneviewSDK::VolumeTemplate.new(@client)
+        volume_template = OneviewSDK::VolumeTemplate.new(@client_200)
         volume_template.set_storage_system(fake_storage_system)
         expect(volume_template['storageSystemUri']).to eq('/rest/storage-systems/fake_uri')
       end
 
       it 'snapshot pool' do
-        volume_template = OneviewSDK::VolumeTemplate.new(@client)
+        volume_template = OneviewSDK::VolumeTemplate.new(@client_200)
         volume_template.set_snapshot_pool(fake_snapshot_pool)
         expect(volume_template['snapshotPoolUri']).to eq('/rest/storage-systems/snapshot-pools/fake_uri')
       end
@@ -110,9 +110,9 @@ RSpec.describe OneviewSDK::VolumeTemplate do
 
   describe '#get_connectable_volume_templates' do
     it 'gets the connectable volume templates by its attributes' do
-      volume_template = OneviewSDK::VolumeTemplate.new(@client)
+      volume_template = OneviewSDK::VolumeTemplate.new(@client_200)
       allow(OneviewSDK::Resource)
-        .to receive(:find_by).with(@client, {}, '/rest/storage-volume-templates/connectable-volume-templates').and_return('fake')
+        .to receive(:find_by).with(@client_200, {}, '/rest/storage-volume-templates/connectable-volume-templates').and_return('fake')
       expect(volume_template.get_connectable_volume_templates).to eq('fake')
     end
   end

--- a/spec/unit/resource/api300/c7000/firmware_bundle_spec.rb
+++ b/spec/unit/resource/api300/c7000/firmware_bundle_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe OneviewSDK::API300::C7000::FirmwareBundle do
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
       http_fake = spy('http')
       allow(Net::HTTP).to receive(:new).and_return(http_fake)
-      described_class.add(@client, 'file.tar')
+      described_class.add(@client_200, 'file.tar')
       expect(http_fake).to have_received(:read_timeout=).with(described_class::READ_TIMEOUT)
     end
 
@@ -39,7 +39,7 @@ RSpec.describe OneviewSDK::API300::C7000::FirmwareBundle do
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
       http_fake = spy('http')
       allow(Net::HTTP).to receive(:new).and_return(http_fake)
-      described_class.add(@client, 'file.tar', 600)
+      described_class.add(@client_200, 'file.tar', 600)
       expect(http_fake).to have_received(:read_timeout=).with(600)
     end
 
@@ -49,7 +49,7 @@ RSpec.describe OneviewSDK::API300::C7000::FirmwareBundle do
       allow(File).to receive(:file?).and_return(true)
       allow(File).to receive(:open).with('file.tar').and_yield('FAKE FILE CONTENT')
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
-      expect { described_class.add(@client, 'file.tar') }.to raise_error(/The connection was closed/)
+      expect { described_class.add(@client_200, 'file.tar') }.to raise_error(/The connection was closed/)
     end
   end
 end

--- a/spec/unit/resource/api300/c7000/storage_system_spec.rb
+++ b/spec/unit/resource/api300/c7000/storage_system_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe OneviewSDK::API300::C7000::StorageSystem do
         state: 'Configured'
       }
       item = OneviewSDK::API300::C7000::StorageSystem.new(
-        @client,
+        @client_200,
         name: 'StorageSystemName',
         credentials: {
           'ip_hostname' => '127.0.0.1',
@@ -115,7 +115,7 @@ RSpec.describe OneviewSDK::API300::C7000::StorageSystem do
         'state' => 'Configured'
       }
       item = OneviewSDK::API300::C7000::StorageSystem.new(
-        @client,
+        @client_200,
         'name' => 'StorageSystemName',
         'credentials' => {
           'ip_hostname' => '127.0.0.1',
@@ -129,14 +129,14 @@ RSpec.describe OneviewSDK::API300::C7000::StorageSystem do
     it 'must not compare storage system credentials with password when compares resources ' do
       options1 = { name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin' } }
       options2 = { name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin', password: 'secret' } }
-      item1 = OneviewSDK::API300::C7000::StorageSystem.new(@client, options1)
-      item2 = OneviewSDK::API300::C7000::StorageSystem.new(@client, options2)
+      item1 = OneviewSDK::API300::C7000::StorageSystem.new(@client_200, options1)
+      item2 = OneviewSDK::API300::C7000::StorageSystem.new(@client_200, options2)
       expect(item1.like?(item2)).to eq(true)
     end
 
     it 'must not compare storage system with invalid data types' do
       options = { name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin' } }
-      item1 = OneviewSDK::API300::C7000::StorageSystem.new(@client, options)
+      item1 = OneviewSDK::API300::C7000::StorageSystem.new(@client_200, options)
       expect(item1.like?(credentials: true)).to eq(false)
     end
   end

--- a/spec/unit/resource/api300/synergy/enclosure_spec.rb
+++ b/spec/unit/resource/api300/synergy/enclosure_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe OneviewSDK::API300::Synergy::Enclosure do
 
   describe '#set_environmental_configuration' do
     it 'does not allow the method' do
-      enclosure = OneviewSDK::API300::Synergy::Enclosure.new(@client)
+      enclosure = OneviewSDK::API300::Synergy::Enclosure.new(@client_200)
       expect { enclosure.set_environmental_configuration }
         .to raise_error(OneviewSDK::MethodUnavailable, /The method #set_environmental_configuration is unavailable for this resource/)
     end

--- a/spec/unit/resource/api300/synergy/firmware_bundle_spec.rb
+++ b/spec/unit/resource/api300/synergy/firmware_bundle_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe OneviewSDK::API300::Synergy::FirmwareBundle do
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
       http_fake = spy('http')
       allow(Net::HTTP).to receive(:new).and_return(http_fake)
-      described_class.add(@client, 'file.tar')
+      described_class.add(@client_200, 'file.tar')
       expect(http_fake).to have_received(:read_timeout=).with(described_class::READ_TIMEOUT)
     end
 
@@ -39,7 +39,7 @@ RSpec.describe OneviewSDK::API300::Synergy::FirmwareBundle do
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
       http_fake = spy('http')
       allow(Net::HTTP).to receive(:new).and_return(http_fake)
-      described_class.add(@client, 'file.tar', 600)
+      described_class.add(@client_200, 'file.tar', 600)
       expect(http_fake).to have_received(:read_timeout=).with(600)
     end
 
@@ -49,7 +49,7 @@ RSpec.describe OneviewSDK::API300::Synergy::FirmwareBundle do
       allow(File).to receive(:file?).and_return(true)
       allow(File).to receive(:open).with('file.tar').and_yield('FAKE FILE CONTENT')
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
-      expect { described_class.add(@client, 'file.tar') }.to raise_error(/The connection was closed/)
+      expect { described_class.add(@client_200, 'file.tar') }.to raise_error(/The connection was closed/)
     end
   end
 end

--- a/spec/unit/resource/api300/synergy/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api300/synergy/logical_interconnect_group_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe OneviewSDK::API300::Synergy::LogicalInterconnectGroup do
   describe '#add_internal_network' do
     it 'adds a network' do
       item = described_class.new(@client_300)
-      network = OneviewSDK::API300::Synergy::EthernetNetwork.new(@client, uri: '/rest/fake')
+      network = OneviewSDK::API300::Synergy::EthernetNetwork.new(@client_200, uri: '/rest/fake')
       expect(item.add_internal_network(network)).to be
       expect(item['internalNetworkUris']).to eq(['/rest/fake'])
     end

--- a/spec/unit/resource/api300/synergy/storage_system_spec.rb
+++ b/spec/unit/resource/api300/synergy/storage_system_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe OneviewSDK::API300::Synergy::StorageSystem do
         state: 'Configured'
       }
       item = OneviewSDK::API300::Synergy::StorageSystem.new(
-        @client,
+        @client_200,
         name: 'StorageSystemName',
         credentials: {
           'ip_hostname' => '127.0.0.1',
@@ -117,7 +117,7 @@ RSpec.describe OneviewSDK::API300::Synergy::StorageSystem do
         'state' => 'Configured'
       }
       item = OneviewSDK::API300::Synergy::StorageSystem.new(
-        @client,
+        @client_200,
         'name' => 'StorageSystemName',
         'credentials' => {
           'ip_hostname' => '127.0.0.1',
@@ -131,14 +131,14 @@ RSpec.describe OneviewSDK::API300::Synergy::StorageSystem do
     it 'must not compare storage system credentials with password when compares resources ' do
       options1 = { name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin' } }
       options2 = { name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin', password: 'secret' } }
-      item1 = OneviewSDK::API300::Synergy::StorageSystem.new(@client, options1)
-      item2 = OneviewSDK::API300::Synergy::StorageSystem.new(@client, options2)
+      item1 = OneviewSDK::API300::Synergy::StorageSystem.new(@client_200, options1)
+      item2 = OneviewSDK::API300::Synergy::StorageSystem.new(@client_200, options2)
       expect(item1.like?(item2)).to eq(true)
     end
 
     it 'must not compare storage system with invalid data types' do
       options = { name: 'Fake', credentials: { ip_hostname: 'a.com', username: 'admin' } }
-      item1 = OneviewSDK::API300::Synergy::StorageSystem.new(@client, options)
+      item1 = OneviewSDK::API300::Synergy::StorageSystem.new(@client_200, options)
       expect(item1.like?(credentials: true)).to eq(false)
     end
   end

--- a/spec/unit/resource/api500/c7000/resource_spec.rb
+++ b/spec/unit/resource/api500/c7000/resource_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe OneviewSDK::API500::C7000::Resource do
+  include_context 'shared context'
+
+  it 'inherits from OneviewSDK::Resource' do
+    expect(described_class).to be < OneviewSDK::Resource
+  end
+end

--- a/spec/unit/resource/api500/c7000_spec.rb
+++ b/spec/unit/resource/api500/c7000_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe OneviewSDK::API500::C7000 do
+  describe '#resource_named' do
+    it 'calls the OneviewSDK::API500.resource_named method' do
+      expect(OneviewSDK::API500).to receive(:resource_named).with('ConnectionTemplate', 'C7000')
+      described_class.resource_named('ConnectionTemplate')
+    end
+  end
+end

--- a/spec/unit/resource/api500/synergy/resource_spec.rb
+++ b/spec/unit/resource/api500/synergy/resource_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe OneviewSDK::API500::Synergy::Resource do
+  include_context 'shared context'
+
+  it 'inherits from OneviewSDK::Resource' do
+    expect(described_class).to be < OneviewSDK::Resource
+  end
+end

--- a/spec/unit/resource/api500/synergy_spec.rb
+++ b/spec/unit/resource/api500/synergy_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe OneviewSDK::API500::Synergy do
+  describe '#resource_named' do
+    it 'calls the OneviewSDK::API500.resource_named method' do
+      expect(OneviewSDK::API500).to receive(:resource_named).with('ConnectionTemplate', 'Synergy')
+      described_class.resource_named('ConnectionTemplate')
+    end
+  end
+end

--- a/spec/unit/resource/api500_spec.rb
+++ b/spec/unit/resource/api500_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe OneviewSDK::API500 do
+  it 'has a list of supported variants' do
+    variants = described_class::SUPPORTED_VARIANTS
+    expect(variants).to be_a Array
+    %w(C7000 Synergy).each { |v| expect(variants).to include(v) }
+  end
+
+  it 'returns a valid API500 variant' do
+    %w(C7000 Synergy).each { |v| expect { OneviewSDK::API500.const_get(v) }.not_to raise_error }
+  end
+
+  it 'raises an error when an invalid API500 variant is called' do
+    expect { OneviewSDK::API500::C6000 }
+      .to raise_error(NameError, 'The C6000 method or resource does not exist for OneView API500 variant C7000.')
+  end
+
+  it 'has a default api variant' do
+    expect(described_class::DEFAULT_VARIANT).to eq('C7000')
+  end
+
+  describe '#resource_named' do
+    it 'gets the correct resource class' do
+      expect(described_class.resource_named('ServerProfile')).to eq(described_class::ServerProfile)
+    end
+
+    it 'allows you to override the variant' do
+      expect(described_class.resource_named('ServerProfile', 'Synergy')).to eq(described_class::Synergy::ServerProfile)
+      expect(described_class.resource_named('ServerProfile', 'C7000')).to eq(described_class::C7000::ServerProfile)
+    end
+  end
+
+  describe '#variant' do
+    it 'gets the current variant' do
+      expect(described_class::SUPPORTED_VARIANTS).to include(OneviewSDK::API500.variant)
+    end
+  end
+
+  describe '#variant=' do
+    it 'sets the current variant' do
+      OneviewSDK::API500.variant = 'Synergy'
+      expect(OneviewSDK::API500.variant).to eq('Synergy')
+      expect(OneviewSDK::API500.variant_updated?).to eq(true)
+    end
+  end
+end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -10,32 +10,32 @@ RSpec.describe OneviewSDK::Resource do
     end
 
     it 'uses the client\'s logger' do
-      res = OneviewSDK::Resource.new(@client)
-      expect(res.logger).to eq(@client.logger)
+      res = OneviewSDK::Resource.new(@client_200)
+      expect(res.logger).to eq(@client_200.logger)
     end
 
     it 'uses the client\'s api version' do
-      res = OneviewSDK::Resource.new(@client)
-      expect(res.api_version).to eq(@client.api_version)
+      res = OneviewSDK::Resource.new(@client_200)
+      expect(res.api_version).to eq(@client_200.api_version)
     end
 
     it 'can override the client\'s api version' do
-      res = OneviewSDK::Resource.new(@client, {}, 120)
-      expect(res.api_version).to_not eq(@client.api_version)
+      res = OneviewSDK::Resource.new(@client_200, {}, 120)
+      expect(res.api_version).to_not eq(@client_200.api_version)
       expect(res.api_version).to eq(120)
     end
 
     it 'can\'t use an api version greater than the client\'s max' do
-      expect { OneviewSDK::Resource.new(@client, {}, 400) }.to raise_error(OneviewSDK::UnsupportedVersion, /is greater than the client's max/)
+      expect { OneviewSDK::Resource.new(@client_200, {}, 600) }.to raise_error(OneviewSDK::UnsupportedVersion, /is greater than the client's max/)
     end
 
     it 'starts with an empty data hash' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       expect(res.data).to eq({})
     end
 
     it 'sets the provided attributes' do
-      res = OneviewSDK::Resource.new(@client, name: 'Test', description: 'None')
+      res = OneviewSDK::Resource.new(@client_200, name: 'Test', description: 'None')
       expect(res[:name]).to eq('Test')
       expect(res['description']).to eq('None')
     end
@@ -43,14 +43,14 @@ RSpec.describe OneviewSDK::Resource do
 
   describe '#retrieve!' do
     it 'requires the name attribute to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       expect { res.retrieve! }.to raise_error(OneviewSDK::IncompleteResource, /Must set resource name/)
     end
 
     it 'sets the data if the resource is found' do
-      res = OneviewSDK::Resource.new(@client, name: 'ResourceName')
+      res = OneviewSDK::Resource.new(@client_200, name: 'ResourceName')
       allow(OneviewSDK::Resource).to receive(:find_by).and_return([
-        OneviewSDK::Resource.new(@client, res.data.merge(uri: '/rest/fake', description: 'Blah'))
+        OneviewSDK::Resource.new(@client_200, res.data.merge(uri: '/rest/fake', description: 'Blah'))
       ])
       res.retrieve!
       expect(res['uri']).to eq('/rest/fake')
@@ -59,41 +59,41 @@ RSpec.describe OneviewSDK::Resource do
 
     it 'returns false when the resource is not found' do
       allow(OneviewSDK::Resource).to receive(:find_by).and_return([])
-      res = OneviewSDK::Resource.new(@client, name: 'ResourceName')
+      res = OneviewSDK::Resource.new(@client_200, name: 'ResourceName')
       expect(res.retrieve!).to eq(false)
     end
 
     it 'returns false when multiple resources match' do
       allow(OneviewSDK::Resource).to receive(:find_by).and_return([
-        OneviewSDK::Resource.new(@client, name: 'ResourceName'),
-        OneviewSDK::Resource.new(@client, name: 'ResourceName')
+        OneviewSDK::Resource.new(@client_200, name: 'ResourceName'),
+        OneviewSDK::Resource.new(@client_200, name: 'ResourceName')
       ])
-      res = OneviewSDK::Resource.new(@client, name: 'ResourceName')
+      res = OneviewSDK::Resource.new(@client_200, name: 'ResourceName')
       expect(res.retrieve!).to eq(false)
     end
   end
 
   describe '#exists?' do
     it 'requires the name attribute to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       expect { res.exists? }.to raise_error(OneviewSDK::IncompleteResource, /Must set resource name or uri/)
     end
 
     it 'uses the uri attribute when the name is not set' do
-      res = OneviewSDK::Resource.new(@client, uri: '/rest/fake')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, 'uri' => res['uri']).and_return([])
+      res = OneviewSDK::Resource.new(@client_200, uri: '/rest/fake')
+      expect(OneviewSDK::Resource).to receive(:find_by).with(@client_200, 'uri' => res['uri']).and_return([])
       expect(res.exists?).to eq(false)
     end
 
     it 'returns true when the resource is found' do
-      res = OneviewSDK::Resource.new(@client, name: 'ResourceName')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, 'name' => res['name']).and_return([res])
+      res = OneviewSDK::Resource.new(@client_200, name: 'ResourceName')
+      expect(OneviewSDK::Resource).to receive(:find_by).with(@client_200, 'name' => res['name']).and_return([res])
       expect(res.exists?).to eq(true)
     end
 
     it 'returns false when the resource is not found' do
-      res = OneviewSDK::Resource.new(@client, uri: '/rest/fake')
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, 'uri' => res['uri']).and_return([])
+      res = OneviewSDK::Resource.new(@client_200, uri: '/rest/fake')
+      expect(OneviewSDK::Resource).to receive(:find_by).with(@client_200, 'uri' => res['uri']).and_return([])
       expect(res.exists?).to eq(false)
     end
   end
@@ -101,28 +101,28 @@ RSpec.describe OneviewSDK::Resource do
   describe '#==' do
     context 'class equality' do
       it 'returns true when the classes are the same' do
-        res1 = OneviewSDK::Enclosure.new(@client, name: 'ResourceName')
-        res2 = OneviewSDK::Enclosure.new(@client, name: 'ResourceName')
+        res1 = OneviewSDK::Enclosure.new(@client_200, name: 'ResourceName')
+        res2 = OneviewSDK::Enclosure.new(@client_200, name: 'ResourceName')
         expect(res1 == res2).to eq(true)
       end
 
       it 'returns false when the classes are not the same' do
-        res1 = OneviewSDK::Resource.new(@client, name: 'ResourceName')
-        res2 = OneviewSDK::Enclosure.new(@client, name: 'ResourceName')
+        res1 = OneviewSDK::Resource.new(@client_200, name: 'ResourceName')
+        res2 = OneviewSDK::Enclosure.new(@client_200, name: 'ResourceName')
         expect(res1 == res2).to eq(false)
       end
     end
 
     context 'attribute equality' do
       it 'returns true when the attributes are the same' do
-        res1 = OneviewSDK::Enclosure.new(@client, name: 'ResourceName')
-        res2 = OneviewSDK::Enclosure.new(@client, name: 'ResourceName')
+        res1 = OneviewSDK::Enclosure.new(@client_200, name: 'ResourceName')
+        res2 = OneviewSDK::Enclosure.new(@client_200, name: 'ResourceName')
         expect(res1 == res2).to eq(true)
       end
 
       it 'returns false when the attributes are not the same' do
-        res1 = OneviewSDK::Enclosure.new(@client)
-        res2 = OneviewSDK::Enclosure.new(@client, name: 'ResourceName')
+        res1 = OneviewSDK::Enclosure.new(@client_200)
+        res2 = OneviewSDK::Enclosure.new(@client_200, name: 'ResourceName')
         expect(res1 == res2).to eq(false)
       end
     end
@@ -130,8 +130,8 @@ RSpec.describe OneviewSDK::Resource do
 
   describe '#eql?' do
     it 'calls the == method' do
-      res1 = OneviewSDK::Enclosure.new(@client, name: 'ResourceName')
-      res2 = OneviewSDK::Enclosure.new(@client, name: 'ResourceName')
+      res1 = OneviewSDK::Enclosure.new(@client_200, name: 'ResourceName')
+      res2 = OneviewSDK::Enclosure.new(@client_200, name: 'ResourceName')
       expect(res1).to receive(:==).with(res2)
       res1.eql?(res2)
     end
@@ -140,68 +140,68 @@ RSpec.describe OneviewSDK::Resource do
   describe '#like?' do
     it 'returns true for an alike hash' do
       options = { name: 'res', uri: '/rest/fake', description: 'Resource' }
-      res = OneviewSDK::Resource.new(@client, options)
+      res = OneviewSDK::Resource.new(@client_200, options)
       expect(res.like?(description: 'Resource', uri: '/rest/fake', name: 'res')).to eq(true)
     end
 
     it 'returns true for an alike resource' do
       options = { name: 'res', uri: '/rest/fake', description: 'Resource' }
-      res = OneviewSDK::Resource.new(@client, options)
-      res2 = OneviewSDK::Resource.new(@client, options)
+      res = OneviewSDK::Resource.new(@client_200, options)
+      res2 = OneviewSDK::Resource.new(@client_200, options)
       expect(res.like?(res2)).to eq(true)
     end
 
     it 'does not compare client object or api_version' do
       options = { name: 'res', uri: '/rest/fake', description: 'Resource' }
-      res = OneviewSDK::Resource.new(@client, options)
+      res = OneviewSDK::Resource.new(@client_200, options)
       res2 = OneviewSDK::Resource.new(@client_120, options, 120)
       expect(res.like?(res2)).to eq(true)
     end
 
     it 'works for nested hashes' do
       options = { name: 'res', uri: '/rest/fake', data: { 'key1' => 'val1', 'key2' => 'val2' } }
-      res = OneviewSDK::Resource.new(@client, options)
+      res = OneviewSDK::Resource.new(@client_200, options)
       expect(res.like?(data: { key2: 'val2' })).to eq(true)
     end
 
     it 'returns false for unlike hashes' do
       options = { name: 'res', uri: '/rest/fake' }
-      res = OneviewSDK::Resource.new(@client, options)
+      res = OneviewSDK::Resource.new(@client_200, options)
       expect(res.like?(data: { key2: 'val2' })).to eq(false)
     end
 
     it 'requires the other objet to respond to .each' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       expect { res.like?(nil) }.to raise_error(/Can't compare with object type: NilClass/)
     end
   end
 
   describe '#create' do
     it 'requires the client to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       res.client = nil
       expect { res.create }.to raise_error(OneviewSDK::IncompleteResource, /Please set client attribute/)
     end
 
     it 'sets the data from the response' do
-      res = OneviewSDK::Resource.new(@client, name: 'Name')
+      res = OneviewSDK::Resource.new(@client_200, name: 'Name')
       fake_response = FakeResponse.new(res.data.merge(uri: '/rest/fake'))
-      allow(@client).to receive(:rest_post).and_return(fake_response)
+      allow(@client_200).to receive(:rest_post).and_return(fake_response)
       res.create
       expect(res['uri']).to eq('/rest/fake')
     end
 
     it 'raises an error if the request failed' do
-      res = OneviewSDK::Resource.new(@client, name: 'Name')
+      res = OneviewSDK::Resource.new(@client_200, name: 'Name')
       fake_response = FakeResponse.new({ message: 'Invalid' }, 400)
-      allow(@client).to receive(:rest_post).and_return(fake_response)
+      allow(@client_200).to receive(:rest_post).and_return(fake_response)
       expect { res.create }.to raise_error(OneviewSDK::BadRequest, /400 BAD REQUEST {"message":"Invalid"}/)
     end
   end
 
   describe '#create!' do
     before :each do
-      @res = OneviewSDK::Resource.new(@client, name: 'Name')
+      @res = OneviewSDK::Resource.new(@client_200, name: 'Name')
     end
 
     it 'deletes the resource if it exists' do
@@ -221,20 +221,20 @@ RSpec.describe OneviewSDK::Resource do
 
   describe '#refresh' do
     it 'requires the client to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       res.client = nil
       expect { res.refresh }.to raise_error(OneviewSDK::IncompleteResource, /Please set client attribute/)
     end
 
     it 'requires the uri to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       expect { res.refresh }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute/)
     end
 
     it 'sets the data from the server\'s response' do
-      res = OneviewSDK::Resource.new(@client, name: 'Name', uri: '/rest/fake')
+      res = OneviewSDK::Resource.new(@client_200, name: 'Name', uri: '/rest/fake')
       fake_response = FakeResponse.new(res.data.merge(name: 'NewName', description: 'Blah'))
-      allow(@client).to receive(:rest_get).and_return(fake_response)
+      allow(@client_200).to receive(:rest_get).and_return(fake_response)
       res.refresh
       expect(res['name']).to eq('NewName')
       expect(res['description']).to eq('Blah')
@@ -243,52 +243,52 @@ RSpec.describe OneviewSDK::Resource do
 
   describe '#update' do
     it 'requires the client to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       res.client = nil
       expect { res.update }.to raise_error(OneviewSDK::IncompleteResource, /Please set client attribute/)
     end
 
     it 'requires the uri to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       expect { res.update }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute/)
     end
 
     it 'uses the rest_put method to update the data' do
-      res = OneviewSDK::Resource.new(@client, name: 'Name', uri: '/rest/fake')
-      expect(@client).to receive(:rest_put).with(res['uri'], { 'body' => res.data }, res.api_version).and_return(FakeResponse.new)
+      res = OneviewSDK::Resource.new(@client_200, name: 'Name', uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_put).with(res['uri'], { 'body' => res.data }, res.api_version).and_return(FakeResponse.new)
       res.update
     end
 
     it 'raises an error if the update fails' do
-      res = OneviewSDK::Resource.new(@client, name: 'Name', uri: '/rest/fake')
+      res = OneviewSDK::Resource.new(@client_200, name: 'Name', uri: '/rest/fake')
       fake_response = FakeResponse.new({ message: 'Invalid' }, 400)
-      expect(@client).to receive(:rest_put).with(res['uri'], { 'body' => res.data }, res.api_version).and_return(fake_response)
+      expect(@client_200).to receive(:rest_put).with(res['uri'], { 'body' => res.data }, res.api_version).and_return(fake_response)
       expect { res.update }.to raise_error(OneviewSDK::BadRequest, /400 BAD REQUEST {"message":"Invalid"}/)
     end
   end
 
   describe '#delete' do
     it 'requires the client to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       res.client = nil
       expect { res.delete }.to raise_error(OneviewSDK::IncompleteResource, /Please set client attribute/)
     end
 
     it 'requires the uri to be set' do
-      res = OneviewSDK::Resource.new(@client)
+      res = OneviewSDK::Resource.new(@client_200)
       expect { res.delete }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute/)
     end
 
     it 'returns true if the delete was successful' do
-      res = OneviewSDK::Resource.new(@client, name: 'Name', uri: '/rest/fake')
-      expect(@client).to receive(:rest_delete).with(res['uri'], {}, res.api_version).and_return(FakeResponse.new)
+      res = OneviewSDK::Resource.new(@client_200, name: 'Name', uri: '/rest/fake')
+      expect(@client_200).to receive(:rest_delete).with(res['uri'], {}, res.api_version).and_return(FakeResponse.new)
       expect(res.delete).to eq(true)
     end
 
     it 'raises an error if the delete fails' do
-      res = OneviewSDK::Resource.new(@client, name: 'Name', uri: '/rest/fake')
+      res = OneviewSDK::Resource.new(@client_200, name: 'Name', uri: '/rest/fake')
       fake_response = FakeResponse.new({ message: 'Invalid' }, 400)
-      expect(@client).to receive(:rest_delete).with(res['uri'], {}, res.api_version).and_return(fake_response)
+      expect(@client_200).to receive(:rest_delete).with(res['uri'], {}, res.api_version).and_return(fake_response)
       expect { res.delete }.to raise_error(OneviewSDK::BadRequest, /400 BAD REQUEST {"message":"Invalid"}/)
     end
   end
@@ -297,7 +297,7 @@ RSpec.describe OneviewSDK::Resource do
     let(:file_like_object) { double('file like object') }
 
     before :each do
-      @res = OneviewSDK::Enclosure.new(@client, name: 'Name', uri: '/rest/fake')
+      @res = OneviewSDK::Enclosure.new(@client_200, name: 'Name', uri: '/rest/fake')
       @data = { type: @res.class.name, api_version: @res.api_version, data: @res.data }
     end
 
@@ -323,31 +323,31 @@ RSpec.describe OneviewSDK::Resource do
 
   describe '#schema' do
     it 'forwards the instance method call to the class method' do
-      expect(OneviewSDK::Resource).to receive(:schema).with(@client)
-      OneviewSDK::Resource.new(@client).schema
+      expect(OneviewSDK::Resource).to receive(:schema).with(@client_200)
+      OneviewSDK::Resource.new(@client_200).schema
     end
 
     it 'tries to get BASE_URI/schema' do
-      expect(@client).to receive(:rest_get).with("#{OneviewSDK::Resource::BASE_URI}/schema", @client.api_version)
+      expect(@client_200).to receive(:rest_get).with("#{OneviewSDK::Resource::BASE_URI}/schema", @client_200.api_version)
         .and_return(FakeResponse.new(key: 'val1', other_key: 'val2'))
-      schema = OneviewSDK::Resource.schema(@client)
+      schema = OneviewSDK::Resource.schema(@client_200)
       expect(schema['key']).to eq('val1')
       expect(schema['other_key']).to eq('val2')
     end
 
     it 'displays a nice error if the schema endpoint returns a 404 response' do
       fake_response = FakeResponse.new({ message: 'Not Found' }, 404)
-      allow(@client).to receive(:rest_get).and_return(fake_response)
-      expect(@client.logger).to receive(:error).with(/does not implement the schema endpoint/)
-      expect { OneviewSDK::Resource.schema(@client) }.to raise_error(OneviewSDK::NotFound, /404 NOT FOUND/)
+      allow(@client_200).to receive(:rest_get).and_return(fake_response)
+      expect(@client_200.logger).to receive(:error).with(/does not implement the schema endpoint/)
+      expect { OneviewSDK::Resource.schema(@client_200) }.to raise_error(OneviewSDK::NotFound, /404 NOT FOUND/)
     end
   end
 
   describe '#find_by' do
     it 'returns an empty array if no results are found' do
       fake_response = FakeResponse.new(members: [])
-      allow(@client).to receive(:rest_get).and_return(fake_response)
-      res = OneviewSDK::Enclosure.find_by(@client, {})
+      allow(@client_200).to receive(:rest_get).and_return(fake_response)
+      res = OneviewSDK::Enclosure.find_by(@client_200, {})
       expect(res.size).to eq(0)
     end
 
@@ -358,8 +358,8 @@ RSpec.describe OneviewSDK::Resource do
         { name: 'Enc3', uri: "#{OneviewSDK::Enclosure::BASE_URI}/3", state: 'Monitored' },
         { name: 'Enc4', uri: "#{OneviewSDK::Enclosure::BASE_URI}/4" }
       ])
-      allow(@client).to receive(:rest_get).and_return(fake_response)
-      res = OneviewSDK::Enclosure.find_by(@client, state: 'Monitored')
+      allow(@client_200).to receive(:rest_get).and_return(fake_response)
+      res = OneviewSDK::Enclosure.find_by(@client_200, state: 'Monitored')
       expect(res.size).to eq(2)
       res.each do |r|
         expect(r.class).to eq(OneviewSDK::Enclosure)
@@ -370,8 +370,8 @@ RSpec.describe OneviewSDK::Resource do
 
   describe '#get_all' do
     it 'calls find_by with an empty attributes hash' do
-      expect(OneviewSDK::Resource).to receive(:find_by).with(@client, {})
-      OneviewSDK::Resource.get_all(@client)
+      expect(OneviewSDK::Resource).to receive(:find_by).with(@client_200, {})
+      OneviewSDK::Resource.get_all(@client_200)
     end
   end
 
@@ -381,12 +381,12 @@ RSpec.describe OneviewSDK::Resource do
     end
 
     it 'builds resource query' do
-      fake_resource = OneviewSDK::Resource.new(@client, 'uri' => 'URI')
+      fake_resource = OneviewSDK::Resource.new(@client_200, 'uri' => 'URI')
       expect(OneviewSDK::Resource.build_query('this_resource' => fake_resource)).to eq('?thisResourceUri=URI')
     end
 
     it 'builds composed query' do
-      fake_resource = OneviewSDK::Resource.new(@client, 'uri' => 'URI')
+      fake_resource = OneviewSDK::Resource.new(@client_200, 'uri' => 'URI')
       expect(OneviewSDK::Resource.build_query('test' => 'TEST', 'this_resource' => fake_resource)).to eq('?test=TEST&thisResourceUri=URI')
     end
 

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -14,21 +14,21 @@ RSpec.describe OneviewSDK::Client do
     end
 
     it 'requires a path' do
-      expect { @client.rest_api(:get, nil) }.to raise_error(OneviewSDK::InvalidRequest, /Must specify path/)
+      expect { @client_200.rest_api(:get, nil) }.to raise_error(OneviewSDK::InvalidRequest, /Must specify path/)
     end
 
     it 'logs the request type and path (debug level)' do
-      @client.logger.level = @client.logger.class.const_get('DEBUG')
+      @client_200.logger.level = @client_200.logger.class.const_get('DEBUG')
       %w(get post put patch delete).each do |type|
-        expect { @client.rest_api(type, path) }
-          .to output(/Making :#{type} rest call to #{@client.url + path}/).to_stdout_from_any_process
+        expect { @client_200.rest_api(type, path) }
+          .to output(/Making :#{type} rest call to #{@client_200.url + path}/).to_stdout_from_any_process
       end
     end
 
     it 'raises an error when the ssl validation fails' do
       allow_any_instance_of(Net::HTTP).to receive(:request).and_raise(OpenSSL::SSL::SSLError, 'Msg')
-      expect(@client.logger).to receive(:error).with(/SSL verification failed/)
-      expect { @client.rest_api(:get, path) }.to raise_error(OpenSSL::SSL::SSLError)
+      expect(@client_200.logger).to receive(:error).with(/SSL verification failed/)
+      expect { @client_200.rest_api(:get, path) }.to raise_error(OpenSSL::SSL::SSLError)
     end
 
     it 'respects the client.timeout value' do
@@ -45,7 +45,7 @@ RSpec.describe OneviewSDK::Client do
       expect(response1).to receive(:class).and_return(Net::HTTPRedirection) # Simulate 301 on first request
       response2 = FakeResponse.new({ name: 'New' }, 200)
       expect(http).to receive(:request).and_return(response1, response2)
-      r = @client.rest_api(:get, path)
+      r = @client_200.rest_api(:get, path)
       expect(r).to eq(response2)
     end
 
@@ -53,8 +53,8 @@ RSpec.describe OneviewSDK::Client do
       response = FakeResponse.new({ name: 'New' }, 301, 'location' => path)
       allow(response.class).to receive(:<=).with(Net::HTTPRedirection).and_return(true)
       allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
-      expect(@client).to receive(:rest_api).exactly(4).times.and_call_original
-      r = @client.rest_api(:get, path)
+      expect(@client_200).to receive(:rest_api).exactly(4).times.and_call_original
+      r = @client_200.rest_api(:get, path)
       expect(r).to eq(response)
     end
 
@@ -62,97 +62,97 @@ RSpec.describe OneviewSDK::Client do
       response = FakeResponse.new({ name: 'New' }, 301)
       allow(response.class).to receive(:<=).with(Net::HTTPRedirection).and_return(true)
       allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
-      expect(@client).to receive(:rest_api).once.and_call_original
-      @client.rest_api(:get, path)
+      expect(@client_200).to receive(:rest_api).once.and_call_original
+      @client_200.rest_api(:get, path)
     end
   end
 
   describe '#rest_get' do
     it 'calls rest_api' do
-      expect(@client).to receive(:rest_api).with(:get, path, {}, @client.api_version)
-      @client.rest_get(path)
+      expect(@client_200).to receive(:rest_api).with(:get, path, {}, @client_200.api_version)
+      @client_200.rest_get(path)
     end
   end
 
   describe '#rest_post' do
     it 'calls rest_api' do
-      expect(@client).to receive(:rest_api).with(:post, path, { body: data }, @client.api_version)
-      @client.rest_post(path, { body: data }, @client.api_version)
+      expect(@client_200).to receive(:rest_api).with(:post, path, { body: data }, @client_200.api_version)
+      @client_200.rest_post(path, { body: data }, @client_200.api_version)
     end
 
     it 'has default options and api_ver' do
-      expect(@client).to receive(:rest_api).with(:post, path, {}, @client.api_version)
-      @client.rest_post(path)
+      expect(@client_200).to receive(:rest_api).with(:post, path, {}, @client_200.api_version)
+      @client_200.rest_post(path)
     end
   end
 
   describe '#rest_put' do
     it 'calls rest_api' do
-      expect(@client).to receive(:rest_api).with(:put, path, {}, @client.api_version)
-      @client.rest_put(path, {}, @client.api_version)
+      expect(@client_200).to receive(:rest_api).with(:put, path, {}, @client_200.api_version)
+      @client_200.rest_put(path, {}, @client_200.api_version)
     end
 
     it 'has default options and api_ver' do
-      expect(@client).to receive(:rest_api).with(:put, path, {}, @client.api_version)
-      @client.rest_put(path)
+      expect(@client_200).to receive(:rest_api).with(:put, path, {}, @client_200.api_version)
+      @client_200.rest_put(path)
     end
   end
 
   describe '#rest_patch' do
     it 'calls rest_api' do
-      expect(@client).to receive(:rest_api).with(:patch, path, {}, @client.api_version)
-      @client.rest_patch(path, {}, @client.api_version)
+      expect(@client_200).to receive(:rest_api).with(:patch, path, {}, @client_200.api_version)
+      @client_200.rest_patch(path, {}, @client_200.api_version)
     end
 
     it 'has default options and api_ver' do
-      expect(@client).to receive(:rest_api).with(:patch, path, {}, @client.api_version)
-      @client.rest_patch(path)
+      expect(@client_200).to receive(:rest_api).with(:patch, path, {}, @client_200.api_version)
+      @client_200.rest_patch(path)
     end
   end
 
   describe '#rest_delete' do
     it 'calls rest_api' do
-      expect(@client).to receive(:rest_api).with(:delete, path, {}, @client.api_version)
-      @client.rest_delete(path, {}, @client.api_version)
+      expect(@client_200).to receive(:rest_api).with(:delete, path, {}, @client_200.api_version)
+      @client_200.rest_delete(path, {}, @client_200.api_version)
     end
 
     it 'has default options and api_ver' do
-      expect(@client).to receive(:rest_api).with(:delete, path, {}, @client.api_version)
-      @client.rest_delete(path)
+      expect(@client_200).to receive(:rest_api).with(:delete, path, {}, @client_200.api_version)
+      @client_200.rest_delete(path)
     end
   end
 
   describe '#response_handler' do
     it 'returns the JSON-parsed body for 200 status' do
-      expect(@client.response_handler(FakeResponse.new(data))).to eq(data)
+      expect(@client_200.response_handler(FakeResponse.new(data))).to eq(data)
     end
 
     it 'returns the JSON-parsed body for 201 status' do
-      expect(@client.response_handler(FakeResponse.new(data, 201))).to eq(data)
+      expect(@client_200.response_handler(FakeResponse.new(data, 201))).to eq(data)
     end
 
     it 'waits on the task completion for 202 status' do
       initial_response = FakeResponse.new(data, 202, 'location' => '/rest/task/fake')
 
       wait_response = FakeResponse.new({}, 200, 'associatedResource' => { 'resourceUri' => data['uri'] })
-      expect(@client).to receive(:wait_for).with('/rest/task/fake').and_return(wait_response)
+      expect(@client_200).to receive(:wait_for).with('/rest/task/fake').and_return(wait_response)
 
-      expect(@client).to receive(:rest_get).with(data['uri']).and_return(FakeResponse.new(data))
-      expect(@client.response_handler(initial_response)).to eq(data)
+      expect(@client_200).to receive(:rest_get).with(data['uri']).and_return(FakeResponse.new(data))
+      expect(@client_200.response_handler(initial_response)).to eq(data)
     end
 
     it 'allows you to set wait_for_task to false' do
       response = FakeResponse.new(data, 202, 'location' => '/rest/task/fake')
-      expect(@client.response_handler(response, false)).to eq(data)
+      expect(@client_200.response_handler(response, false)).to eq(data)
     end
 
     it 'returns an empty hash for 204 status' do
-      expect(@client.response_handler(FakeResponse.new({}, 204))).to eq({})
+      expect(@client_200.response_handler(FakeResponse.new({}, 204))).to eq({})
     end
 
     it 'raises an error for 400 status' do
       resp = FakeResponse.new({ message: 'Blah' }, 400)
-      expect { @client.response_handler(resp) }.to raise_error { |e|
+      expect { @client_200.response_handler(resp) }.to raise_error { |e|
         expect(e).to be_a(OneviewSDK::BadRequest)
         expect(e.message).to match(/400 BAD REQUEST.*Blah/)
         expect(e.data).to eq(resp)
@@ -161,7 +161,7 @@ RSpec.describe OneviewSDK::Client do
 
     it 'raises an error for 401 status' do
       resp = FakeResponse.new({ message: 'Blah' }, 401)
-      expect { @client.response_handler(resp) }.to raise_error { |e|
+      expect { @client_200.response_handler(resp) }.to raise_error { |e|
         expect(e).to be_a(OneviewSDK::Unauthorized)
         expect(e.message).to match(/401 UNAUTHORIZED.*Blah/)
         expect(e.data).to eq(resp)
@@ -170,7 +170,7 @@ RSpec.describe OneviewSDK::Client do
 
     it 'raises an error for 404 status' do
       resp = FakeResponse.new({ message: 'Blah' }, 404)
-      expect { @client.response_handler(resp) }.to raise_error { |e|
+      expect { @client_200.response_handler(resp) }.to raise_error { |e|
         expect(e).to be_a(OneviewSDK::NotFound)
         expect(e.message).to match(/404 NOT FOUND.*Blah/)
         expect(e.data).to eq(resp)
@@ -180,35 +180,36 @@ RSpec.describe OneviewSDK::Client do
     it 'raises an error for undefined status codes' do
       [0, 19, 199, 203, 399, 402, 500].each do |status|
         resp = FakeResponse.new({ message: 'Blah' }, status)
-        expect { @client.response_handler(resp) }.to raise_error(OneviewSDK::RequestError, /#{status}.*Blah/)
+        expect { @client_200.response_handler(resp) }.to raise_error(OneviewSDK::RequestError, /#{status}.*Blah/)
       end
     end
   end
 
   describe '#build_request' do
     before :each do
-      @uri = URI.parse(URI.escape(@client.url + path))
+      @uri = URI.parse(URI.escape(@client_200.url + path))
       @options = {
-        'X-API-Version' => @client.api_version,
-        'auth' => @client.token
+        'X-API-Version' => @client_200.api_version,
+        'auth' => @client_200.token
       }
     end
 
     it 'fails when an invalid request type is given' do
-      expect { @client.send(:build_request, :fake, @uri, {}, @client.api_version) }.to raise_error(OneviewSDK::InvalidRequest, /Invalid rest method/)
+      expect { @client_200.send(:build_request, :fake, @uri, {}, @client_200.api_version) }
+        .to raise_error(OneviewSDK::InvalidRequest, /Invalid rest method/)
     end
 
     context 'default header values' do
       before :each do
-        @req = @client.send(:build_request, :get, @uri, {}, @client.api_version)
+        @req = @client_200.send(:build_request, :get, @uri, {}, @client_200.api_version)
       end
 
       it 'sets the X-API-Version' do
-        expect(@req['x-api-version']).to eq(@client.api_version.to_s)
+        expect(@req['x-api-version']).to eq(@client_200.api_version.to_s)
       end
 
       it 'sets the auth token' do
-        expect(@req['auth']).to eq(@client.token)
+        expect(@req['auth']).to eq(@client_200.token)
       end
 
       it 'sets the Content-Type' do
@@ -218,7 +219,7 @@ RSpec.describe OneviewSDK::Client do
 
     it 'allows deletion of default headers' do
       options = { 'Content-Type' => :none, 'X-API-Version' => :none, 'auth' => 'none' }
-      req = @client.send(:build_request, :get, @uri, options, @client.api_version)
+      req = @client_200.send(:build_request, :get, @uri, options, @client_200.api_version)
       expect(req['Content-Type']).to eq(nil)
       expect(req['x-api-version']).to eq(nil)
       expect(req['auth']).to eq(nil)
@@ -226,20 +227,20 @@ RSpec.describe OneviewSDK::Client do
 
     it 'allows additional headers to be set' do
       options = { 'My-Header' => 'blah' }
-      req = @client.send(:build_request, :get, @uri, options, @client.api_version)
+      req = @client_200.send(:build_request, :get, @uri, options, @client_200.api_version)
       expect(req['My-Header']).to eq('blah')
     end
 
     it 'sets the body option to the request body' do
       options = { 'body' => { name: 'New', uri: path } }
-      req = @client.send(:build_request, :get, @uri, options, @client.api_version)
+      req = @client_200.send(:build_request, :get, @uri, options, @client_200.api_version)
       expect(req.body).to eq(options['body'].to_json)
     end
 
     it 'logs the request options (debug level)' do
-      def_options = { 'X-API-Version' => @client.api_version, 'auth' => 'secretToken', 'Content-Type' => 'application/json' }
-      @client.logger.level = @client.logger.class.const_get('DEBUG')
-      expect { @client.send(:build_request, :get, @uri, {}, @client.api_version) }
+      def_options = { 'X-API-Version' => @client_200.api_version, 'auth' => 'secretToken', 'Content-Type' => 'application/json' }
+      @client_200.logger.level = @client_200.logger.class.const_get('DEBUG')
+      expect { @client_200.send(:build_request, :get, @uri, {}, @client_200.api_version) }
         .to output(/Options: #{def_options}/).to_stdout_from_any_process
     end
   end
@@ -247,7 +248,7 @@ RSpec.describe OneviewSDK::Client do
   describe 'upload_file' do
     context 'when file does not exist' do
       it 'should raise exception' do
-        expect { @client.upload_file('file.zip', '/uri') }.to raise_error(OneviewSDK::NotFound, //)
+        expect { @client_200.upload_file('file.zip', '/uri') }.to raise_error(OneviewSDK::NotFound, //)
       end
     end
 
@@ -257,8 +258,8 @@ RSpec.describe OneviewSDK::Client do
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
       http_fake = spy('http')
       allow(Net::HTTP).to receive(:new).and_return(http_fake)
-      allow(@client).to receive(:response_handler).and_return(FakeResponse.new)
-      @client.upload_file('file.zip', '/uri-file-upload')
+      allow(@client_200).to receive(:response_handler).and_return(FakeResponse.new)
+      @client_200.upload_file('file.zip', '/uri-file-upload')
       expect(http_fake).to have_received(:read_timeout=).with(OneviewSDK::Rest::READ_TIMEOUT)
     end
 
@@ -272,9 +273,9 @@ RSpec.describe OneviewSDK::Client do
       allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler)
         .and_return(FakeResponse.new)
 
-      @client.upload_file('file.zip', '/uri-file-upload', { 'name' => 'TestName' }, 600)
+      @client_200.upload_file('file.zip', '/uri-file-upload', { 'name' => 'TestName' }, 600)
 
-      expected_options = { 'Content-Type' => 'multipart/form-data', 'X-Api-Version' => @client.api_version.to_s, 'auth' => @client.token }
+      expected_options = { 'Content-Type' => 'multipart/form-data', 'X-Api-Version' => @client_200.api_version.to_s, 'auth' => @client_200.token }
       expect(Net::HTTP::Post::Multipart).to have_received(:new)
         .with('/uri-file-upload', { 'file' => 'Fake_File_IO' }, expected_options)
       expect(http_fake).to have_received(:read_timeout=).with(600)
@@ -290,7 +291,7 @@ RSpec.describe OneviewSDK::Client do
       allow(File).to receive(:file?).and_return(true)
       allow(File).to receive(:open).with('file.zip').and_yield('FAKE FILE CONTENT')
       allow(UploadIO).to receive(:new).and_return('FAKE FILE CONTENT')
-      result = @client.upload_file('file.zip', 'rest/fake/1', options)
+      result = @client_200.upload_file('file.zip', 'rest/fake/1', options)
       expect(result).to eq(expected_result)
     end
   end
@@ -310,10 +311,10 @@ RSpec.describe OneviewSDK::Client do
       expect(http_response_fake).to receive(:read_body).and_yield(stream_fake)
       expect(file_fake).to receive(:write).with(stream_fake)
 
-      expect(@client).to receive(:build_request)
-      expect(@client).not_to receive(:response_handler)
+      expect(@client_200).to receive(:build_request)
+      expect(@client_200).not_to receive(:response_handler)
 
-      result = @client.download_file('/file-download-uri', 'file.zip')
+      result = @client_200.download_file('/file-download-uri', 'file.zip')
       expect(result).to eq(true)
     end
 
@@ -327,7 +328,7 @@ RSpec.describe OneviewSDK::Client do
         allow(http_fake).to receive(:request).and_yield(http_response_fake)
         allow(http_response_fake).to receive(:code).and_return(400) # != 200..204
 
-        expect { @client.download_file('/file-download-uri', 'file.zip') }.to raise_error(OneviewSDK::BadRequest)
+        expect { @client_200.download_file('/file-download-uri', 'file.zip') }.to raise_error(OneviewSDK::BadRequest)
       end
     end
   end
@@ -336,11 +337,11 @@ RSpec.describe OneviewSDK::Client do
     context 'with ssl enabled and timeout variable defined' do
       it 'should create a http object with valid data' do
         uri = URI.parse('https://localhost:1000')
-        @client.ssl_enabled = true
-        @client.cert_store = 'some_certificate'
-        @client.timeout = 300
+        @client_200.ssl_enabled = true
+        @client_200.cert_store = 'some_certificate'
+        @client_200.timeout = 300
 
-        http = @client.send(:build_http_object, uri)
+        http = @client_200.send(:build_http_object, uri)
 
         expect(http.address).to eq('localhost')
         expect(http.port).to eq(1000)
@@ -356,9 +357,9 @@ RSpec.describe OneviewSDK::Client do
       it 'should create a http object with valid data' do
         http_default = Net::HTTP.new('http://localhost')
         uri = URI.parse('http://localhost:1000')
-        @client.ssl_enabled = false
+        @client_200.ssl_enabled = false
 
-        http = @client.send(:build_http_object, uri)
+        http = @client_200.send(:build_http_object, uri)
 
         expect(http.address).to eq('localhost')
         expect(http.port).to eq(1000)


### PR DESCRIPTION
### Description
It is necessary to create structure for api500 support for class development, unit tests, integration tests and examples.

In the shared context, I did the refactoring by creating the clients for the unit tests using the concatenation of the `client_` with the desired version. I did this thinking in other future versions that can be added.

### Issues Resolved
#199 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
