### PR TITLE
Fix 'like?' method for Logical Interconnect Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased Changes
-## Suggested release: v5.0.0
+## Suggested release: v4.1.1
 
 #### New Resources:
 (none)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#202](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/202) The method #get_default_settings in LogicalInterconnectGroup is used on integration test
 - [#125](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/125) References to resources C7000 in Synergy integration tests
 - [#212](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/212) Unable to create a Server Profile with Deployment Plan settings
+- [#89](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/89) Fix like? method for Logical Interconnect Groups
 
 #### Design changes:
    - Architecture for future API500 support. Features for API500 are not yet supported.

--- a/lib/oneview-sdk/resource.rb
+++ b/lib/oneview-sdk/resource.rb
@@ -361,6 +361,12 @@ module OneviewSDK
         return false unless data && data.respond_to?(:[])
         if val.is_a?(Hash)
           return false unless data.class == Hash && recursive_like?(val, data[key.to_s])
+        elsif val.is_a?(Array) && val.first.is_a?(Hash)
+          data_array = data[key.to_s] || data[key.to_sym]
+          return false unless data_array.is_a?(Array)
+          val.each do |other_item|
+            return false unless data_array.find { |data_item| recursive_like?(other_item, data_item) }
+          end
         elsif val != data[key.to_s] && val != data[key.to_sym]
           return false
         end

--- a/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
+++ b/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
@@ -25,7 +25,7 @@ module OneviewSDK
         super
         # Default values:
         @data['logicalPortConfigInfos'] ||= []
-        @data['lacpTimer'] ||= 'Short'
+        @data['lacpTimer'] ||= 'Short' unless @data['networkType'] == 'FibreChannel' # FibreChannel does not need set up lacpTimer
         @data['mode'] ||= 'Auto'
         @data['networkUris'] ||= []
       end

--- a/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
@@ -110,7 +110,6 @@ module OneviewSDK
         response = @client.rest_put(@data['uri'], update_options, @api_version)
         body = @client.response_handler(response)
         set_all(body)
-        self
       end
 
       private

--- a/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
@@ -45,10 +45,13 @@ module OneviewSDK
       # Adds an interconnect
       # @param [Fixnum] bay Bay number
       # @param [String] type Interconnect type
-      # @raise [StandardError] if an invalid type is given
+      # @raise [OneviewSDK::NotFound] if an invalid type is given
       def add_interconnect(bay, type)
         interconnect_type = OneviewSDK::Interconnect.get_type(@client, type)
-        raise OneviewSDK::NotFound unless interconnect_type
+        unless interconnect_type
+          list = OneviewSDK::Interconnect.get_types(@client).map { |t| t['name'] }
+          raise OneviewSDK::NotFound, "Interconnect type #{type} not found! Supported types: #{list}"
+        end
 
         entry_already_present = false
         @data['interconnectMapTemplate']['interconnectMapEntryTemplates'].each do |entry|
@@ -64,10 +67,6 @@ module OneviewSDK
           new_entry = new_interconnect_entry_template(bay, interconnect_type['uri'])
           @data['interconnectMapTemplate']['interconnectMapEntryTemplates'] << new_entry
         end
-
-      rescue OneviewSDK::NotFound
-        list = OneviewSDK::Interconnect.get_types(@client).map { |t| t['name'] }
-        raise "Interconnect type #{type} not found! Supported types: #{list}"
       end
 
       # Adds an uplink set

--- a/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api200/logical_interconnect_group.rb
@@ -45,7 +45,7 @@ module OneviewSDK
       # Adds an interconnect
       # @param [Fixnum] bay Bay number
       # @param [String] type Interconnect type
-      # @raise [StandardError] if a invalid type is given then raises an error
+      # @raise [StandardError] if an invalid type is given
       def add_interconnect(bay, type)
         interconnect_type = OneviewSDK::Interconnect.get_type(@client, type)
         raise OneviewSDK::NotFound unless interconnect_type

--- a/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       'type' => 'logical-interconnect-groupV3'
     }
     @item_2 = OneviewSDK::LogicalInterconnectGroup.new($client, lig_default_options_2)
+    @item_2_state_before_create = {} # it is built in #create test and used in #like? test
 
     lig_default_options_3 = {
       'name' => LOG_INT_GROUP3_NAME,
@@ -39,7 +40,8 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       networkType: 'Ethernet',
       ethernetNetworkType: 'Tagged'
     }
-    @eth_lig_uplink_set = OneviewSDK::LIGUplinkSet.new($client, eth_uplink_options)
+    @eth_lig_uplink_set_1 = OneviewSDK::LIGUplinkSet.new($client, eth_uplink_options)
+    @eth_lig_uplink_set_2 = OneviewSDK::LIGUplinkSet.new($client, eth_uplink_options)
     @ethernet_network = OneviewSDK::EthernetNetwork.new($client, name: ETH_NET_NAME)
     @ethernet_network.retrieve!
 
@@ -70,10 +72,10 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
     it 'LIG with interconnect of type HP VC FlexFabric-20/40 F8 Module' do
       @item.add_interconnect(1, interconnect_type2)
 
-      @eth_lig_uplink_set.add_network(@ethernet_network)
-      @eth_lig_uplink_set.add_uplink(1, 'X1')
-      @eth_lig_uplink_set.add_uplink(1, 'X2')
-      @item.add_uplink_set(@eth_lig_uplink_set)
+      @eth_lig_uplink_set_1.add_network(@ethernet_network)
+      @eth_lig_uplink_set_1.add_uplink(1, 'X1')
+      @eth_lig_uplink_set_1.add_uplink(1, 'X2')
+      @item.add_uplink_set(@eth_lig_uplink_set_1)
 
       expect { @item.create }.not_to raise_error
       expect(@item['uri']).to be
@@ -83,15 +85,20 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
     it 'LIG with interconnect and uplink sets' do
       @item_2.add_interconnect(1, interconnect_type)
 
-      @eth_lig_uplink_set.add_network(@ethernet_network)
-      @eth_lig_uplink_set.add_uplink(1, 'X1')
-      @eth_lig_uplink_set.add_uplink(1, 'X2')
-      @item_2.add_uplink_set(@eth_lig_uplink_set)
+      # require 'byebug'
+      # byebug
+
+      @eth_lig_uplink_set_2.add_network(@ethernet_network)
+      @eth_lig_uplink_set_2.add_uplink(1, 'X1')
+      @eth_lig_uplink_set_2.add_uplink(1, 'X2')
+      @item_2.add_uplink_set(@eth_lig_uplink_set_2)
 
       @fc_lig_uplink_set.add_network(@fc_network)
       @fc_lig_uplink_set.add_uplink(1, 'X3')
       @fc_lig_uplink_set.add_uplink(1, 'X4')
       @item_2.add_uplink_set(@fc_lig_uplink_set)
+
+      @item_2_state_before_create.merge!(Marshal.load(Marshal.dump(@item_2.data)))
 
       expect { @item_2.create }.not_to raise_error
       expect(@item_2['uri']).to be
@@ -152,6 +159,15 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       expect(default_settings['type']).to eq('InterconnectSettingsV3')
       expect(default_settings['uri']).to_not be
       expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
+    end
+  end
+
+  describe '#like?' do
+    context 'when logical interconnect group has interconnect and uplink sets and use "like?" with identical data' do
+      it 'should work properly' do
+        lig_item_2 = OneviewSDK::API200::LogicalInterconnectGroup.find_by($client, name: LOG_INT_GROUP2_NAME).first
+        expect(lig_item_2.like?(@item_2_state_before_create)).to eq(true)
+      end
     end
   end
 end

--- a/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
     end
 
     it 'LIG with unrecognized interconnect' do
-      expect { @item.add_interconnect(1, 'invalid_type') }.to raise_error(/Interconnect type invalid_type/)
+      expect { @item.add_interconnect(1, 'invalid_type') }.to raise_error(OneviewSDK::NotFound, /Interconnect type invalid_type not found!/)
     end
 
     it 'LIG with interconnect of type HP VC FlexFabric-20/40 F8 Module' do

--- a/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       'type' => 'logical-interconnect-groupV300'
     }
     @item_2 = OneviewSDK::API300::C7000::LogicalInterconnectGroup.new($client_300, lig_default_options_2)
+    @item_2_state_before_create = {} # it is built in #create test and used in #like? test
 
     lig_default_options_3 = {
       'name' => LOG_INT_GROUP3_NAME,
@@ -39,7 +40,8 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       networkType: 'Ethernet',
       ethernetNetworkType: 'Tagged'
     }
-    @eth_lig_uplink_set = OneviewSDK::API300::C7000::LIGUplinkSet.new($client_300, eth_uplink_options)
+    @eth_lig_uplink_set_1 = OneviewSDK::API300::C7000::LIGUplinkSet.new($client_300, eth_uplink_options)
+    @eth_lig_uplink_set_2 = OneviewSDK::API300::C7000::LIGUplinkSet.new($client_300, eth_uplink_options)
     @ethernet_network = OneviewSDK::API300::C7000::EthernetNetwork.new($client_300, name: ETH_NET_NAME)
     @ethernet_network.retrieve!
 
@@ -70,10 +72,10 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
     it 'LIG with interconnect of type HP VC FlexFabric-20/40 F8 Module' do
       @item.add_interconnect(1, interconnect_type2)
 
-      @eth_lig_uplink_set.add_network(@ethernet_network)
-      @eth_lig_uplink_set.add_uplink(1, 'X1')
-      @eth_lig_uplink_set.add_uplink(1, 'X2')
-      @item.add_uplink_set(@eth_lig_uplink_set)
+      @eth_lig_uplink_set_1.add_network(@ethernet_network)
+      @eth_lig_uplink_set_1.add_uplink(1, 'X1')
+      @eth_lig_uplink_set_1.add_uplink(1, 'X2')
+      @item.add_uplink_set(@eth_lig_uplink_set_1)
 
       expect { @item.create }.not_to raise_error
       expect(@item['uri']).to be
@@ -83,15 +85,17 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
     it 'LIG with interconnect and uplink sets' do
       @item_2.add_interconnect(1, interconnect_type)
 
-      @eth_lig_uplink_set.add_network(@ethernet_network)
-      @eth_lig_uplink_set.add_uplink(1, 'X1')
-      @eth_lig_uplink_set.add_uplink(1, 'X2')
-      @item_2.add_uplink_set(@eth_lig_uplink_set)
+      @eth_lig_uplink_set_2.add_network(@ethernet_network)
+      @eth_lig_uplink_set_2.add_uplink(1, 'X1')
+      @eth_lig_uplink_set_2.add_uplink(1, 'X2')
+      @item_2.add_uplink_set(@eth_lig_uplink_set_2)
 
       @fc_lig_uplink_set.add_network(@fc_network)
       @fc_lig_uplink_set.add_uplink(1, 'X3')
       @fc_lig_uplink_set.add_uplink(1, 'X4')
       @item_2.add_uplink_set(@fc_lig_uplink_set)
+
+      @item_2_state_before_create.merge!(Marshal.load(Marshal.dump(@item_2.data)))
 
       expect { @item_2.create }.not_to raise_error
       expect(@item_2['uri']).to be
@@ -144,6 +148,15 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       expect(default_settings['type']).to eq('InterconnectSettingsV201')
       expect(default_settings['uri']).to_not be
       expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
+    end
+  end
+
+  describe '#like?' do
+    context 'when logical interconnect group has interconnect and uplink sets and use "like?" with identical data' do
+      it 'should work properly' do
+        lig_item_2 = OneviewSDK::API300::C7000::LogicalInterconnectGroup.find_by($client_300, name: LOG_INT_GROUP2_NAME).first
+        expect(lig_item_2.like?(@item_2_state_before_create)).to eq(true)
+      end
     end
   end
 end

--- a/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api300/c7000/logical_interconnect_group/create_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
     end
 
     it 'LIG with unrecognized interconnect' do
-      expect { @item.add_interconnect(1, 'invalid_type') }.to raise_error(/Interconnect type invalid_type/)
+      expect { @item.add_interconnect(1, 'invalid_type') }.to raise_error(OneviewSDK::NotFound, /Interconnect type invalid_type not found!/)
     end
 
     it 'LIG with interconnect of type HP VC FlexFabric-20/40 F8 Module' do

--- a/spec/unit/resource/api200/lig_uplink_set_spec.rb
+++ b/spec/unit/resource/api200/lig_uplink_set_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OneviewSDK::LIGUplinkSet do
     it 'sets the defaults correctly' do
       item = OneviewSDK::LIGUplinkSet.new(@client_200, networkType: 'FibreChannel')
       expect(item[:logicalPortConfigInfos]).to eq([])
-      expect(item[:lacpTimer]).to eq('Short')
+      expect(item[:lacpTimer]).to eq(nil)
       expect(item[:mode]).to eq('Auto')
       expect(item[:networkUris]).to eq([])
     end

--- a/spec/unit/resource/api200/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api200/logical_interconnect_group_spec.rb
@@ -10,9 +10,8 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
       expect(item['state']).to eq('Active')
       expect(item['uplinkSets']).to eq([])
       expect(item['type']).to eq('logical-interconnect-groupV3')
-      path = 'spec/support/fixtures/unit/resource/lig_default_templates.json'
-      expect(item['interconnectMapTemplate']).to eq(JSON.parse(File.read(path)))
-      expect(item['interconnectMapTemplate']['interconnectMapEntryTemplates'].size).to eq(8)
+      expect(item['interconnectMapTemplate']).to eq('interconnectMapEntryTemplates' => [])
+      expect(item['interconnectMapTemplate']['interconnectMapEntryTemplates']).to be_empty
     end
   end
 
@@ -34,13 +33,13 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
       expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client_200, @type)
         .and_return('uri' => '/rest/fake')
       @item.add_interconnect(3, @type)
