### PR TITLE
QSFP uplink & Integer ports support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Suggested release: v4.3.1 (Unreleased Changes)
+
+#### Bug fixes & Enhancements
+- [#216](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/216) Missing support for Q ports in API300::Synergy::LIGUplinkSet, missing support for multiple Synergy frames
+- [#228](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/228) Method add_uplink for LIG Uplinks Set does not work with Q ports nor integer ports
+
 ## v4.3.0
 
 #### New Features:

--- a/examples/api300/synergy/logical_interconnect_group.rb
+++ b/examples/api300/synergy/logical_interconnect_group.rb
@@ -14,17 +14,46 @@ require_relative '../../_client' # Gives access to @client,
 # Example: Create a Logical Interconnect Group
 
 options = {
-  name: 'Sample LIG',
-  redundancyType: 'Redundant',
-  interconnectBaySet: 3
+  name: 'Sample LIG 2 Frames',
+  redundancyType: 'HighlyAvailable',
+  interconnectBaySet: 3,
+  enclosureIndexes: [1, 2],
+  enclosureType: 'SY12000'
 }
 
 # Adds a new LIG with the options defined above
 item = OneviewSDK::API300::Synergy::LogicalInterconnectGroup.new(@client, options)
 
 # Adds the following interconnects to the bays 3 and 6 with an Interconnect Type, respectively
-item.add_interconnect(3, 'Virtual Connect SE 40Gb F8 Module for Synergy')
-item.add_interconnect(6, 'Virtual Connect SE 40Gb F8 Module for Synergy')
+item.add_interconnect(3, 'Virtual Connect SE 40Gb F8 Module for Synergy', 1)
+item.add_interconnect(6, 'Synergy 20Gb Interconnect Link Module', 1)
+item.add_interconnect(3, 'Synergy 20Gb Interconnect Link Module', 2)
+item.add_interconnect(6, 'Virtual Connect SE 40Gb F8 Module for Synergy', 2)
+
+# Adds a new Ethernet / Tagged network
+network01_options = {
+  name: 'Management',
+  vlanId:  1000,
+  purpose: 'General',
+  smartLink: false,
+  privateNetwork: false
+}
+network01 = OneviewSDK::API300::EthernetNetwork.new(c, network01_options)
+network01.create
+
+# Adds Uplink Set
+upset01_options = {
+  name: 'UplinkSet1',
+  networkType: 'Ethernet'
+}
+upset01 = OneviewSDK::API300::LIGUplinkSet.new(@client, upset01_options)
+
+# Adds Uplink ports from Frame #1 ICM3, Frame #2 ICM6
+upset01.add_uplink(3, 'Q1', 'Virtual Connect SE 40Gb F8 Module for Synergy', 1)
+upset01.add_uplink(6, 'Q1', 'Virtual Connect SE 40Gb F8 Module for Synergy', 2)
+
+# Adds netowork 'Management' to the Uplink Set
+upset01.add_network(network01)
 
 # Creates the LIG
 item.create

--- a/examples/api300/synergy/logical_interconnect_group.rb
+++ b/examples/api300/synergy/logical_interconnect_group.rb
@@ -55,6 +55,9 @@ upset01.add_uplink(6, 'Q1', 'Virtual Connect SE 40Gb F8 Module for Synergy', 2)
 # Adds netowork 'Management' to the Uplink Set
 upset01.add_network(network01)
 
+# Adds Uplink set to the LIG
+item.add_uplink(upset01)
+
 # Creates the LIG
 item.create
 

--- a/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
+++ b/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
@@ -44,7 +44,7 @@ module OneviewSDK
       # @param [String] interconnect model name
       # @param [Fixnum] enclosure number for multi-frame configurations
       def add_uplink(bay, port, type = nil, enclosure_index = 1)
-        enclosure_index = !type.nil? && type.include?('Virtual Connect SE 16Gb FC Module') ? -1 : enclosure_index
+        enclosure_index = type && type.include?('Virtual Connect SE 16Gb FC Module') ? -1 : enclosure_index
         port =
           if type
             fetch_relative_value_of(port, type)

--- a/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
+++ b/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
@@ -49,7 +49,7 @@ module OneviewSDK
           if type
             fetch_relative_value_of(port, type)
           else
-            # Detect integer ports typed as String
+            # Detect Integer port: for example 67 or '67'
             port.to_s == port.to_i.to_s ? port.to_i : relative_value_of(port)
           end
         entry = {

--- a/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
+++ b/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
@@ -40,15 +40,24 @@ module OneviewSDK
 
       # Specify one uplink passing the virtual connect bay and the port to be attached.
       # @param [Fixnum] bay number to identify the VC
-      # @param [String] port to attach the uplink. Allowed D1..D16 and X1..X10
-      def add_uplink(bay, port)
+      # @param [String, Fixnum] port to attach the uplink. Examples: X1, D1, Q1, Q1.1, Q1:1, 67 ...
+      # @param [String] interconnect model name
+      # @param [Fixnum] enclosure number for multi-frame configurations
+      def add_uplink(bay, port, type = nil, enclosure_index = 1)
+        enclosure_index = !type.nil? && type.include?('Virtual Connect SE 16Gb FC Module') ? -1 : enclosure_index
+        port =
+          if type
+            fetch_relative_value_of(port, type)
+          else
+            port.to_s == port.to_i.to_s ? port : relative_value_of(port)
+          end
         entry = {
           'desiredSpeed' => 'Auto',
           'logicalLocation' => {
             'locationEntries' => [
               { 'relativeValue' => bay, 'type' => 'Bay' },
-              { 'relativeValue' => 1, 'type' => 'Enclosure' },
-              { 'relativeValue' => relative_value_of(port), 'type' => 'Port' }
+              { 'relativeValue' => enclosure_index, 'type' => 'Enclosure' },
+              { 'relativeValue' => port, 'type' => 'Port' }
             ]
           }
         }
@@ -78,6 +87,18 @@ module OneviewSDK
                  else raise InvalidResource, "Port not supported: #{identifier} type not found"
                  end
         port.to_i + offset
+      end
+
+      def fetch_relative_value_of(port, type)
+        port_formats = [port.sub('.', ':'), port.sub(':', '.')].uniq
+        interconnect_type = OneviewSDK::Interconnect.get_type(@client, type)
+        unless interconnect_type
+          list = OneviewSDK::Interconnect.get_types(@client).map { |t| t['name'] }
+          raise OneviewSDK::NotFound, "Interconnect type #{type} not found! Supported types: #{list}"
+        end
+        type_port = interconnect_type['portInfos'].find { |p| port_formats.include? p['portName'] }
+        raise OneviewSDK::NotFound, "Port #{port} not found!" unless type_port
+        type_port['portNumber']
       end
     end
   end

--- a/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
+++ b/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
@@ -49,6 +49,7 @@ module OneviewSDK
           if type
             fetch_relative_value_of(port, type)
           else
+            # Detect integer ports typed as String
             port.to_s == port.to_i.to_s ? port.to_i : relative_value_of(port)
           end
         entry = {

--- a/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
+++ b/lib/oneview-sdk/resource/api200/lig_uplink_set.rb
@@ -49,7 +49,7 @@ module OneviewSDK
           if type
             fetch_relative_value_of(port, type)
           else
-            port.to_s == port.to_i.to_s ? port : relative_value_of(port)
+            port.to_s == port.to_i.to_s ? port.to_i : relative_value_of(port)
           end
         entry = {
           'desiredSpeed' => 'Auto',

--- a/spec/unit/resource/api200/lig_uplink_set_spec.rb
+++ b/spec/unit/resource/api200/lig_uplink_set_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe OneviewSDK::LIGUplinkSet do
         upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
         expect { upset.add_uplink(1, 'Q1.1', @type) }.not_to raise_error
       end
-      it 'not supported port' do
+      it 'not existing port' do
         upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
-        expect { upset.add_uplink(1, 'Q8:1', @type) }.to raise_error(OneviewSDK::NotFound)
+        expect { upset.add_uplink(1, 'Q9:1', @type) }.to raise_error(OneviewSDK::NotFound)
       end
     end
   end

--- a/spec/unit/resource/api200/lig_uplink_set_spec.rb
+++ b/spec/unit/resource/api200/lig_uplink_set_spec.rb
@@ -15,29 +15,61 @@ RSpec.describe OneviewSDK::LIGUplinkSet do
 
   describe 'adds' do
     def_options = { networkType: 'Ethernet', ethernetNetworkType: 'NotApplicable' }
-    it 'Add empty network resource' do
+    it 'empty network resource' do
       upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
       net = OneviewSDK::EthernetNetwork.new(@client_200, {})
       expect { upset.add_network(net) }.to raise_error(OneviewSDK::IncompleteResource, /Must set/)
     end
-    it 'Add retrieved network resource' do
+    it 'retrieved network resource' do
       options = { networkType: 'Ethernet', ethernetNetworkType: 'NotApplicable' }
       upset = OneviewSDK::LIGUplinkSet.new(@client_200, options)
       net = OneviewSDK::EthernetNetwork.new(@client_200, uri: '/rest/ethernet-networks/65546B-A55F20-663390-CA96F5')
       expect { upset.add_network(net) }.not_to raise_error
     end
-    it 'Add X7 port' do
-      upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
-      expect { upset.add_uplink(1, 'X7') }.not_to raise_error
+    context 'statically obtained relative value of' do
+      it 'port X7' do
+        upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+        expect { upset.add_uplink(1, 'X7') }.not_to raise_error
+      end
+      it 'port D5' do
+        upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+        expect { upset.add_uplink(1, 'D5') }.not_to raise_error
+      end
+      it 'port 67' do
+        upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+        expect { upset.add_uplink(1, '67') }.not_to raise_error
+      end
+      it 'not supported port' do
+        upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+        expect { upset.add_uplink(1, 'V5') }.to raise_error(OneviewSDK::InvalidResource, /Port not supported/)
+      end
     end
-    it 'Add D5 port' do
-      upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
-      expect { upset.add_uplink(1, 'D5') }.not_to raise_error
-    end
-    it 'Add not supported port' do
-      upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
-      expect { upset.add_uplink(1, 'V5') }.to raise_error(OneviewSDK::InvalidResource, /Port not supported/)
+    context 'dynamically obtained relative value of' do
+      before :each do
+        @type = 'HP VC FlexFabric-20/40 F8 Module'
+        resp = { 'portInfos' => [
+          { 'portName' => 'Q8:1', 'portNumber' => 97 },
+          { 'portName' => 'Q1.1', 'portNumber' => 17 },
+          { 'portName' => 'Q1', 'portNumber' => 61 }
+          ] }
+        allow(OneviewSDK::Interconnect).to receive(:get_type).with(@client_200, @type).and_return(resp)
+      end
+      it 'port Q8:1' do
+        upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+        expect { upset.add_uplink(1, 'Q8:1', @type) }.not_to raise_error
+      end
+      it 'port Q1' do
+        upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+        expect { upset.add_uplink(1, 'Q1', @type) }.not_to raise_error
+      end
+      it 'port Q1.1' do
+        upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+        expect { upset.add_uplink(1, 'Q1.1', @type) }.not_to raise_error
+      end
+      it 'not supported port' do
+        upset = OneviewSDK::LIGUplinkSet.new(@client_200, def_options)
+        expect { upset.add_uplink(1, 'Q8:1', @type) }.to raise_error(OneviewSDK::NotFound)
+      end
     end
   end
-
 end


### PR DESCRIPTION
### Description
This pull request contains fixes for #216 and #228. Now it is possible to create LIGs will all supported Interconnect Modules / Uplink ports. Legacy functionality for Ten-Gig (`X`) and Downlink (`D`) ports has remained preserved. There is also a new functionality (requested in #228) which enables use of Integer ports (final relative value of uplink port).

### Issues Resolved
- #216
- #228 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
