### PR TITLE
Added require_relative to avoid race condition in ResourceHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v5.3.0(Unreleased)
+## v5.3.0
 
 #### New Resources:
 - Login Detail
@@ -6,6 +6,7 @@
 
 #### Bug fixes & Enhancements
 - [#226](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/226) Add_rack_resource method returns NOMATCHING_ETAG_MESSAGE.
+- [#301](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/301) Bug - Race condition when requiring oneview-sdk gem on ruby 2.4
 
 ## v5.2.0
 

--- a/lib/oneview-sdk.rb
+++ b/lib/oneview-sdk.rb
@@ -13,6 +13,7 @@ require_relative 'oneview-sdk/version'
 require_relative 'oneview-sdk/exceptions'
 require_relative 'oneview-sdk/client'
 require_relative 'oneview-sdk/resource'
+require_relative 'oneview-sdk/resource_helper'
 Dir[File.dirname(__FILE__) + '/oneview-sdk/resource/*.rb'].each { |file| require file }
 require_relative 'oneview-sdk/scmb'
 require_relative 'oneview-sdk/image_streamer'

--- a/lib/oneview-sdk/version.rb
+++ b/lib/oneview-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module OneviewSDK
-  VERSION = '5.2.0'.freeze
+  VERSION = '5.3.0'.freeze
 end


### PR DESCRIPTION
### Description
Adds an explicit `require_relative` for the `resource_helper.rb` file, to make sure the `OneviewSDK::ResourceHelper` modules are loaded before the `resources` which include them.

### Issues Resolved
#301 

### Check List
- [X] All tests pass (`$ rake test`).
- [X] Changes are documented in the CHANGELOG.