-      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'][2]['permittedInterconnectTypeUri'])
+      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'].first['permittedInterconnectTypeUri'])
         .to eq('/rest/fake')
     end
 
     it 'raises an error if the interconnect is not found' do
       expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client_200, @type)
-        .and_return([])
+        .and_return(nil)
       expect(OneviewSDK::Interconnect).to receive(:get_types).and_return([{ 'name' => '1' }, { 'name' => '2' }])
       expect { @item.add_interconnect(3, @type) }.to raise_error(/not found!/)
     end
@@ -62,6 +61,17 @@ RSpec.describe OneviewSDK::LogicalInterconnectGroup do
       expect(@client_200).to receive(:rest_get).with('/rest/fake/settings', item.api_version)
         .and_return(FakeResponse.new)
       expect(item.get_settings).to be
+    end
+  end
+
+  describe '#like?' do
+    context 'when LIG has Interconnects attached and Uplink Sets defined' do
+      it 'should work properly' do
+        item = described_class.new(@client_200, uri: '/rest/fake')
+        expect(@client_200).to receive(:rest_get).with('/rest/fake/settings', item.api_version)
+          .and_return(FakeResponse.new)
+        expect(item.get_settings).to be
+      end
     end
   end
 end

--- a/spec/unit/resource/api300/c7000/lig_uplink_set_spec.rb
+++ b/spec/unit/resource/api300/c7000/lig_uplink_set_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OneviewSDK::API300::C7000::LIGUplinkSet do
     it 'sets the defaults correctly' do
       item = OneviewSDK::API300::C7000::LIGUplinkSet.new(@client_300, networkType: 'FibreChannel')
       expect(item[:logicalPortConfigInfos]).to eq([])
