### PR TITLE
Add ruby missing imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2.5
+  - 2.2.6
   - 2.3.1
+  - 2.4.1
 
 before_install: gem update bundler
 
 script:
   - rake build
   - rake test
+
+matrix:
+  allow_failures:
+    - rvm: 2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v5.0.2 (Unreleased)
+
+#### Bug fixes & Enhancements
+- [#263](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/263) cannot require oneview-sdk because the code is using non-require'd code
+
 ## v5.0.1
 
 #### Bug fixes & Enhancements

--- a/lib/oneview-sdk/resource/api300/c7000/ethernet_network.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/ethernet_network.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api200/ethernet_network'
+require_relative 'scope'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api300/c7000/fc_network.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/fc_network.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api200/fc_network'
+require_relative 'scope'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api300/c7000/fcoe_network.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/fcoe_network.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api200/fcoe_network'
+require_relative 'scope'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api300/c7000/logical_switch_group.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/logical_switch_group.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api200/logical_switch_group'
+require_relative 'scope'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api300/c7000/network_set.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/network_set.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api200/network_set'
+require_relative 'scope'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api300/synergy/ethernet_network.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/ethernet_network.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api200/ethernet_network'
+require_relative 'scope'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api300/synergy/fc_network.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/fc_network.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api200/fc_network'
+require_relative 'scope'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api300/synergy/fcoe_network.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/fcoe_network.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../c7000/fcoe_network'
+require_relative 'scope'
 
 module OneviewSDK
   module API300

--- a/lib/oneview-sdk/resource/api500/c7000/fc_network.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/fc_network.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api300/c7000/fc_network'
+require_relative 'scope'
 
 module OneviewSDK
   module API500

--- a/lib/oneview-sdk/resource/api500/synergy/fc_network.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/fc_network.rb
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 require_relative '../../api300/synergy/fc_network'
+require_relative 'scope'
 
 module OneviewSDK
   module API500

--- a/oneview-sdk.gemspec
+++ b/oneview-sdk.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = all_files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.2.6'
+
   spec.add_runtime_dependency 'thor'
   spec.add_runtime_dependency 'highline'
   spec.add_runtime_dependency 'pry'

--- a/oneview-sdk.gemspec
+++ b/oneview-sdk.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = all_files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2.6'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency 'thor'
   spec.add_runtime_dependency 'highline'


### PR DESCRIPTION
### Description
Adds Ruby missing imports

⚠️ This adds the missing gemspec requirement for minimum ruby supported (That was 2.2 since the start of the project). This way the gem will have the minimum ruby supported information in rubygems.org

### Issues Resolved
Fixes #263 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
