### PR TITLE
Removed triple T in ServerProfile #set_os_deployment_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v4.5.1 (New Release)
+
+#### Bug fixes & Enhancements
+- [#241](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/241) Wrong method name in Server Profile
+
 ## v4.5.0
 
 #### New Resources:

--- a/lib/oneview-sdk/resource/api300/synergy/server_profile.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/server_profile.rb
@@ -79,7 +79,7 @@ module OneviewSDK
         #   The internal hashes may contain:
         #   - 'name' [String] name of the attribute
         #   - 'value' [String] value of the attribute
-        def set_os_deployment_setttings(os_deployment_plan, custom_attributes = [])
+        def set_os_deployment_settings(os_deployment_plan, custom_attributes = [])
           os_deployment_plan.ensure_uri
           @data['osDeploymentSettings'] ||= {}
           @data['osDeploymentSettings']['osDeploymentPlanUri'] = os_deployment_plan['uri']

--- a/spec/unit/resource/api300/synergy/server_profile_spec.rb
+++ b/spec/unit/resource/api300/synergy/server_profile_spec.rb
@@ -493,14 +493,14 @@ RSpec.describe OneviewSDK::API300::Synergy::ServerProfile do
     end
   end
 
-  describe '#set_os_deployment_setttings' do
+  describe '#set_os_deployment_settings' do
     let(:os_deployment_plan) { OneviewSDK::API300::Synergy::OSDeploymentPlan.new(@client_300, uri: '/os-deployment-plan/1') }
 
     it 'should pupulate osDeploymentSettings attribute correctly' do
       custom_attrs = [{ name: 'field.one', value: 'value1' }, { name: 'field.two', value: 'value2' }]
       expect(@item['osDeploymentSettings']).not_to be
 
-      @item.set_os_deployment_setttings(os_deployment_plan, custom_attrs)
+      @item.set_os_deployment_settings(os_deployment_plan, custom_attrs)
 
       expected_settings = { 'osDeploymentPlanUri' => '/os-deployment-plan/1', 'osCustomAttributes' => custom_attrs }
       expect(@item['osDeploymentSettings']).to eq(expected_settings)
@@ -512,7 +512,7 @@ RSpec.describe OneviewSDK::API300::Synergy::ServerProfile do
         settings = { 'osDeploymentPlanUri' => '/fake/uri', 'osCustomAttributes' => custom_attrs }
         @item['osDeploymentSettings'] = settings
 
-        @item.set_os_deployment_setttings(os_deployment_plan, [{ name: 'new_name', value: 'new_value' }])
+        @item.set_os_deployment_settings(os_deployment_plan, [{ name: 'new_name', value: 'new_value' }])
 
         expected_settings = { 'osDeploymentPlanUri' => '/os-deployment-plan/1', 'osCustomAttributes' => [{ name: 'new_name', value: 'new_value' }] }
         expect(@item['osDeploymentSettings']).to eq(expected_settings)
@@ -522,7 +522,7 @@ RSpec.describe OneviewSDK::API300::Synergy::ServerProfile do
     context 'when os_deployment_plan has not URI' do
       it 'should throw IncompleteResource error' do
         wrong_os_deployment_plan = OneviewSDK::API300::Synergy::OSDeploymentPlan.new(@client_300)
-        expect { @item.set_os_deployment_setttings(wrong_os_deployment_plan) }
+        expect { @item.set_os_deployment_settings(wrong_os_deployment_plan) }
           .to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute*/)
       end
     end


### PR DESCRIPTION
### Description
Fixes the ttt in the ServerProfile #set_os_deployment_settings

### Issues Resolved
#241 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
