### PR TITLE
Fixed the references to resources C7000 in Synergy integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#201](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/201) Code to search the collection of resources (paginated search) is repeated in some resources
 - [#119](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/112) VolumeAttachment::remove_extra_unmanaged_volume throw Unexpected Http Error
 - [#202](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/202) The method #get_default_settings in LogicalInterconnectGroup is used on integration test
+- [#125](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/125) References to resources C7000 in Synergy integration tests
 
 #### Design changes:
    - Architecture for future API500 support. Features for API500 are not yet supported.

--- a/spec/integration/resource/api300/synergy/storage_system/update_spec.rb
+++ b/spec/integration/resource/api300/synergy/storage_system/update_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe klass, integration: true, type: UPDATE do
       storage_system['credentials']['ip_hostname'] = $secrets_synergy['storage_system1_ip']
       storage_system.retrieve!
 
-      fc_network = OneviewSDK::API300::C7000::FCNetwork.find_by($client_300_synergy, {}).first
+      fc_network = OneviewSDK::API300::Synergy::FCNetwork.find_by($client_300_synergy, {}).first
 
       storage_system.data['unmanagedPorts'].first['expectedNetworkUri'] = fc_network.data['uri']
       storage_system.update

--- a/spec/integration/resource/api300/synergy/switch/create_spec.rb
+++ b/spec/integration/resource/api300/synergy/switch/create_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-klass = OneviewSDK::API300::C7000::Switch
+klass = OneviewSDK::API300::Synergy::Switch
 RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
   include_context 'integration api300 context'
 


### PR DESCRIPTION
### Description
There were some wrong references to C7000 resources in integration test for Synergy.

### Issues Resolved
Fixes #125 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
