### PR TITLE
Fix URI to get OS Deployment Plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.2.1
+
+#### Bug fixes & Enhancements:
+- [#222](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/222) Error listing the OS Deployment Plans from OneView
+
 # v4.2.0
 
 #### New Resources:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# v4.2.1
+# Unreleased Changes
+## Suggested release: v4.2.1
 
 #### Bug fixes & Enhancements:
 - [#222](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/222) Error listing the OS Deployment Plans from OneView

--- a/lib/oneview-sdk/resource/api300/synergy/os_deployment_plan.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/os_deployment_plan.rb
@@ -16,7 +16,7 @@ module OneviewSDK
     module Synergy
       # Network set resource implementation for API300 Synergy
       class OSDeploymentPlan < OneviewSDK::API300::Synergy::Resource
-        BASE_URI = '/rest/os-deployment-plans'.freeze
+        BASE_URI = '/rest/os-deployment-plans/'.freeze
 
         # Method is not available
         # @raise [OneviewSDK::MethodUnavailable] method is not available

--- a/spec/unit/resource/api300/synergy/os_deployment_plan_spec.rb
+++ b/spec/unit/resource/api300/synergy/os_deployment_plan_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OneviewSDK::API300::Synergy::OSDeploymentPlan do
   include_context 'shared context'
 
   it 'BASE_URI should be the correct URI' do
-    expect(described_class::BASE_URI).to eq('/rest/os-deployment-plans')
+    expect(described_class::BASE_URI).to eq('/rest/os-deployment-plans/')
   end
 
   it 'inherits from Resource' do


### PR DESCRIPTION
### Description
Changed the URI to get OS Deployment Plan, from  '/rest/os-deployment-plans' to  '/rest/os-deployment-plans/'.

### Issues Resolved
Fixes #222 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
