### PR TITLE
Changing the 'add' method in Volume API500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v6.0.0(unreleased)
+
+#### Breaking changes:
+- [#275](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/275) Method 'add' in Volume API 500 expects different arguments from usual 'add' implementations
+
 ## v5.0.5
 
 #### Bug fixes & Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v6.0.0(unreleased)
+# v6.0.0
 
 #### Breaking changes:
 - [#275](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/275) Method 'add' in Volume API 500 expects different arguments from usual 'add' implementations

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The OneView SDK provides a Ruby library to easily interact with HPE OneView and 
 - Require the gem in your Gemfile:
 
   ```ruby
-  gem 'oneview-sdk', '~> 5.0'
+  gem 'oneview-sdk', '~> 6.0'
   ```
 
   Then run `$ bundle install`

--- a/examples/api500/volume.rb
+++ b/examples/api500/volume.rb
@@ -123,10 +123,14 @@ puts "\nAdding a unmanaged volume..."
 
 options5 = {
   'name' => 'ONEVIEW_SDK_TEST_VOLUME_5',
-  'description' => 'adding a volume'
+  'description' => 'Volume added',
+  'deviceVolumeName' => device_volume,
+  'isShareable' => false,
+  'storageSystemUri' => storage_system['uri']
 }
 
-item5 = volume_class.add(@client, storage_system, device_volume, false, options5)
+item5 = volume_class.new(@client, options5)
+item5.add
 puts "\nVolume added successfully! \nName: #{item5['name']} \nURI: #{item5['uri']}"
 
 puts "\nCreating a volume from Storage Virtual..."

--- a/examples/api500/volume.rb
+++ b/examples/api500/volume.rb
@@ -122,11 +122,11 @@ puts "\nVolume removed successfully!"
 puts "\nAdding a unmanaged volume..."
 
 options5 = {
-  'name' => 'ONEVIEW_SDK_TEST_VOLUME_5',
-  'description' => 'Volume added',
-  'deviceVolumeName' => device_volume,
-  'isShareable' => false,
-  'storageSystemUri' => storage_system['uri']
+  name: 'ONEVIEW_SDK_TEST_VOLUME_5',
+  description: 'Volume added',
+  deviceVolumeName: device_volume,
+  isShareable: false,
+  storageSystemUri: storage_system['uri']
 }
 
 item5 = volume_class.new(@client, options5)

--- a/lib/oneview-sdk/resource/api500/c7000/volume.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/volume.rb
@@ -116,7 +116,7 @@ module OneviewSDK
         def add
           ensure_client
           required_attributes = %w(deviceVolumeName isShareable storageSystemUri)
-          required_attributes.each { |k| raise IncompleteResource, "Missing required attribute: '#{k}'" unless @data.key?(k) }
+          required_attributes.each { |k| raise IncompleteResource, "Missing required attribute: '#{k}'" unless @data.key?(k) || @data.key?(k.to_sym) }
           @data['name'] ||= @data['deviceVolumeName']
           response = @client.rest_post("#{BASE_URI}/from-existing", { 'body' => @data }, @api_version)
           set_all(client.response_handler(response))

--- a/lib/oneview-sdk/resource/api500/c7000/volume.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/volume.rb
@@ -111,20 +111,16 @@ module OneviewSDK
 
         # Initiates a process to import a volume (created external to OneView) for management by the appliance.
         # @note Volumes can be added only on the storage system and storage pools managed by the appliance.
-        # @param [OneviewSDK::Client] client The client object for the OneView appliance.
-        # @param [OneviewSDK::StorageSystem] storage_system The storage system in which the volume exists to be managed.
-        # @param [String] volume_name The name of the volume on the actual storage system.
-        # @param [Boolean] is_shareable Describes if the volume is shareable or private.
-        # @param [Hash] options The options to create a volume.
-        # @option options [String] :name The name for new volume.
-        # @option options [String] :description The description for new volume.
-        # @raise [OneviewSDK::IncompleteResource] if storage system is not found
+        # @raise [OneviewSDK::IncompleteResource] if the client is not set or required attributes are missing
         # @return [OneviewSDK::Volume] The volume imported.
-        def self.add(client, storage_system, volume_name, is_shareable = false, options = {})
-          raise IncompleteResource, 'Storage system not found!' unless storage_system.retrieve!
-          data = options.merge('storageSystemUri' => storage_system['uri'], 'deviceVolumeName' => volume_name, 'isShareable' => is_shareable)
-          response = client.rest_post("#{BASE_URI}/from-existing", { 'body' => data }, client.api_version)
-          new(client, client.response_handler(response))
+        def add
+          ensure_client
+          required_attributes = %w(deviceVolumeName isShareable storageSystemUri)
+          required_attributes.each { |k| raise IncompleteResource, "Missing required attribute: '#{k}'" unless @data.key?(k) }
+          @data['name'] ||= @data['deviceVolumeName']
+          response = @client.rest_post("#{BASE_URI}/from-existing", { 'body' => @data }, @api_version)
+          set_all(client.response_handler(response))
+          self
         end
 
         # Retrieve resource details based on this resource's name or URI.

--- a/lib/oneview-sdk/version.rb
+++ b/lib/oneview-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module OneviewSDK
-  VERSION = '5.0.5'.freeze
+  VERSION = '6.0.0'.freeze
 end

--- a/spec/unit/resource/api500/c7000/volume_spec.rb
+++ b/spec/unit/resource/api500/c7000/volume_spec.rb
@@ -193,6 +193,12 @@ RSpec.describe OneviewSDK::API500::C7000::Volume do
       expect { item.add }.to raise_error(/Missing required attribute: 'isShareable'/)
     end
 
+    it 'raises an exception when some attribute is missing and passed as symbol' do
+      item = described_class.new(@client_500, storageSystemUri: '/rest/storage-system/1', isShareable: false)
+      item.data = { storageSystemUri: '/rest/storage-system/1', isShareable: false }
+      expect { item.add }.to raise_error(/Missing required attribute: 'deviceVolumeName'/)
+    end
+
     it 'adding a volume' do
       data = {
         'name' => 'Volume1',

--- a/spec/unit/resource/api500/c7000/volume_spec.rb
+++ b/spec/unit/resource/api500/c7000/volume_spec.rb
@@ -171,49 +171,68 @@ RSpec.describe OneviewSDK::API500::C7000::Volume do
     end
   end
 
-  describe '#self.add' do
+  describe '#add' do
     before :each do
       @storage_system_class = OneviewSDK::API500::C7000::StorageSystem
       @storage_system = @storage_system_class.new(@client_500, uri: '/rest/storage-system/fake')
+      @device_volume_name = 'External Volume'
     end
 
-    it 'raises an exception when storage system not found' do
-      allow_any_instance_of(@storage_system_class).to receive(:retrieve!).and_return(false)
-      expect { described_class.add(@client_500, @storage_system, 'volume') }.to raise_error(/Storage system not found/)
+    it 'raises an exception when deviceVolumeName is missing' do
+      item = described_class.new(@client_500, storageSystemUri: '/rest/storage-system/1', isShareable: false)
+      expect { item.add }.to raise_error(/Missing required attribute: 'deviceVolumeName'/)
+    end
+
+    it 'raises an exception when storageSystemUri is missing' do
+      item = described_class.new(@client_500, deviceVolumeName: 'Anything', isShareable: false)
+      expect { item.add }.to raise_error(/Missing required attribute: 'storageSystemUri'/)
+    end
+
+    it 'raises an exception when isShareable is missing' do
+      item = described_class.new(@client_500, deviceVolumeName: 'Anything', storageSystemUri: '/rest/storage-system/1')
+      expect { item.add }.to raise_error(/Missing required attribute: 'isShareable'/)
     end
 
     it 'adding a volume' do
-      allow_any_instance_of(@storage_system_class).to receive(:retrieve!).and_return(true)
       data = {
-        'storageSystemUri' => @storage_system['uri'],
-        'deviceVolumeName' => 'volume',
-        'isShareable' => false
+        'name' => 'Volume1',
+        'description' => 'Volume added',
+        'deviceVolumeName' => @device_volume_name,
+        'isShareable' => false,
+        'storageSystemUri' => @storage_system['uri']
       }
 
-      allow_any_instance_of(OneviewSDK::Client).to receive(:rest_post)
+      expect(@client_500).to receive(:rest_post)
         .with("#{described_class::BASE_URI}/from-existing", { 'body' => data }, 500).and_return(fake_response)
-      expect(@client_500).to receive(:response_handler).with(fake_response).and_return('uri' => '/rest/fake2')
-      volume = described_class.add(@client_500, @storage_system, 'volume')
-      expect(volume['uri']).to eq('/rest/fake2')
+      expect(@client_500).to receive(:response_handler).with(fake_response).and_return(data.merge('uri' => '/rest/fake2'))
+
+      item = described_class.new(@client_500, data)
+      expect { item.add }.to_not raise_error
+      expect(item['uri']).to eq('/rest/fake2')
+      expect(item['name']).to eq('Volume1')
+      expect(item['deviceVolumeName']).to eq(@device_volume_name)
+      expect(item['storageSystemUri']).to eq(@storage_system['uri'])
     end
 
-    it 'adding a volume with options' do
-      allow_any_instance_of(@storage_system_class).to receive(:retrieve!).and_return(true)
+    it 'adding a volume without name attribute' do
       data = {
-        'storageSystemUri' => @storage_system['uri'],
-        'deviceVolumeName' => 'volume',
+        'description' => 'Volume added',
+        'deviceVolumeName' => @device_volume_name,
         'isShareable' => false,
-        'name' => 'Volume1',
-        'description' => 'volume test'
+        'storageSystemUri' => @storage_system['uri']
       }
 
-      allow_any_instance_of(OneviewSDK::Client).to receive(:rest_post)
-        .with("#{described_class::BASE_URI}/from-existing", { 'body' => data }, 500).and_return(fake_response)
-      expect(@client_500).to receive(:response_handler).with(fake_response).and_return('uri' => '/rest/fake2')
+      expect(@client_500).to receive(:rest_post)
+        .with("#{described_class::BASE_URI}/from-existing", { 'body' => data.merge('name' => @device_volume_name) }, 500)
+        .and_return(fake_response)
+      expect(@client_500).to receive(:response_handler).with(fake_response).and_return(data.merge('uri' => '/rest/fake2'))
 
-      options = { 'name' => 'Volume1', 'description' => 'volume test' }
-      volume = described_class.add(@client_500, @storage_system, 'volume', false, options)
-      expect(volume['uri']).to eq('/rest/fake2')
+      item = described_class.new(@client_500, data)
+      expect { item.add }.to_not raise_error
+      expect(item['uri']).to eq('/rest/fake2')
+      expect(item['name']).to eq(@device_volume_name)
+      expect(item['deviceVolumeName']).to eq(@device_volume_name)
+      expect(item['storageSystemUri']).to eq(@storage_system['uri'])
     end
   end
 


### PR DESCRIPTION
### Description
Currently, the add method in Volume is necessary to pass some parameters. The add method was modified for  standard way to use the add method in the Ruby SDK using the hash data.

### Issues Resolved
#275 

### Check List
- [] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
