### PR TITLE
Fix 231

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Bug fixes & Enhancements
 - [#216](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/216) Missing support for Q ports in API300::Synergy::LIGUplinkSet, missing support for multiple Synergy frames
 - [#228](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/228) Method add_uplink for LIG Uplinks Set does not work with Q ports nor integer ports
+- [##231](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/#231) Support id in ServerProfile#add_connection
 
 ## v4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Bug fixes & Enhancements
 - [#216](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/216) Missing support for Q ports in API300::Synergy::LIGUplinkSet, missing support for multiple Synergy frames
 - [#228](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/228) Method add_uplink for LIG Uplinks Set does not work with Q ports nor integer ports
-- [##231](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/#231) Support id in ServerProfile#add_connection
+- [#231](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/#231) Support id in ServerProfile#add_connection
 
 ## v4.3.0
 

--- a/lib/oneview-sdk/resource/api200/server_profile.rb
+++ b/lib/oneview-sdk/resource/api200/server_profile.rb
@@ -148,6 +148,7 @@ module OneviewSDK
       #   The value can be 'Undefined', 'Reserved', or 'Deployed'.
       # @option connection_options [String] 'functionType' Type of function required for the connection.
       #   functionType cannot be modified after the connection is created.
+      # @option connection_options [String] 'id' Unique identifier for this connection. Defaults to 0 (auto).
       # @option connection_options [String] 'mac' The MAC address that is currently programmed on the FlexNic.
       # @option connection_options [String] 'macType' Specifies the type of MAC address to be programmed into the IO Devices.
       #   The value can be 'Virtual', 'Physical' or 'UserDefined'.
@@ -165,7 +166,7 @@ module OneviewSDK
       #   The value can be 'Virtual', 'Physical' or 'UserDefined'.
       def add_connection(network, connection_options = {})
         self['connections'] = [] unless self['connections']
-        connection_options['id'] = 0 # Letting OneView treat the ID registering
+        connection_options['id'] ||= 0 unless connection_options[:id] # Letting OneView treat the ID registering
         connection_options['networkUri'] = network['uri'] if network['uri'] || network.retrieve!
         self['connections'] << connection_options
       end

--- a/spec/unit/resource/api200/server_profile_spec.rb
+++ b/spec/unit/resource/api200/server_profile_spec.rb
@@ -352,6 +352,13 @@ RSpec.describe OneviewSDK::ServerProfile do
       expect(@item['connections'].first['networkUri']).to eq('rest/fake/ethernet-networks/unit')
     end
 
+    it 'allows you to set the id' do
+      @item.add_connection(@network, id: 1)
+      @item.add_connection(@network, 'id' => 2)
+      expect(@item['connections'].first[:id]).to eq(1)
+      expect(@item['connections'].last['id']).to eq(2)
+    end
+
     it 'adds multiple connections' do
       base_uri = @network['uri']
       1.upto(4) do |count|


### PR DESCRIPTION
### Description
Allow `ServerProfile#add_connection` to set an id.

### Issues Resolved
Fixes #231

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