-      expect(item[:lacpTimer]).to eq('Short')
+      expect(item[:lacpTimer]).to eq(nil)
       expect(item[:mode]).to eq('Auto')
       expect(item[:networkUris]).to eq([])
     end

--- a/spec/unit/resource/api300/c7000/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api300/c7000/logical_interconnect_group_spec.rb
@@ -14,9 +14,8 @@ RSpec.describe OneviewSDK::API300::C7000::LogicalInterconnectGroup do
       expect(item['state']).to eq('Active')
       expect(item['uplinkSets']).to eq([])
       expect(item['type']).to eq('logical-interconnect-groupV300')
-      path = 'spec/support/fixtures/unit/resource/lig_default_templates.json'
-      expect(item['interconnectMapTemplate']).to eq(JSON.parse(File.read(path)))
-      expect(item['interconnectMapTemplate']['interconnectMapEntryTemplates'].size).to eq(8)
+      expect(item['interconnectMapTemplate']).to eq('interconnectMapEntryTemplates' => [])
+      expect(item['interconnectMapTemplate']['interconnectMapEntryTemplates']).to be_empty
     end
   end
 
@@ -30,13 +29,13 @@ RSpec.describe OneviewSDK::API300::C7000::LogicalInterconnectGroup do
       expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client_300, @type)
         .and_return('uri' => '/rest/fake')
       @item.add_interconnect(3, @type)
