### PR TITLE
plain IPv4, IPv6 and hostname support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Bug fixes & Enhancements
 - [#244](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/244) OneviewSDK::Rest can't properly handle IPv6 addresses
-- [#246]https://github.com/HewlettPackard/oneview-sdk-ruby/issues/246 Missing support for zone ID in IPv6 addresses
+- [#246](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/246) Missing support for zone ID in IPv6 addresses
 
 ## v4.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.x.x (new release)
+
+#### Bug fixes & Enhancements
+- [#244](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/244) OneviewSDK::Rest can't properly handle IPv6 addresses
+- [#246]https://github.com/HewlettPackard/oneview-sdk-ruby/issues/246 Missing support for zone ID in IPv6 addresses
+
 ## v4.5.1
 
 #### Bug fixes & Enhancements

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The OneView client has a few configuration options, which you can pass in during
 # Create a OneView client object:
 require 'oneview-sdk'
 client = OneviewSDK::Client.new(
-  url: 'https://oneview.example.com',
+  url: 'https://oneview.example.com', # Set EITHER this or the hostname & port
+  hostname: 'oneview.example.com',
+  port: 443,
   user: 'Administrator',              # This is the default
   password: 'secret123',
   token: 'xxxx...',                   # Set EITHER this or the user & password
@@ -82,6 +84,8 @@ You can also set many of the client attributes using environment variables. To s
 ```bash
 # OneView client options:
 export ONEVIEWSDK_URL='https://oneview.example.com'
+export ONEVIEWSDK_HOSTNAME='oneview.example.com'
+export ONEVIEWSDK_PORT=443
 export ONEVIEWSDK_DOMAIN='LOCAL'
 # You can set the token if you know it, or set the user and password to generate one:
 export ONEVIEWSDK_TOKEN='xxxx...'

--- a/lib/oneview-sdk/client.rb
+++ b/lib/oneview-sdk/client.rb
@@ -30,6 +30,9 @@ module OneviewSDK
     # @option options [Symbol] :log_level (:info) Log level. Logger must define a constant with this name. ie Logger::INFO
     # @option options [Boolean] :print_wait_dots (false) When true, prints status dots while waiting on the tasks to complete.
     # @option options [String] :url URL of OneView appliance
+    # @option options [String] :hostname IPv4, IPv6 or hostname of OneView appliance
+    # @option options [Integer] :port TCP/IP port of OneView appliance
+    #   Use the url or hostname + port (not both). The url has precedence.
     # @option options [String] :user ('Administrator') The username to use for authentication with the OneView appliance
     # @option options [String] :password (ENV['ONEVIEWSDK_PASSWORD']) The password to use for authentication with OneView appliance
     # @option options [String] :domain ('LOCAL') The name of the domain directory used for authentication
@@ -46,7 +49,9 @@ module OneviewSDK
       self.log_level = options[:log_level] || :info
       @print_wait_dots = options.fetch(:print_wait_dots, false)
       @url = options[:url] || ENV['ONEVIEWSDK_URL']
-      raise InvalidClient, 'Must set the url option' unless @url
+      @hostname = options[:hostname] || ENV['ONEVIEWSDK_HOSTNAME']
+      @port = options[:port] || ENV['ONEVIEWSDK_PORT']
+      raise InvalidClient, 'Must set the url or hostname + port.' unless @url || (@hostname && @port)
       @max_api_version = appliance_api_version
       if options[:api_version] && options[:api_version].to_i > @max_api_version
         logger.warn "API version #{options[:api_version]} is greater than the appliance API version (#{@max_api_version})"

--- a/lib/oneview-sdk/client.rb
+++ b/lib/oneview-sdk/client.rb
@@ -18,8 +18,8 @@ module OneviewSDK
   # The client defines the connection to the OneView server and handles communication with it.
   class Client
     attr_reader :max_api_version
-    attr_accessor :url, :user, :token, :password, :domain, :ssl_enabled, :api_version, \
-                  :logger, :log_level, :cert_store, :print_wait_dots, :timeout
+    attr_accessor :url, :hostname, :port, :user, :token, :password, :domain, :ssl_enabled, \
+                  :api_version, :logger, :log_level, :cert_store, :print_wait_dots, :timeout
 
     include Rest
 
@@ -51,7 +51,7 @@ module OneviewSDK
       @url = options[:url] || ENV['ONEVIEWSDK_URL']
       @hostname = options[:hostname] || ENV['ONEVIEWSDK_HOSTNAME']
       @port = options[:port] || ENV['ONEVIEWSDK_PORT']
-      raise InvalidClient, 'Must set the url or hostname + port.' unless @url || (@hostname && @port)
+      raise InvalidClient, 'Must set the url or hostname + port' unless @url || (@hostname && @port)
       @max_api_version = appliance_api_version
       if options[:api_version] && options[:api_version].to_i > @max_api_version
         logger.warn "API version #{options[:api_version]} is greater than the appliance API version (#{@max_api_version})"

--- a/lib/oneview-sdk/rest.rb
+++ b/lib/oneview-sdk/rest.rb
@@ -34,7 +34,7 @@ module OneviewSDK
     # @return [NetHTTPResponse] Response object
     def rest_api(type, path, options = {}, api_ver = @api_version, redirect_limit = 3)
       logger_path = @url ? "#{@url}#{path}" : "https://#{@hostname}:#{@port}#{path}"
-      @logger.debug "Making :#{type} rest call to #{logger_path}"      
+      @logger.debug "Making :#{type} rest call to #{logger_path}"
       raise InvalidRequest, 'Must specify path' unless path
       req_info = prepare_request_info(path)
       http = build_http_object(req_info[:host], req_info[:port], req_info[:use_ssl])

--- a/lib/oneview-sdk/rest.rb
+++ b/lib/oneview-sdk/rest.rb
@@ -238,7 +238,6 @@ module OneviewSDK
 
     # Prepare host/request info according to given data
     def prepare_request_info(path)
-      path = URI.escape(path)
       begin
         URI.parse(path)
       rescue URI::InvalidURIError
@@ -254,7 +253,7 @@ module OneviewSDK
         host = @hostname
         port = @port.to_i # forcibly convert to integer
       end
-      { host: host, port: port, use_ssl: use_ssl, path: path }
+      { host: host, port: port, use_ssl: use_ssl, path: URI.escape(path) }
     end
 
     # Builds a http object using the data given

--- a/lib/oneview-sdk/rest.rb
+++ b/lib/oneview-sdk/rest.rb
@@ -243,16 +243,10 @@ module OneviewSDK
       rescue URI::InvalidURIError
         raise InvalidRequest, 'Invalid path'
       end
-      if @url
-        uri = URI.parse(@url)
-        host = uri.hostname
-        port = uri.port
-        use_ssl = uri.scheme == 'https'
-      else
-        use_ssl = @port == 443
-        host = @hostname
-        port = @port.to_i # forcibly convert to integer
-      end
+      uri = @url ? URI.parse(@url) : nil
+      host = @url ? uri.hostname : @hostname
+      port = @url ? uri.port : @port
+      use_ssl = @url ? uri.scheme == 'https' : @port == 443
       { host: host, port: port, use_ssl: use_ssl, path: URI.escape(path) }
     end
 

--- a/lib/oneview-sdk/rest.rb
+++ b/lib/oneview-sdk/rest.rb
@@ -33,11 +33,12 @@ module OneviewSDK
     # @raise [OpenSSL::SSL::SSLError] if SSL validation of OneView instance's certificate failed
     # @return [NetHTTPResponse] Response object
     def rest_api(type, path, options = {}, api_ver = @api_version, redirect_limit = 3)
-      @logger.debug "Making :#{type} rest call to #{@url}#{path}"
+      logger_path = @url ? "#{@url}#{path}" : "https://#{@hostname}:#{@port}#{path}"
+      @logger.debug "Making :#{type} rest call to #{logger_path}"      
       raise InvalidRequest, 'Must specify path' unless path
-      uri = URI.parse(URI.escape(@url + path))
-      http = build_http_object(uri)
-      request = build_request(type, uri, options.dup, api_ver)
+      req_info = prepare_request_info(path)
+      http = build_http_object(req_info[:host], req_info[:port], req_info[:use_ssl])
+      request = build_request(type, req_info[:path], options.dup, api_ver)
       response = http.request(request)
       @logger.debug "  Response: Code=#{response.code}. Headers=#{response.to_hash}\n  Body=#{response.body}"
       if response.class <= Net::HTTPRedirection && redirect_limit > 0 && response['location']
@@ -140,12 +141,12 @@ module OneviewSDK
         name_to_show = options['file_name'] || File.basename(file_path)
         body_params['file'] = UploadIO.new(file, 'application/octet-stream', name_to_show)
 
-        uri = URI.parse(URI.escape(@url + path))
-        http_request = build_http_object(uri)
+        req_info = prepare_request_info(path)
+        http_request = build_http_object(req_info[:host], req_info[:port], req_info[:use_ssl])
         http_request.read_timeout = timeout
 
         req = Net::HTTP::Post::Multipart.new(
-          uri.path,
+          req_info[:path],
           body_params,
           headers
         )
@@ -169,9 +170,9 @@ module OneviewSDK
     # @param [String] local_drive_path Path to save file downloaded
     # @return [Boolean] if file was downloaded
     def download_file(path, local_drive_path)
-      uri = URI.parse(URI.escape(@url + path))
-      http_request = build_http_object(uri)
-      req = build_request(:get, uri, {}, @api_version.to_s)
+      req_info = prepare_request_info(path)
+      http_request = build_http_object(req_info[:host], req_info[:port], req_info[:use_ssl])
+      req = build_request(:get, req_info[:path], {}, @api_version.to_s)
 
       http_request.start do |http|
         http.request(req) do |res|
@@ -235,10 +236,31 @@ module OneviewSDK
 
     private
 
+    # Prepare host/request info according to given data
+    def prepare_request_info(path)
+      path = URI.escape(path)
+      begin
+        URI.parse(path)
+      rescue URI::InvalidURIError
+        raise InvalidRequest, 'Invalid path'
+      end
+      if @url
+        uri = URI.parse(@url)
+        host = uri.hostname
+        port = uri.port
+        use_ssl = uri.scheme == 'https'
+      else
+        use_ssl = @port == 443
+        host = @hostname
+        port = @port.to_i # forcibly convert to integer
+      end
+      { host: host, port: port, use_ssl: use_ssl, path: path }
+    end
+
     # Builds a http object using the data given
-    def build_http_object(uri)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true if uri.scheme == 'https'
+    def build_http_object(host, port, use_ssl)
+      http = Net::HTTP.new(host, port)
+      http.use_ssl = use_ssl
       if @ssl_enabled
         http.cert_store = @cert_store if @cert_store
       else http.verify_mode = OpenSSL::SSL::VERIFY_NONE
@@ -249,18 +271,18 @@ module OneviewSDK
     end
 
     # Builds a request object using the data given
-    def build_request(type, uri, options, api_ver)
+    def build_request(type, path, options, api_ver)
       case type.downcase.to_sym
       when :get
-        request = Net::HTTP::Get.new(uri.request_uri)
+        request = Net::HTTP::Get.new(path)
       when :post
-        request = Net::HTTP::Post.new(uri.request_uri)
+        request = Net::HTTP::Post.new(path)
       when :put
-        request = Net::HTTP::Put.new(uri.request_uri)
+        request = Net::HTTP::Put.new(path)
       when :patch
-        request = Net::HTTP::Patch.new(uri.request_uri)
+        request = Net::HTTP::Patch.new(path)
       when :delete
-        request = Net::HTTP::Delete.new(uri.request_uri)
+        request = Net::HTTP::Delete.new(path)
       else
         raise InvalidRequest, "Invalid rest method: #{type}. Valid methods are: get, post, put, patch, delete"
       end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -20,8 +20,26 @@ RSpec.describe OneviewSDK::Client do
       expect { OneviewSDK::Client.new(options) }.to raise_error(OneviewSDK::InvalidClient, /Must set user & password options or token/)
     end
 
+    it 'creates a client with hostname and port' do
+      options = { hostname: 'oneview.example.com', port: 443, user: 'Administrator', password: 'secret123' }
+      client = OneviewSDK::Client.new(options)
+      expect(client.hostname).to eq(options[:hostname])
+      expect(client.port).to eq(options[:port])
+    end
+
+    it 'requires hostname and port pair' do
+      options = { hostname: 'oneview.example.com', user: 'Administrator', password: 'secret123' }
+      expect { OneviewSDK::Client.new(options) }.to raise_error(OneviewSDK::InvalidClient, /Must set the url or hostname \+ port/)
+    end
+
+    it 'requires hostname and port pair' do
+      options = { port: 443, user: 'Administrator', password: 'secret123' }
+      expect { OneviewSDK::Client.new(options) }.to raise_error(OneviewSDK::InvalidClient, /Must set the url or hostname \+ port/)
+    end
+
+
     it 'requires the url attribute to be set' do
-      expect { OneviewSDK::Client.new({}) }.to raise_error(OneviewSDK::InvalidClient, /Must set the url option/)
+      expect { OneviewSDK::Client.new({}) }.to raise_error(OneviewSDK::InvalidClient, /Must set the url or hostname \+ port/)
     end
 
     it 'sets the username to "Administrator" by default' do
@@ -141,6 +159,16 @@ RSpec.describe OneviewSDK::Client do
     it 'allows the url to be re-set' do
       @client_200.url = 'https://new-url.example.com'
       expect(@client_200.url).to eq('https://new-url.example.com')
+    end
+
+    it 'allows the hostname to be re-set' do
+      @client_200.hostname = '10.10.10.10'
+      expect(@client_200.hostname).to eq('10.10.10.10')
+    end
+
+    it 'allows the port to be re-set' do
+      @client_200.port = 443
+      expect(@client_200.port).to eq(443)
     end
 
     it 'allows the user to be re-set' do

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe OneviewSDK::Client do
       expect { @client_200.rest_api(:get, path) }.to raise_error(OpenSSL::SSL::SSLError)
     end
 
+    it 'raises an error when invalid path is supplied' do
+      expect { @client_200.rest_api(:get, '/invalid_uri%') }.to raise_error(OneviewSDK::InvalidRequest, /Invalid path/)
+    end
+
     it 'respects the client.timeout value' do
       client = OneviewSDK::Client.new(url: 'https://oneview.example.com', token: 'secret123', timeout: 5)
       expect_any_instance_of(Net::HTTP).to receive(:read_timeout=).with(5).and_call_original

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe OneviewSDK::Client do
         @client_200.cert_store = 'some_certificate'
         @client_200.timeout = 300
 
-        http = @client_200.send(:build_http_object, uri)
+        http = @client_200.send(:build_http_object, uri.hostname, uri.port, uri.scheme == 'https')
 
         expect(http.address).to eq('localhost')
         expect(http.port).to eq(1000)
@@ -368,7 +368,7 @@ RSpec.describe OneviewSDK::Client do
         uri = URI.parse('http://localhost:1000')
         @client_200.ssl_enabled = false
 
-        http = @client_200.send(:build_http_object, uri)
+        http = @client_200.send(:build_http_object, uri.hostname, uri.port, uri.scheme == 'https')
 
         expect(http.address).to eq('localhost')
         expect(http.port).to eq(1000)


### PR DESCRIPTION
### Description
This PR addresses issues #246 and #245. Majority of changes in `OneViewSDK::Client` and `OneViewSDK::Rest` are basically just workaround for lacking support of RFC6874 in the URI library. 

### Issues Resolved
- #246 
- #245 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
