### PR TITLE
Revert the removal of the 'self.add' in the Volume API 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# v6.0.0
+# v5.1.0
 
-#### Breaking changes:
-- [#275](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/275) Method 'add' in Volume API 500 expects different arguments from usual 'add' implementations
+#### Bug fixes & Enhancements
+1. The method `self.add` in the Volumes API 500 was deprecated, use the `add` method instead.
+  - [#275](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/275) Method 'add' in Volume API 500 expects different arguments from usual 'add' implementations
 
 ## v5.0.5
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The OneView SDK provides a Ruby library to easily interact with HPE OneView and 
 - Require the gem in your Gemfile:
 
   ```ruby
-  gem 'oneview-sdk', '~> 6.0'
+  gem 'oneview-sdk', '~> 5.1'
   ```
 
   Then run `$ bundle install`

--- a/lib/oneview-sdk/resource/api500/c7000/volume.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/volume.rb
@@ -111,6 +111,25 @@ module OneviewSDK
 
         # Initiates a process to import a volume (created external to OneView) for management by the appliance.
         # @note Volumes can be added only on the storage system and storage pools managed by the appliance.
+        # @param [OneviewSDK::Client] client The client object for the OneView appliance.
+        # @param [OneviewSDK::StorageSystem] storage_system The storage system in which the volume exists to be managed.
+        # @param [String] volume_name The name of the volume on the actual storage system.
+        # @param [Boolean] is_shareable Describes if the volume is shareable or private.
+        # @param [Hash] options The options to create a volume.
+        # @option options [String] :name The name for new volume.
+        # @option options [String] :description The description for new volume.
+        # @raise [OneviewSDK::IncompleteResource] if storage system is not found
+        # @return [OneviewSDK::Volume] The volume imported.
+        # @deprecated Use {#add} instead.
+        def self.add(client, storage_system, volume_name, is_shareable = false, options = {})
+          raise IncompleteResource, 'Storage system not found!' unless storage_system.retrieve!
+          data = options.merge('storageSystemUri' => storage_system['uri'], 'deviceVolumeName' => volume_name, 'isShareable' => is_shareable)
+          response = client.rest_post("#{BASE_URI}/from-existing", { 'body' => data }, client.api_version)
+          new(client, client.response_handler(response))
+        end
+
+        # Initiates a process to import a volume (created external to OneView) for management by the appliance.
+        # @note Volumes can be added only on the storage system and storage pools managed by the appliance.
         # @raise [OneviewSDK::IncompleteResource] if the client is not set or required attributes are missing
         # @return [OneviewSDK::Volume] The volume imported.
         def add

--- a/lib/oneview-sdk/version.rb
+++ b/lib/oneview-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module OneviewSDK
-  VERSION = '6.0.0'.freeze
+  VERSION = '5.1.0'.freeze
 end

--- a/spec/integration/shared_examples/volume/api500/create.rb
+++ b/spec/integration/shared_examples/volume/api500/create.rb
@@ -157,6 +157,33 @@ RSpec.shared_examples 'VolumeCreateExample API500' do |context_name|
     end
   end
 
+  describe '#self.add' do
+    it 'raises an exception when storage system not found' do
+      storage = storage_system_class.new(current_client, name: 'Any')
+      expect { described_class.add(current_client, storage, 'any') }.to raise_error(/Storage system not found/)
+    end
+
+    it 'adding a volume' do
+      item = described_class.new(current_client, properties: options_store_serv.merge(name: VOLUME5_NAME))
+      item.set_storage_pool(storage_pool)
+      item.set_snapshot_pool(storage_pool)
+      item.create
+      device_volume = item['deviceVolumeName']
+      expect { item.delete(:oneview) }.to_not raise_error
+
+      volume = nil
+      options = {
+        'name' => VOLUME5_NAME,
+        'description' => 'adding a volume'
+      }
+      expect { volume = described_class.add(current_client, storage_system, device_volume, false, options) }.to_not raise_error
+      expect(volume.retrieve!).to eq(true)
+      expect(volume['name']).to eq(VOLUME5_NAME)
+      expect(volume['isShareable']).to eq(false)
+      expect(volume['deviceVolumeName']).to eq(device_volume)
+    end
+  end
+
   describe '#add' do
     it 'raises an exception when deviceVolumeName is missing' do
       item = described_class.new(current_client, storageSystemUri: '/rest/storage-system/1', isShareable: false)
@@ -175,9 +202,7 @@ RSpec.shared_examples 'VolumeCreateExample API500' do |context_name|
 
     it 'adding a volume' do
       item = described_class.new(current_client, properties: options_store_serv.merge(name: VOLUME5_NAME))
-      item.set_storage_pool(storage_pool)
-      item.set_snapshot_pool(storage_pool)
-      item.create
+      expect(item.retrieve!).to eq(true)
       device_volume = item['deviceVolumeName']
       expect { item.delete(:oneview) }.to_not raise_error
 


### PR DESCRIPTION
### Description
Revert the removal of the ```self.add``` in the Volume API 500. The ```self.add``` was deprecated in favor of the ```add``` method.

### Issues Resolved
#276 
#277 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
