### PR TITLE
Removed the ::get_default_settings method from integration test of LIG

### DIFF
--- a/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
+++ b/spec/integration/resource/api200/logical_interconnect_group/create_spec.rb
@@ -138,14 +138,6 @@ RSpec.describe klass, integration: true, type: CREATE, sequence: seq(klass) do
       expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
     end
 
-    it 'default settings from the lig instance' do
-      default_settings = @item.get_default_settings
-      expect(default_settings).to be
-      expect(default_settings['type']).to eq('InterconnectSettingsV3')
-      expect(default_settings['uri']).to_not be
-      expect(default_settings['ethernetSettings']['uri']).to match(/ethernetSettings/)
-    end
-
     it 'current settings' do
       default_settings = @item.get_settings
       expect(default_settings).to be


### PR DESCRIPTION
### Description
This problem already was solved for the api300 test integration.
And now was solved for api200 test integration.
The CHANGELOG already has the description of the issue solved.

### Issues Resolved
Fixes #202 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