-      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'][2]['permittedInterconnectTypeUri'])
+      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'].first['permittedInterconnectTypeUri'])
         .to eq('/rest/fake')
     end
 
     it 'raises an error if the interconnect is not found' do
       expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client_300, @type)
-        .and_return([])
+        .and_return(nil)
       expect(OneviewSDK::Interconnect).to receive(:get_types).and_return([{ 'name' => '1' }, { 'name' => '2' }])
       expect { @item.add_interconnect(3, @type) }.to raise_error(/not found!/)
     end

--- a/spec/unit/resource/api300/c7000/logical_interconnect_group_spec.rb
+++ b/spec/unit/resource/api300/c7000/logical_interconnect_group_spec.rb
@@ -29,8 +29,18 @@ RSpec.describe OneviewSDK::API300::C7000::LogicalInterconnectGroup do
       expect(OneviewSDK::Interconnect).to receive(:get_type).with(@client_300, @type)
         .and_return('uri' => '/rest/fake')
       @item.add_interconnect(3, @type)
-      expect(@item['interconnectMapTemplate']['interconnectMapEntryTemplates'].first['permittedInterconnectTypeUri'])
-        .to eq('/rest/fake')
+
+      location_entries = @item['interconnectMapTemplate']['interconnectMapEntryTemplates'].first['logicalLocation']['locationEntries']
+      expect(location_entries.size).to eq(2)
+
+      bay_entry, enclosure_entry = location_entries
+      expect(bay_entry['type']).to eq('Bay')
+      expect(bay_entry['relativeValue']).to eq(3)
+      expect(enclosure_entry['type']).to eq('Enclosure')
+      expect(enclosure_entry['relativeValue']).to eq(1)
+
+      permitted_interconnect_type_uri = @item['interconnectMapTemplate']['interconnectMapEntryTemplates'].first['permittedInterconnectTypeUri']
+      expect(permitted_interconnect_type_uri).to eq('/rest/fake')
     end
 
     it 'raises an error if the interconnect is not found' do

