### PR TITLE
adds method to apply endpoint PUT /configuration that was missing of the Interconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## v5.2.0 (Unreleased)
 
-#### New features
-- [#290](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/290) Adding update ports for Switch API 300
+#### New Features:
+- [#287](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/287) Missing method to apply/reapply configuration to Interconnect of API500
+- [#290](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/290) Missing update ports method for Switch on API 300
 
 ## v5.1.2
 #### Notes

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -182,7 +182,7 @@ OneviewSDK::Datacenter.find_by(@client, width: 11000).map(&:remove)
 |<sub>/rest/interconnects</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/interconnects/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/interconnects/{id}</sub>                                                      | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/configuration</sub>                                        | PUT      | :heavy_minus_sign:   | :heavy_minus_sign:   |    |
+|<sub>/rest/interconnects/{id}/configuration</sub>                                        | PUT      | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   |
 |<sub>/rest/interconnects/{id}/pluggableModuleInformation</sub>                           | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   |
 |<sub>/rest/interconnects/{id}/ports</sub>                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/interconnects/{id}/ports</sub>                                                | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/shared_samples/interconnect.rb
+++ b/examples/shared_samples/interconnect.rb
@@ -111,3 +111,13 @@ begin
 rescue NoMethodError
   puts 'The method #get_pluggable_module_information is available only for api greater than or equal to 500.'
 end
+
+# Applies or re-applies the current interconnect configuration.
+# This method 'configuration' was added from api version 500.
+begin
+  puts "\nApplying the configuration to interconnect #{item['uri']}."
+  item.configuration
+  puts "\nThe action was executed successfully"
+rescue NoMethodError
+  puts 'The method #configuration is available only for api greater than or equal to 500.'
+end

--- a/examples/shared_samples/interconnect.rb
+++ b/examples/shared_samples/interconnect.rb
@@ -112,12 +112,12 @@ rescue NoMethodError
   puts 'The method #get_pluggable_module_information is available only for api greater than or equal to 500.'
 end
 
-# Applies or re-applies the current interconnect configuration.
-# This method 'configuration' was added from api version 500.
+# Applies or reapplies the current interconnect configuration.
+# This method 'configuration' was added in API version 500.
 begin
   puts "\nApplying the configuration to interconnect #{item['uri']}."
   item.configuration
   puts "\nThe action was executed successfully"
 rescue NoMethodError
-  puts 'The method #configuration is available only for api greater than or equal to 500.'
+  puts 'The method #configuration is available only for API version greater than or equal to 500.'
 end

--- a/lib/oneview-sdk/resource/api200/enclosure.rb
+++ b/lib/oneview-sdk/resource/api200/enclosure.rb
@@ -12,11 +12,14 @@
 require 'time'
 require 'date'
 require_relative 'resource'
+require_relative '../../resource_helper'
 
 module OneviewSDK
   module API200
     # Enclosure resource implementation
     class Enclosure < Resource
+      include OneviewSDK::ResourceHelper::ConfigurationOperation
+
       BASE_URI = '/rest/enclosures'.freeze
       UNIQUE_IDENTIFIERS = %w(name uri serialNumber activeOaPreferredIP standbyOaPreferredIP).freeze
 
@@ -82,15 +85,6 @@ module OneviewSDK
         end
         self
       end
-
-      # Reapplies the enclosure configuration
-      def configuration
-        ensure_client && ensure_uri
-        response = @client.rest_put(@data['uri'] + '/configuration', {}, @api_version)
-        new_data = @client.response_handler(response)
-        set_all(new_data)
-      end
-
 
       # Refreshes the enclosure along with all of its components
       # @param [String] state NotRefreshing, RefreshFailed, RefreshPending, Refreshing

--- a/lib/oneview-sdk/resource/api200/logical_interconnect.rb
+++ b/lib/oneview-sdk/resource/api200/logical_interconnect.rb
@@ -10,11 +10,14 @@
 # language governing permissions and limitations under the License.
 
 require_relative 'resource'
+require_relative '../../resource_helper'
 
 module OneviewSDK
   module API200
     # Logical interconnect resource implementation
     class LogicalInterconnect < Resource
+      include OneviewSDK::ResourceHelper::ConfigurationOperation
+
       BASE_URI = '/rest/logical-interconnects'.freeze
       LOCATION_URI = '/rest/logical-interconnects/locations/interconnects'.freeze
 
@@ -131,15 +134,6 @@ module OneviewSDK
       def compliance
         ensure_client && ensure_uri
         response = @client.rest_put(@data['uri'] + '/compliance', {}, @api_version)
-        body = client.response_handler(response)
-        set_all(body)
-      end
-
-      # Asynchronously applies or re-applies the logical interconnect configuration to all managed interconnects
-      # @return returns the updated object
-      def configuration
-        ensure_client && ensure_uri
-        response = @client.rest_put(@data['uri'] + '/configuration', {}, @api_version)
         body = client.response_handler(response)
         set_all(body)
       end

--- a/lib/oneview-sdk/resource/api200/server_profile.rb
+++ b/lib/oneview-sdk/resource/api200/server_profile.rb
@@ -16,7 +16,7 @@ module OneviewSDK
   module API200
     # Server profile resource implementation
     class ServerProfile < Resource
-      include OneviewSDK::ResourceHelper
+      include OneviewSDK::ResourceHelper::PatchOperation
       BASE_URI = '/rest/server-profiles'.freeze
       UNIQUE_IDENTIFIERS = %w(name uri associatedServer serialNumber serverHardwareUri).freeze
 

--- a/lib/oneview-sdk/resource/api300/c7000/logical_enclosure.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/logical_enclosure.rb
@@ -17,7 +17,7 @@ module OneviewSDK
     module C7000
       # Logical Enclosure resource implementation on API300 C7000
       class LogicalEnclosure < OneviewSDK::API200::LogicalEnclosure
-        include OneviewSDK::ResourceHelper
+        include OneviewSDK::ResourceHelper::PatchOperation
 
         def initialize(client, params = {}, api_ver = nil)
           super

--- a/lib/oneview-sdk/resource/api300/synergy/sas_logical_interconnect.rb
+++ b/lib/oneview-sdk/resource/api300/synergy/sas_logical_interconnect.rb
@@ -16,6 +16,8 @@ module OneviewSDK
     module Synergy
       # SAS logical interconnect resource implementation
       class SASLogicalInterconnect < Resource
+        include OneviewSDK::ResourceHelper::ConfigurationOperation
+
         BASE_URI = '/rest/sas-logical-interconnects'.freeze
 
         # Create a resource object, associate it with a client, and set its properties.
@@ -94,15 +96,6 @@ module OneviewSDK
           }
           response = @client.rest_post(@data['uri'] + '/replaceDriveEnclosure', update_json)
           @client.response_handler(response)
-        end
-
-        # Asynchronously applies or re-applies the SAS logical interconnect configuration to all managed interconnects
-        # @return returns the updated object
-        def configuration
-          ensure_client && ensure_uri
-          response = @client.rest_put(@data['uri'] + '/configuration', {}, @api_version)
-          body = client.response_handler(response)
-          set_all(body)
         end
       end
     end

--- a/lib/oneview-sdk/resource/api500/c7000/interconnect.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/interconnect.rb
@@ -16,6 +16,7 @@ module OneviewSDK
     module C7000
       # Interconnect resource implementation on API500 C7000
       class Interconnect < OneviewSDK::API300::C7000::Interconnect
+        include OneviewSDK::ResourceHelper::ConfigurationOperation
 
         # Gets all the Small Form-factor Pluggable (SFP) instances from an interconnect.
         # @return [Hash] hash The Small Form-factor Pluggable (SFP) instances of the interconnect

--- a/lib/oneview-sdk/resource/api500/c7000/logical_enclosure.rb
+++ b/lib/oneview-sdk/resource/api500/c7000/logical_enclosure.rb
@@ -17,7 +17,7 @@ module OneviewSDK
     module C7000
       # Contains helper methods to include operation with firmware of a given logical enclosure resource
       module FirmwareHelper
-        include ResourceHelper
+        include ResourceHelper::PatchOperation
 
         # Updates  the firmware attributes of a given logical enclosure resource
         # @param [Hash] attributes Hash with firmware attributes

--- a/lib/oneview-sdk/resource_helper.rb
+++ b/lib/oneview-sdk/resource_helper.rb
@@ -12,19 +12,33 @@
 module OneviewSDK
   # Contains helper methods to include certain functionalities on resources
   module ResourceHelper
-    # Performs a specific patch operation for the given resource.
-    # If the resource supports the particular operation, the operation is performed
-    # and a response is returned to the caller with the results.
-    # @param [String] operation The operation to be performed
-    # @param [String] path The path of operation
-    # @param [String] value The value
-    # @note This attribute is subject to incompatible changes in future release versions, including redefinition or removal.
-    def patch(operation, path, value = nil, header_options = {})
-      ensure_client && ensure_uri
-      options = { 'body' => [op: operation, path: path, value: value] }
-      options = options.merge(header_options)
-      response = @client.rest_patch(@data['uri'], options, @api_version)
-      @client.response_handler(response)
+    # Contains helper method to call patch endpoint of resource
+    module PatchOperation
+      # Performs a specific patch operation for the given resource.
+      # If the resource supports the particular operation, the operation is performed
+      # and a response is returned to the caller with the results.
+      # @param [String] operation The operation to be performed
+      # @param [String] path The path of operation
+      # @param [String] value The value
+      # @note This attribute is subject to incompatible changes in future release versions, including redefinition or removal.
+      def patch(operation, path, value = nil, header_options = {})
+        ensure_client && ensure_uri
+        options = { 'body' => [op: operation, path: path, value: value] }
+        options = options.merge(header_options)
+        response = @client.rest_patch(@data['uri'], options, @api_version)
+        @client.response_handler(response)
+      end
+    end
+
+    # Contains helper method to call configuration endpoint of resource
+    module ConfigurationOperation
+      # Reapplies the configuration
+      def configuration
+        ensure_client && ensure_uri
+        response = @client.rest_put(@data['uri'] + '/configuration', {}, @api_version)
+        new_data = @client.response_handler(response)
+        set_all(new_data)
+      end
     end
   end
 end

--- a/spec/integration/shared_examples/interconnect/update.rb
+++ b/spec/integration/shared_examples/interconnect/update.rb
@@ -54,6 +54,12 @@ RSpec.shared_examples 'InterconnectUpdateExample' do |context_name|
     end
   end
 
+  describe '#configuration' do
+    it 'applies or re-applies the current interconnect configuration.' do
+      expect { item.configuration }.not_to raise_error
+    end
+  end
+
   describe '#patch' do
     xit 'update a given interconnect across a patch (Skipping this test due to the lack of type of interconnection that supports this operation)' do
       expect { item.patch('replace', '/uidState', 'Off') }.not_to raise_error

--- a/spec/unit/resource_helper_spec.rb
+++ b/spec/unit/resource_helper_spec.rb
@@ -4,11 +4,14 @@ require_relative './../spec_helper'
 RSpec.describe OneviewSDK::ResourceHelper do
   include_context 'shared context'
   class SomeIncluder < OneviewSDK::Resource
-    include OneviewSDK::ResourceHelper
+    include OneviewSDK::ResourceHelper::PatchOperation
+  end
+
+  class SomeIncluderConfigurationOperation < OneviewSDK::Resource
+    include OneviewSDK::ResourceHelper::ConfigurationOperation
   end
 
   subject(:klass) { SomeIncluder.new(@client_200) }
-
 
   describe '#patch' do
     it 'requires a uri' do
@@ -25,6 +28,22 @@ RSpec.describe OneviewSDK::ResourceHelper do
       expect(@client_200).to receive(:rest_patch).with(item['uri'], options, item.api_version).and_return(FakeResponse.new)
       allow_any_instance_of(SomeIncluder).to receive(:retrieve!).and_return(true)
       item.patch('replace', '/path', 'val', 'If-Match' => item['eTag'])
+    end
+  end
+
+  describe '#configuration' do
+    it 'requires a uri' do
+      item = SomeIncluderConfigurationOperation.new(@client_200)
+      expect { item.configuration }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri/)
+    end
+
+    it 'applying configuration' do
+      item = SomeIncluderConfigurationOperation.new(@client_200, uri: '/rest/fake/1')
+      allow_any_instance_of(SomeIncluderConfigurationOperation).to receive(:retrieve!).and_return(true)
+      allow(@client_200).to receive(:response_handler)
+      expect(@client_200).to receive(:rest_put).with('/rest/fake/1/configuration', {}, item.api_version).and_return(FakeResponse.new)
+      expect(item).to receive(:set_all)
+      item.configuration
     end
   end
 end


### PR DESCRIPTION
### Description
Added a configuration method to Interconnect resource of API500.
- The "configuration" method is present in other resources, so it was created a new Module to be included where is needed use that method;
- It was moved the patch method to a new Module inside ResourceHelper, for organize the code because a new Module for configuration method was added too.

### Issues Resolved
Fixes #287 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
