### PR TITLE
Fix like? method for server profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
 (none)
 
 #### Bug fixes & Enhancements:
+- [#89](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/89) Fix like? method for Logical Interconnect Groups
+- [#119](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/112) VolumeAttachment::remove_extra_unmanaged_volume throw Unexpected Http Error
+- [#125](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/125) References to resources C7000 in Synergy integration tests
 - [#189](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/189) Use helper methods of Rest module for upload and download file
 - [#201](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/201) Code to search the collection of resources (paginated search) is repeated in some resources
-- [#119](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/112) VolumeAttachment::remove_extra_unmanaged_volume throw Unexpected Http Error
 - [#202](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/202) The method #get_default_settings in LogicalInterconnectGroup is used on integration test
-- [#125](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/125) References to resources C7000 in Synergy integration tests
 - [#212](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/212) Unable to create a Server Profile with Deployment Plan settings
-- [#89](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/89) Fix like? method for Logical Interconnect Groups
+- [#219](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/219) Fix like? method for Server Profile
 
 #### Design changes:
    - Architecture for future API500 support. Features for API500 are not yet supported.

--- a/lib/oneview-sdk/resource.rb
+++ b/lib/oneview-sdk/resource.rb
@@ -367,7 +367,7 @@ module OneviewSDK
           val.each do |other_item|
             return false unless data_array.find { |data_item| recursive_like?(other_item, data_item) }
           end
-        elsif val != data[key.to_s] && val != data[key.to_sym]
+        elsif val.to_s != data[key.to_s].to_s && val.to_s != data[key.to_sym].to_s
           return false
         end
       end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -159,9 +159,12 @@ RSpec.describe OneviewSDK::Resource do
     end
 
     it 'works for nested hashes' do
-      options = { name: 'res', uri: '/rest/fake', data: { 'key1' => 'val1', 'key2' => 'val2' } }
+      options = { name: 'res', uri: '/rest/fake', data: { 'key1' => 1, 'key2' => 'val2', 'key3' => '2' } }
       res = OneviewSDK::Resource.new(@client_200, options)
+      expect(res.like?(data: { key1: '1' })).to eq(true)
+      expect(res.like?(data: { key1: 1 })).to eq(true)
       expect(res.like?(data: { key2: 'val2' })).to eq(true)
+      expect(res.like?(data: { key3: 2 })).to eq(true)
     end
 
     it 'returns false for unlike hashes' do


### PR DESCRIPTION
Fixing like? for cases where ov returns integers or strings where those are unexpected.

### Description
Fixes `like?` method for server profile, which failed in cases such as cited in issue #219 

### Issues Resolved
#219 

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] Changes are documented in the CHANGELOG.
