### PR TITLE
Adding the endpoint update-ports in switch resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v5.2.0 (Unreleased)
 
-#### Bug fixes & Enhancements
+#### New features
 - [#290](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/290) Adding update ports for Switch API 300
 
 ## v5.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v5.2.0 (Unreleased)
+
+#### Bug fixes & Enhancements
+- [#290](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/290) Adding update ports for Switch API 300
+
 ## v5.1.2
 #### Notes
 This release adds the [endpoints-support.md](endpoints-support.md) file to the repository, in order to track implemented endpoints and what is in the scope of this SDK.
@@ -12,7 +17,7 @@ Also adds the [TESTING.md](TESTING.md) file to the repository, in order to guide
 #### Bug fixes & Enhancements
 - [#279](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/279) Bug when setting the Storage Pool and Snapshot Pool when trying to make an update
 
-# v5.1.0
+## v5.1.0
 
 #### Bug fixes & Enhancements
 1. The method `self.add` in the Volumes API 500 was deprecated, use the `add` method instead.

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -472,7 +472,7 @@ OneviewSDK::Datacenter.find_by(@client, width: 11000).map(&:remove)
 |<sub>/rest/switches/{id}/environmentalConfiguration</sub>                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/switches/{id}/statistics</sub>                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/switches/{id}/statistics/{portName:.+}</sub>                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switches/{id}/update-ports</sub>                                              | PUT      | :heavy_minus_sign:   |    |    |
+|<sub>/rest/switches/{id}/update-ports</sub>                                              | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |     **Switch Type**                                                                                                                              |
 |<sub>/rest/switch-types</sub>                                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/switch-types/{id}</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/lib/oneview-sdk/resource/api300/c7000/switch.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/switch.rb
@@ -32,7 +32,7 @@ module OneviewSDK
         # @param [Hash] attributes hash with attributes and values to be changed
         def update_port(portName, attributes)
           ensure_uri
-          port = @data['ports'].select { |p| p['portName'] == portName }.first
+          port = @data['ports'].find { |p| p['portName'] == portName }
           attributes.each { |key, value| port[key.to_s] = value }
           response = @client.rest_put(@data['uri'] + '/update-ports', 'body' => [port])
           @client.response_handler(response)

--- a/lib/oneview-sdk/resource/api300/c7000/switch.rb
+++ b/lib/oneview-sdk/resource/api300/c7000/switch.rb
@@ -25,6 +25,18 @@ module OneviewSDK
         def set_scope_uris(scope_uris)
           patch('replace', '/scopeUris', scope_uris)
         end
+
+        # Updates the switch ports
+        # @note Only the ports under the management of OneView and those that are unlinked are supported for update
+        # @param [String] portName port name
+        # @param [Hash] attributes hash with attributes and values to be changed
+        def update_port(portName, attributes)
+          ensure_uri
+          port = @data['ports'].select { |p| p['portName'] == portName }.first
+          attributes.each { |key, value| port[key.to_s] = value }
+          response = @client.rest_put(@data['uri'] + '/update-ports', 'body' => [port])
+          @client.response_handler(response)
+        end
       end
     end
   end

--- a/spec/integration/resource/api300/c7000/switch/update_spec.rb
+++ b/spec/integration/resource/api300/c7000/switch/update_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 klass = OneviewSDK::API300::C7000::Switch
 RSpec.describe klass, integration: true, type: UPDATE do
   let(:current_client) { $client_300 }
-  include_examples 'SwitchUpdateExample', 'integration api300 context'
   include_examples 'SwitchUpdateExample  API300', 'integration api300 context'
 
   describe '#set_scope_uris' do

--- a/spec/integration/resource/api300/c7000/switch/update_spec.rb
+++ b/spec/integration/resource/api300/c7000/switch/update_spec.rb
@@ -4,6 +4,7 @@ klass = OneviewSDK::API300::C7000::Switch
 RSpec.describe klass, integration: true, type: UPDATE do
   let(:current_client) { $client_300 }
   include_examples 'SwitchUpdateExample', 'integration api300 context'
+  include_examples 'SwitchUpdateExample  API300', 'integration api300 context'
 
   describe '#set_scope_uris' do
     it 'replaces the switch scopeUris' do

--- a/spec/integration/resource/api500/c7000/switch/update_spec.rb
+++ b/spec/integration/resource/api500/c7000/switch/update_spec.rb
@@ -14,7 +14,6 @@ require 'spec_helper'
 klass = OneviewSDK::API500::C7000::Switch
 RSpec.describe klass, integration: true, type: UPDATE do
   let(:current_client) { $client_500 }
-  include_examples 'SwitchUpdateExample', 'integration api500 context'
   include_examples 'SwitchUpdateExample  API300', 'integration api500 context'
 
   describe '#set_scope_uris' do

--- a/spec/integration/resource/api500/c7000/switch/update_spec.rb
+++ b/spec/integration/resource/api500/c7000/switch/update_spec.rb
@@ -15,6 +15,7 @@ klass = OneviewSDK::API500::C7000::Switch
 RSpec.describe klass, integration: true, type: UPDATE do
   let(:current_client) { $client_500 }
   include_examples 'SwitchUpdateExample', 'integration api500 context'
+  include_examples 'SwitchUpdateExample  API300', 'integration api500 context'
 
   describe '#set_scope_uris' do
     it 'is unavailable' do

--- a/spec/integration/shared_examples/switch/api300/update.rb
+++ b/spec/integration/shared_examples/switch/api300/update.rb
@@ -1,0 +1,37 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+RSpec.shared_examples 'SwitchUpdateExample  API300' do |context_name|
+  include_context context_name
+  let(:switch) do
+    described_class.get_all(current_client).find do |resource|
+      !resource['ports'].select { |k| k['portStatus'] == 'Unlinked' }.empty?
+    end
+  end
+
+  describe '#update_port' do
+    it 'updates with valid attributes [it will fail if the appliance does not have some switch with unlinked ports]' do
+      port = switch['ports'].select { |k| k['portStatus'] == 'Unlinked' }.first
+      old_enabled = port['enabled']
+      expect { switch.update_port(port['name'], enabled: !old_enabled) }.not_to raise_error
+      sleep(30)
+      switch.retrieve!
+      port_updated = switch['ports'].select { |k| k['portName'] == port['name'] }.first
+      expect(port_updated['enabled']).to eq(!old_enabled)
+      uplink = resource_class_of('EthernetNetwork').find_by(current_client, name: ETH_NET_NAME).first
+      expect { switch.update_port(port['name'], enabled: old_enabled, associatedUplinkSetUri: uplink['uri']) }.not_to raise_error
+      sleep(30)
+      switch.retrieve!
+      port_updated = switch['ports'].select { |k| k['portName'] == port['name'] }.first
+      expect(port_updated['enabled']).to eq(old_enabled)
+    end
+  end
+end

--- a/spec/integration/shared_examples/switch/api300/update.rb
+++ b/spec/integration/shared_examples/switch/api300/update.rb
@@ -34,4 +34,6 @@ RSpec.shared_examples 'SwitchUpdateExample  API300' do |context_name|
       expect(port_updated['enabled']).to eq(old_enabled)
     end
   end
+
+  include_examples 'SwitchUpdateExample', context_name
 end

--- a/spec/unit/resource/api300/c7000/switch_spec.rb
+++ b/spec/unit/resource/api300/c7000/switch_spec.rb
@@ -7,73 +7,39 @@ RSpec.describe OneviewSDK::API300::C7000::Switch do
     expect(described_class).to be < OneviewSDK::API200::Switch
   end
 
-  describe '#remove' do
-    it 'Should support remove' do
-      switch = described_class.new(@client_300, uri: '/rest/switches/100')
-      expect(@client_300).to receive(:rest_delete).with('/rest/switches/100', {}, 300).and_return(FakeResponse.new({}))
-      switch.remove
-    end
-  end
-
-  describe '#get_type' do
-    it 'finds the specified switch' do
-      switch_type_list = FakeResponse.new(
-        'members' => [
-          { 'name' => 'SwitchA', 'uri' => 'rest/fake/A' },
-          { 'name' => 'TheSwitch', 'uri' => 'rest/fake/switch' },
-          { 'name' => 'SwitchC', 'uri' => 'rest/fake/C' }
-        ]
-      )
-      expect(@client_300).to receive(:rest_get).with('/rest/switch-types').and_return(switch_type_list)
-      @item = described_class.get_type(@client_300, 'TheSwitch')
-      expect(@item['uri']).to eq('rest/fake/switch')
-    end
-  end
-
-  describe 'statistics' do
-    before :each do
-      @item = described_class.new(@client_300, {})
-    end
-
-    it 'switch' do
-      expect(@client_300).to receive(:rest_get).with('/statistics/').and_return(FakeResponse.new)
-      @item.statistics
-    end
-
-    it 'port' do
-      expect(@client_300).to receive(:rest_get).with('/statistics/p1').and_return(FakeResponse.new)
-      @item.statistics('p1')
-    end
-  end
-
-  describe 'undefined methods' do
-    it 'does not allow the create action' do
-      switch = described_class.new(@client_300)
-      expect { switch.create }.to raise_error(OneviewSDK::MethodUnavailable, /The method #create is unavailable for this resource/)
-    end
-
-    it 'does not allow the update action' do
-      switch = described_class.new(@client_300)
-      expect { switch.update }.to raise_error(OneviewSDK::MethodUnavailable, /The method #update is unavailable for this resource/)
-    end
-
-    it 'does not allow the refresh action' do
-      switch = described_class.new(@client_300)
-      expect { switch.refresh }.to raise_error(OneviewSDK::MethodUnavailable, /The method #refresh is unavailable for this resource/)
-    end
-
-    it 'does not allow the delete action' do
-      switch = described_class.new(@client_300)
-      expect { switch.delete }.to raise_error(OneviewSDK::MethodUnavailable, /The method #delete is unavailable for this resource/)
-    end
-  end
-
   describe '#set_scope_uris' do
     it 'does a PATCH containing the scope uris to a switch' do
       item = described_class.new(@client_300, uri: '/rest/fake')
       data = { 'body' => [{ 'op' => 'replace', 'path' => '/scopeUris', 'value' => ['/rest/scopes/fee00629-9931-426d-8771-a597917eb9d2'] }] }
       expect(@client_300).to receive(:rest_patch).with('/rest/fake', data, item.api_version).and_return(FakeResponse.new(key: 'Val'))
       expect(item.set_scope_uris(['/rest/scopes/fee00629-9931-426d-8771-a597917eb9d2'])).to eq('key' => 'Val')
+    end
+  end
+
+  describe '#update_port' do
+    it 'updates a port' do
+      options = {
+        'uri' => '/rest/fake',
+        'ports' => [
+          {
+            'portName' => 'port1',
+            'enabled' => true
+          }
+        ]
+      }
+
+      options_2 = {
+        'portName' => 'port1',
+        'enabled' => false
+      }
+
+      item = described_class.new(@client_300, options)
+      fake_response = FakeResponse.new
+      expect(@client_300).to receive(:rest_put).with('/rest/fake/update-ports', 'body' => [options_2]).and_return(fake_response)
+      expect(@client_300).to receive(:response_handler).with(fake_response).and_return(options_2)
+      res = item.update_port('port1', enabled: false)
+      expect(res['name']).to eq(options_2['name'])
+      expect(res['enabled']).to eq(options_2['enabled'])
     end
   end
 end


### PR DESCRIPTION
### Description
Added the new endpoint ```/rest/switches/{id}/update-ports``` in the Switch resource API 300. 

### Issues Resolved
#290 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