--- a/spec/unit/resource/api300/synergy/lig_uplink_set_spec.rb
+++ b/spec/unit/resource/api300/synergy/lig_uplink_set_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe OneviewSDK::API300::Synergy::LIGUplinkSet do
     it 'sets the defaults correctly' do
       item = OneviewSDK::API300::Synergy::LIGUplinkSet.new(@client_300, networkType: 'FibreChannel')
       expect(item[:logicalPortConfigInfos]).to eq([])
-      expect(item[:lacpTimer]).to eq('Short')
+      expect(item[:lacpTimer]).to eq(nil)
       expect(item[:mode]).to eq('Auto')
       expect(item[:networkUris]).to eq([])
     end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe OneviewSDK::Resource do
       expect { res.like?(nil) }.to raise_error(/Can't compare with object type: NilClass/)
     end
 
-    context 'when compare similar objects into array' do
+    context 'when comparing similar objects inside arrays' do
       it 'should return true' do
         options = { uri: '/rest/fake', list: [{ uri: '/rest/child/1', tag: 'not_to_compare' }, { uri: '/rest/child/2', tag: 'not_to_compare' }] }
         res = OneviewSDK::Resource.new(@client_200, options)
@@ -189,7 +189,7 @@ RSpec.describe OneviewSDK::Resource do
         expect(res.like?(uri: '/rest/fake', list: [])).to eq(true)
       end
 
-      it 'should return true if value is null' do
+      it 'should return true if value is nil' do
         options = { uri: '/rest/fake', list: nil }
         res = OneviewSDK::Resource.new(@client_200, options)
         expect(res.like?(uri: '/rest/fake', list: nil)).to eq(true)
@@ -208,7 +208,7 @@ RSpec.describe OneviewSDK::Resource do
       end
     end
 
-    context 'when compare different objects into array' do
+    context 'when comparing different objects inside arrays' do
       it 'should return false comparing with wrong value' do
         options = { uri: '/rest/fake', list: [{ uri: '/rest/child/1', tag: 'not_to_compare' }, { uri: '/rest/child/2', tag: 'not_to_compare' }] }
         res = OneviewSDK::Resource.new(@client_200, options)
@@ -221,13 +221,13 @@ RSpec.describe OneviewSDK::Resource do
         expect(res.like?(uri: '/rest/fake', list: [])).to eq(false)
       end
 
-      it 'should return false if current array is empty' do
+      it 'should return false if the array inside Resource that called the method is empty' do
         options = { uri: '/rest/fake', list: [] }
         res = OneviewSDK::Resource.new(@client_200, options)
         expect(res.like?(uri: '/rest/fake', list: [{ uri: '/rest/child/1' }])).to eq(false)
       end
 
-      it 'should return false if current value is null' do
+      it 'should return false if the value of array inside Resource that called the method is nil' do
         options = { uri: '/rest/fake', list: nil }
         res = OneviewSDK::Resource.new(@client_200, options)
         expect(res.like?(uri: '/rest/fake', list: [{ uri: '/rest/child/1' }])).to eq(false)
@@ -453,7 +453,7 @@ RSpec.describe OneviewSDK::Resource do
     end
 
     context 'when there are many pages' do
-      context "and, in the last page, body['nextPageUri'] is null" do
+      context "and, in the last page, body['nextPageUri'] is nil" do
         it 'should return all resources' do
           fake_response_1 = FakeResponse.new(members: [
             { name: 'Enc1', uri: "#{OneviewSDK::Enclosure::BASE_URI}/1" },

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -170,9 +170,80 @@ RSpec.describe OneviewSDK::Resource do
       expect(res.like?(data: { key2: 'val2' })).to eq(false)
     end
 
-    it 'requires the other objet to respond to .each' do
+    it 'requires the other object to respond to .each' do
       res = OneviewSDK::Resource.new(@client_200)
       expect { res.like?(nil) }.to raise_error(/Can't compare with object type: NilClass/)
+    end
+
+    context 'when compare similar objects into array' do
+      it 'should return true' do
+        options = { uri: '/rest/fake', list: [{ uri: '/rest/child/1', tag: 'not_to_compare' }, { uri: '/rest/child/2', tag: 'not_to_compare' }] }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: [{ uri: '/rest/child/2' }, { uri: '/rest/child/1' }])).to eq(true)
+        expect(res.like?(uri: '/rest/fake', list: [{ uri: '/rest/child/1' }])).to eq(true)
+      end
+
+      it 'should return true if array is empty' do
+        options = { uri: '/rest/fake', list: [] }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: [])).to eq(true)
+      end
+
+      it 'should return true if value is null' do
+        options = { uri: '/rest/fake', list: nil }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: nil)).to eq(true)
+      end
+
+      it 'should return true with more than one depth level using array' do
+        options = { uri: '/rest/fake', list: [{ children: [{ name: 'level_2_child' }] }, { children: [{ name: 'level_2_child' }] }] }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: [{ children: [{ name: 'level_2_child' }] }])).to eq(true)
+      end
+
+      it 'should return true with values that are not a Hash' do
+        options = { uri: '/rest/fake', list: %w(value_1 value_2) }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: %w(value_1 value_2))).to eq(true)
+      end
+    end
+
+    context 'when compare different objects into array' do
+      it 'should return false comparing with wrong value' do
+        options = { uri: '/rest/fake', list: [{ uri: '/rest/child/1', tag: 'not_to_compare' }, { uri: '/rest/child/2', tag: 'not_to_compare' }] }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: [{ uri: '/rest/child/3' }])).to eq(false)
+      end
+
+      it 'should return false comparing with empty array' do
+        options = { uri: '/rest/fake', list: [{ uri: '/rest/child/1', tag: 'not_to_compare' }, { uri: '/rest/child/2', tag: 'not_to_compare' }] }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: [])).to eq(false)
+      end
+
+      it 'should return false if current array is empty' do
+        options = { uri: '/rest/fake', list: [] }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: [{ uri: '/rest/child/1' }])).to eq(false)
+      end
+
+      it 'should return false if current value is null' do
+        options = { uri: '/rest/fake', list: nil }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: [{ uri: '/rest/child/1' }])).to eq(false)
+      end
+
+      it 'should return false with more than one depth level using array' do
+        options = { uri: '/rest/fake', list: [{ children: [{ name: 'level_2_child' }] }] }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: [{ children: [{ name: 'level_1_child' }] }])).to eq(false)
+      end
+
+      it 'should return false with values that are not a Hash' do
+        options = { uri: '/rest/fake', list: %(value_1 value_2) }
+        res = OneviewSDK::Resource.new(@client_200, options)
+        expect(res.like?(uri: '/rest/fake', list: ['value_1'])).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
### Description
The `like?` method of Resource class does not can compare arrays correctly. For this, when it compare two Logical Interconnect Groups that have uplinkSets and Interconnects (that are arrays of objects), the `like?` method returns false (it should return true).
This commit changes the method `like?` for accept an object with attributes that are arrays and compare them with the respective resource attribute.

### Issues Resolved
Fixes #89 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
