### PR TITLE
The StoragePool of API500 can't be retrieved by name and storageSystemUri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v5.0.4 (Unreleased)
+
+#### Bug fixes & Enhancements
+- [#269](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/269) The StoragePool of API500 can't be retrieved using retrieve! method by name and storageSystemUri
+
 ## v5.0.3
 
 #### Bug fixes & Enhancements

--- a/lib/oneview-sdk/resource/api500/c7000/storage_pool.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/storage_pool.rb
@@ -40,6 +40,29 @@ module OneviewSDK
           unavailable_method
         end
 
+        # Retrieve resource details based on this resource's name or URI.
+        # @note Name or URI must be specified inside the resource
+        # @return [Boolean] Whether or not retrieve was successful
+        def retrieve!
+          raise IncompleteResource, 'Must set resource name or uri before trying to retrieve!' unless @data['name'] || @data['uri']
+          if @data['name'] && @data['storageSystemUri']
+            results = self.class.find_by(@client, name: @data['name'], storageSystemUri: @data['storageSystemUri'])
+            if results.size == 1
+              set_all(results[0].data)
+              return true
+            end
+          end
+          super
+        end
+
+        # Check if a resource exists
+        # @note name or uri must be specified inside resource
+        # @return [Boolean] Whether or not resource exists
+        def exists?
+          temp = self.class.new(@client, data)
+          temp.retrieve!
+        end
+
         # Gets the storage pools that are connected on the specified networks based on the storage system port's expected network connectivity.
         # @param [OneviewSDK::Client] client The client object for the OneView appliance
         # @param [Array<Resource>] networks The list of networks with URI to be used as a filter

--- a/lib/oneview-sdk/resource/api500/c7000/storage_pool.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/storage_pool.rb
@@ -17,6 +17,7 @@ module OneviewSDK
       # Storage pool resource implementation for API500 C7000
       class StoragePool < OneviewSDK::API500::C7000::Resource
         BASE_URI = '/rest/storage-pools'.freeze
+        UNIQUE_IDENTIFIERS = %w(uri).freeze
 
         # Create a resource object, associate it with a client, and set its properties.
         # @param [OneviewSDK::Client] client The client object for the OneView appliance
@@ -44,15 +45,13 @@ module OneviewSDK
         # @note Name or URI must be specified inside the resource
         # @return [Boolean] Whether or not retrieve was successful
         def retrieve!
-          raise IncompleteResource, 'Must set resource name or uri before trying to retrieve!' unless @data['name'] || @data['uri']
-          if @data['name'] && @data['storageSystemUri']
-            results = self.class.find_by(@client, name: @data['name'], storageSystemUri: @data['storageSystemUri'])
-            if results.size == 1
-              set_all(results[0].data)
-              return true
-            end
+          return super if @data['uri']
+          results = self.class.find_by(@client, name: @data['name'], storageSystemUri: @data['storageSystemUri'])
+          if results.size == 1
+            set_all(results[0].data)
+            return true
           end
-          super
+          false
         end
 
         # Check if a resource exists

--- a/lib/oneview-sdk/resource/api500/c7000/storage_pool.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/storage_pool.rb
@@ -46,6 +46,9 @@ module OneviewSDK
         # @return [Boolean] Whether or not retrieve was successful
         def retrieve!
           return super if @data['uri']
+          unless @data['name'] && @data['storageSystemUri']
+            raise IncompleteResource, 'Must set resource name and storageSystemUri, or uri, before trying to retrieve!'
+          end
           results = self.class.find_by(@client, name: @data['name'], storageSystemUri: @data['storageSystemUri'])
           if results.size == 1
             set_all(results[0].data)

--- a/spec/integration/shared_examples/storage_pool/api500/create.rb
+++ b/spec/integration/shared_examples/storage_pool/api500/create.rb
@@ -45,4 +45,35 @@ RSpec.shared_examples 'StoragePoolCreateExample API500' do
       expect(described_class.reachable($client_500, [fc_network])).to be_empty
     end
   end
+
+  describe '#retrieve!' do
+    it 'should retrieve the storage_pool created by name and storageSystemUri' do
+      item_created = described_class.find_by($client_500, name: STORAGE_POOL_NAME).first
+      item_found = described_class.new($client_500, name: item_created['name'], storageSystemUri: item_created['storageSystemUri'])
+      expect(item_found.retrieve!).to eq(true)
+      expect(item_found['uri']).to eq(item_created['uri'])
+
+      item_found = described_class.new($client_500, name: 'Some wrong name', storageSystemUri: item_created['storageSystemUri'])
+      expect(item_found.retrieve!).to eq(false)
+      expect(item_found['uri']).not_to be
+
+      item_found = described_class.new($client_500, name: item_created['name'], storageSystemUri: '/other-uri/1')
+      expect(item_found.retrieve!).to eq(false)
+      expect(item_found['uri']).not_to be
+    end
+  end
+
+  describe '#exists?' do
+    it 'should verify if exists the storage_pool created by name and storageSystemUri' do
+      item_created = described_class.find_by($client_500, name: STORAGE_POOL_NAME).first
+      item_found = described_class.new($client_500, name: item_created['name'], storageSystemUri: item_created['storageSystemUri'])
+      expect(item_found.exists?).to eq(true)
+
+      item_found = described_class.new($client_500, name: 'Some wrong name', storageSystemUri: item_created['storageSystemUri'])
+      expect(item_found.exists?).to eq(false)
+
+      item_found = described_class.new($client_500, name: item_created['name'], storageSystemUri: '/other-uri/1')
+      expect(item_found.exists?).to eq(false)
+    end
+  end
 end

--- a/spec/unit/resource/api500/c7000/storage_pool_spec.rb
+++ b/spec/unit/resource/api500/c7000/storage_pool_spec.rb
@@ -88,4 +88,34 @@ RSpec.describe OneviewSDK::API500::C7000::StoragePool do
       expect(target['requestingRefresh']).to eq(true)
     end
   end
+
+  describe '#retrieve!' do
+    it 'should call super method if storageSystemUri is not set' do
+      target['name'] = 'StoragePool'
+      target['uri'] = '/fake/1'
+      expect(described_class).to receive(:find_by).with(@client_500, { 'name' => 'StoragePool' }, anything, anything).and_return([])
+      expect(described_class).to receive(:find_by).with(@client_500, { 'uri' => '/fake/1' }, anything, anything).and_return([])
+      target.retrieve!
+    end
+
+    it 'should find_by name and storageSystemUri when possible' do
+      target['name'] = 'StoragePool'
+      target['storageSystemUri'] = '/storage-system/1'
+      expect(described_class).to receive(:find_by)
+        .with(@client_500, name: 'StoragePool', storageSystemUri: '/storage-system/1')
+        .and_return([described_class.new(@client_500, name: 'StoragePool')])
+      expect(described_class).not_to receive(:find_by).with(@client_500, { 'name' => 'StoragePool' }, anything, anything)
+      expect(described_class).not_to receive(:find_by).with(@client_500, { 'uri' => '/fake/1' }, anything, anything)
+      expect(target.retrieve!).to eq(true)
+    end
+  end
+
+  describe '#exists?' do
+    it 'should call retrieve! method with copy of current resource' do
+      target['uri'] = 'fake/1'
+      expect_any_instance_of(described_class).to receive(:retrieve!)
+      expect(target).not_to receive(:retrieve!)
+      target.exists?
+    end
+  end
 end

--- a/spec/unit/resource/api500/c7000/storage_pool_spec.rb
+++ b/spec/unit/resource/api500/c7000/storage_pool_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe OneviewSDK::API500::C7000::StoragePool do
     expect(described_class::BASE_URI).to eq('/rest/storage-pools')
   end
 
+  it 'should have only uri into UNIQUE_IDENTIFIERS' do
+    expect(described_class::UNIQUE_IDENTIFIERS).to eq(['uri'])
+  end
+
   it '#create' do
     expect { target.create }.to raise_error(OneviewSDK::MethodUnavailable)
   end
@@ -90,15 +94,24 @@ RSpec.describe OneviewSDK::API500::C7000::StoragePool do
   end
 
   describe '#retrieve!' do
-    it 'should call super method if storageSystemUri is not set' do
-      target['name'] = 'StoragePool'
-      target['uri'] = '/fake/1'
-      expect(described_class).to receive(:find_by).with(@client_500, { 'name' => 'StoragePool' }, anything, anything).and_return([])
-      expect(described_class).to receive(:find_by).with(@client_500, { 'uri' => '/fake/1' }, anything, anything).and_return([])
-      target.retrieve!
+    context 'should call super method' do
+      before do
+        target['uri'] = '/fake/1'
+        expect(described_class).to receive(:find_by).with(@client_500, { 'uri' => '/fake/1' }, anything, anything).and_return([])
+      end
+
+      it 'when name is set but storageSystemUri is not set' do
+        target['name'] = 'StoragePool'
+        target.retrieve!
+      end
+
+      it 'when storageSystemUri is set but name is not set' do
+        target['storageSystemUri'] = '/fake/storage-system/1'
+        target.retrieve!
+      end
     end
 
-    it 'should find_by name and storageSystemUri when possible' do
+    it 'should find_by name and storageSystemUri when uri is not set' do
       target['name'] = 'StoragePool'
       target['storageSystemUri'] = '/storage-system/1'
       expect(described_class).to receive(:find_by)

--- a/spec/unit/resource/api500/c7000/storage_pool_spec.rb
+++ b/spec/unit/resource/api500/c7000/storage_pool_spec.rb
@@ -94,21 +94,12 @@ RSpec.describe OneviewSDK::API500::C7000::StoragePool do
   end
 
   describe '#retrieve!' do
-    context 'should call super method' do
-      before do
-        target['uri'] = '/fake/1'
-        expect(described_class).to receive(:find_by).with(@client_500, { 'uri' => '/fake/1' }, anything, anything).and_return([])
-      end
-
-      it 'when name is set but storageSystemUri is not set' do
-        target['name'] = 'StoragePool'
-        target.retrieve!
-      end
-
-      it 'when storageSystemUri is set but name is not set' do
-        target['storageSystemUri'] = '/fake/storage-system/1'
-        target.retrieve!
-      end
+    it 'should call super method when uri is set' do
+      target['uri'] = '/fake/1'
+      target['name'] = 'StoragePool'
+      target['storageSystemUri'] = '/fake/storage-system/1'
+      expect(described_class).to receive(:find_by).with(@client_500, { 'uri' => '/fake/1' }, anything, anything).and_return([])
+      target.retrieve!
     end
 
     it 'should find_by name and storageSystemUri when uri is not set' do
@@ -120,6 +111,10 @@ RSpec.describe OneviewSDK::API500::C7000::StoragePool do
       expect(described_class).not_to receive(:find_by).with(@client_500, { 'name' => 'StoragePool' }, anything, anything)
       expect(described_class).not_to receive(:find_by).with(@client_500, { 'uri' => '/fake/1' }, anything, anything)
       expect(target.retrieve!).to eq(true)
+    end
+
+    it 'throw error when name and storageSystemUri, or uri, are not set' do
+      expect { target.retrieve! } .to raise_error(OneviewSDK::IncompleteResource, /Must set resource name and storageSystemUri, or uri, before/)
     end
   end
 


### PR DESCRIPTION
### Description
`retrieve!` method was overwrote into Storage Pool API500.

### Issues Resolved
Fixes #269 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
