### PR TITLE
Api500/600 support to OS Deployment Plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ Extended support to Image Streamer Rest API version 500((ImageStreamer v3.10)) a
 
 #### Features supported
 Extended support to Image Streamer Rest API version 500 and 600 to the already existing features:
-   - Golden Image
    - Deployment Plan
+   - Golden Image
+
 
 ## v5.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Extended support to Image Streamer Rest API version 500((ImageStreamer v3.10)) a
 #### Features supported
 Extended support to Image Streamer Rest API version 500 and 600 to the already existing features:
    - Golden Image
+   - Deployment Plan
 
 ## v5.4.0
 

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -595,11 +595,13 @@ OneviewSDK::Datacenter.find_by(@client, width: 11000).map(&:remove)
 |<sub> /rest/deployment-groups</sub>                                       | GET              | :white_check_mark: |
 |<sub> /rest/deployment-groups/{id}</sub>                                  | GET              | :white_check_mark: |
 |     **Deployment Plans**                                                                                         |
-|<sub> /rest/deployment-plans </sub>                                       | POST             | :white_check_mark: |
-|<sub> /rest/deployment-plans </sub>                                       | GET              | :white_check_mark: |
-|<sub> /rest/deployment-plans/{id} </sub>                                  | GET              | :white_check_mark: |
-|<sub> /rest/deployment-plans/{id} </sub>                                  | PUT              | :white_check_mark: |
-|<sub> /rest/deployment-plans/{id} </sub>                                  | DELETE           | :white_check_mark: |
+|<sub> /rest/deployment-plans </sub>                                       | POST             | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans </sub>                                       | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id} </sub>                                  | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id} </sub>                                  | PUT              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id} </sub>                                  | DELETE           | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id}/osdp </sub>                             | GET              | :heavy_minus_sign: | :heavy_minus_sign: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id}/usedby </sub>                           | GET              | :heavy_minus_sign: | :white_check_mark: | :white_check_mark: |
 |     **Golden Images**                                                                                            |
 |<sub> /rest/golden-images</sub>                                           | POST(create)     | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |<sub> /rest/golden-images</sub>                                           | POST(upload)     | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/examples/image-streamer/deployment_plan.rb
+++ b/examples/image-streamer/deployment_plan.rb
@@ -73,6 +73,22 @@ puts "\n#Gets a deployment plan by name #{options[:name]}:"
 item4 = deployment_plan_class.find_by(@client, name: options[:name]).first
 puts "\n#Deployment Plan with name #{item4['uri']} was found."
 
+# Gets a deployment plan usedby server profiles and server profiles templates
+if @client.api_version.to_i >= 500
+  puts "\n#Gets a deployment plan filtered by usedby server profiles and server profiles templates"
+  used_by = item4.get_used_by
+  puts "\n#Deployment plan used by server profiles and server profiles templates retrieved:"
+  used_by.each { |d| puts "  #{d}" }
+end
+
+# Gets a deployment plan by osdp
+if @client.api_version.to_i >= 600
+  puts "\n#Gets a deployment plan by osdp"
+  osdp = item4.get_osdp
+  puts "\n#Deployment plan osdp details retrieved:"
+  osdp.each { |d| puts "  #{d}" }
+end
+
 # Updates a deployment plan
 puts "\n#Updating a deployment plan with uri #{item4['uri']} and name #{item4['name']}:"
 item4['name'] = 'Deployment_Plan_Updated'

--- a/examples/image-streamer/deployment_plan.rb
+++ b/examples/image-streamer/deployment_plan.rb
@@ -9,15 +9,24 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../_client_i3s' # Gives access to @client
+require_relative '../_client_i3s' # Gives access to @client
+# Supported APIs:
+# - 300, 500, 600
 
-# Example: Create a deployment plan for an API300 Image Streamer
+# Resources that can be created according to parameters:
+# api_version = 300 & variant = Synergy to OneviewSDK::ImageStreamer::API300::DeploymentPlan
+# api_version = 500 & variant = Synergy to OneviewSDK::ImageStreamer::API500::DeploymentPlan
+# api_version = 600 & variant = Synergy to OneviewSDK::ImageStreamer::API600::DeploymentPlan
+
+# Example: Create a deployment plan for an Image Streamer
 # NOTE: This will create a deployment plan named 'Deployment_Plan_1', then delete it.
 # NOTE: You'll need to add the following instance variables to the _client_i3s.rb file with valid URIs for your environment:
 #   @build_plan_name
-
-build_plan = OneviewSDK::ImageStreamer::API300::BuildPlan.find_by(@client, name: @build_plan_name).first
-golden_image = OneviewSDK::ImageStreamer::API300::GoldenImage.find_by(@client, name: @golden_image_name).first
+build_plan_class = OneviewSDK::ImageStreamer.resource_named('BuildPlan', @client.api_version)
+build_plan = build_plan_class.find_by(@client, name: @build_plan_name).first
+golden_image_class = OneviewSDK::ImageStreamer.resource_named('GoldenImage', @client.api_version)
+golden_image = golden_image_class.find_by(@client, name: @golden_image_name).first
+deployment_plan_class = OneviewSDK::ImageStreamer.resource_named('DeploymentPlan', @client.api_version)
 
 options = {
   name: 'Deployment_Plan_1',
@@ -35,33 +44,33 @@ options2 = {
 }
 
 # Creating a deployment plan
-item = OneviewSDK::ImageStreamer::API300::DeploymentPlan.new(@client, options)
+item = deployment_plan_class.new(@client, options)
 puts "\n#Creating a deployment plan with name #{options[:name]}."
 item.create!
 item.retrieve!
 puts "\n#Deployment plan with name #{item['name']} and uri #{item['uri']} created successfully."
 
 # Creating a deployment plan with a golden image
-item2 = OneviewSDK::ImageStreamer::API300::DeploymentPlan.new(@client, options2)
+item2 = deployment_plan_class.new(@client, options2)
 puts "\n#Creating a deployment plan with a golden image and name #{options2[:name]}."
 item2.create!
 item2.retrieve!
 puts "\n#Deployment plan with name #{item2['name']} and golden image with uri #{item2['goldenImageURI']} created successfully."
 
 # List all deployments
-list = OneviewSDK::ImageStreamer::API300::DeploymentPlan.get_all(@client)
+list = deployment_plan_class.get_all(@client)
 puts "\n#Listing all:"
 list.each { |p| puts "  #{p['name']}" }
 
 id = list.first['uri']
 # Gets a deployment plan by id
 puts "\n#Gets a deployment plan by id #{id}:"
-item3 = OneviewSDK::ImageStreamer::API300::DeploymentPlan.find_by(@client, uri: id).first
+item3 = deployment_plan_class.find_by(@client, uri: id).first
 puts "\n#Deployment Plan with uri #{item3['uri']} was found."
 
 # Gets a deployment plan by name
 puts "\n#Gets a deployment plan by name #{options[:name]}:"
-item4 = OneviewSDK::ImageStreamer::API300::DeploymentPlan.find_by(@client, name: options[:name]).first
+item4 = deployment_plan_class.find_by(@client, name: options[:name]).first
 puts "\n#Deployment Plan with name #{item4['uri']} was found."
 
 # Updates a deployment plan

--- a/lib/oneview-sdk/image-streamer/resource/api500/deployment_plan.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api500/deployment_plan.rb
@@ -17,6 +17,17 @@ module OneviewSDK
       # Deployment Plan resource implementation for Image Streamer
       class DeploymentPlan < OneviewSDK::ImageStreamer::API300::DeploymentPlan
 
+        # Create a resource object, associate it with a client, and set its properties.
+        # @param [OneviewSDK::ImageStreamer::Client] client The client object for the OneView appliance
+        # @param [Hash] params The options for this resource (key-value pairs)
+        # @param [Integer] api_ver The api version to use when interracting with this resource.
+        def initialize(client, params = {}, api_ver = nil)
+          @data ||= {}
+          # Default values:
+          @data['type'] ||= 'OEDeploymentPlanV5'
+          super
+        end
+
         # Retrieves the Deployment Plan details as per the selected attributes.
         # @return [Hash] The OS Deployment Plan.
         def get_used_by

--- a/lib/oneview-sdk/image-streamer/resource/api500/deployment_plan.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api500/deployment_plan.rb
@@ -1,0 +1,31 @@
+# (C) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api300/deployment_plan'
+
+module OneviewSDK
+  module ImageStreamer
+    module API500
+      # Deployment Plan resource implementation for Image Streamer
+      class DeploymentPlan < OneviewSDK::ImageStreamer::API300::DeploymentPlan
+
+        # Retrieves the Deployment Plan details as per the selected attributes.
+        # @return [Hash] The OS Deployment Plan.
+        def get_used_by
+          ensure_client && ensure_uri
+          path = "#{BASE_URI}/#{@data['uri'].split('/').last}/usedby/"
+          response = @client.rest_get(path, { 'Content-Type' => 'none' }, @api_version)
+          @client.response_handler(response)
+        end
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api600/deployment_plan.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api600/deployment_plan.rb
@@ -1,0 +1,31 @@
+# (C) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api500/deployment_plan'
+
+module OneviewSDK
+  module ImageStreamer
+    module API600
+      # Deployment Plan resource implementation for Image Streamer
+      class DeploymentPlan < OneviewSDK::ImageStreamer::API500::DeploymentPlan
+
+        # Retrieves the Deployment Plan details as per the selected attributes.
+        # @return [Hash] The OS Deployment Plan.
+        def get_osdp
+          ensure_client && ensure_uri
+          path = "#{BASE_URI}/#{@data['uri'].split('/').last}/osdp/"
+          response = @client.rest_get(path, { 'Content-Type' => 'none' }, @api_version)
+          @client.response_handler(response)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/image-streamer/api500/deployment_plan/create_spec.rb
+++ b/spec/integration/image-streamer/api500/deployment_plan/create_spec.rb
@@ -1,0 +1,98 @@
+# (C) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API500::DeploymentPlan
+RSpec.describe klass, integration_i3s: true, type: CREATE, sequence: i3s_seq(klass) do
+  include_context 'integration i3s api500 context'
+
+  before :all do
+    @build_plan = OneviewSDK::ImageStreamer::API500::BuildPlan.find_by($client_i3s_500, name: BUILD_PLAN1_NAME).first
+    @golden_image = OneviewSDK::ImageStreamer::API500::GoldenImage.find_by($client_i3s_500, name: GOLDEN_IMAGE1_NAME).first
+  end
+
+  describe '#create' do
+    it 'creates a deployment plan basic' do
+      options = {
+        name: DEPLOYMENT_PLAN1_NAME,
+        description: 'AnyDescription',
+        hpProvided: false,
+        oeBuildPlanURI: @build_plan['uri']
+      }
+
+      item = klass.new($client_i3s_500, options)
+      expect { item.create! }.not_to raise_error
+      item.retrieve!
+      expect(item['uri']).to be
+      expect(item['name']).to eq(options[:name])
+      expect(item['description']).to eq(options[:description])
+      expect(item['hpProvided']).to eq(options[:hpProvided])
+      expect(item['oeBuildPlanURI']).to eq(@build_plan['uri'])
+    end
+
+    it 'creates a deployment plan with golden image' do
+      options = {
+        name: DEPLOYMENT_PLAN2_NAME,
+        description: 'AnyDescription',
+        hpProvided: false,
+        oeBuildPlanURI: @build_plan['uri'],
+        goldenImageURI: @golden_image['uri']
+      }
+
+      item = klass.new($client_i3s_500, options)
+      expect { item.create! }.not_to raise_error
+      item.retrieve!
+      expect(item['uri']).to be
+      expect(item['name']).to eq(options[:name])
+      expect(item['description']).to eq(options[:description])
+      expect(item['hpProvided']).to eq(options[:hpProvided])
+      expect(item['oeBuildPlanURI']).to eq(@build_plan['uri'])
+      expect(item['goldenImageURI']).to eq(@golden_image['uri'])
+    end
+
+    it 'creates a deployment plan with custom attributes' do
+      build_plan = OneviewSDK::ImageStreamer::API500::BuildPlan.find_by($client_i3s_500, name: BUILD_PLAN4_NAME).first
+      options = {
+        name: DEPLOYMENT_PLAN3_NAME,
+        description: 'AnyDescription',
+        hpProvided: false,
+        oeBuildPlanURI: build_plan['uri'],
+        customAttributes: [{ 'name' => 'DomainName', 'type' => 'String', 'value' => 'fake.com' }]
+      }
+
+      item = klass.new($client_i3s_500, options)
+      expect { item.create! }.not_to raise_error
+      item.retrieve!
+      expect(item['uri']).to be
+      expect(item['name']).to eq(options[:name])
+      expect(item['description']).to eq(options[:description])
+      expect(item['hpProvided']).to eq(options[:hpProvided])
+      expect(item['oeBuildPlanURI']).to eq(build_plan['uri'])
+      expect(item['customAttributes'].first['name']).to eq(options[:customAttributes].first['name'])
+      expect(item['customAttributes'].first['type']).to eq(options[:customAttributes].first['type'])
+      expect(item['customAttributes'].first['value']).to eq(options[:customAttributes].first['value'])
+    end
+  end
+
+  describe '#get_used_by' do
+    it 'raises exception when uri is empty' do
+      item = klass.new($client_i3s_500)
+      expect { item.get_used_by }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute/)
+    end
+
+    it 'gets the details of the OS Deployment Plan' do
+      item = klass.find_by($client_i3s_500, {}).first
+      expect(item['uri']).to be
+      expect { item.get_used_by }.not_to raise_error
+    end
+  end
+end

--- a/spec/integration/image-streamer/api500/deployment_plan/delete_spec.rb
+++ b/spec/integration/image-streamer/api500/deployment_plan/delete_spec.rb
@@ -1,0 +1,34 @@
+# (C) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API500::DeploymentPlan
+RSpec.describe klass, integration_i3s: true, type: DELETE, sequence: i3s_rseq(klass) do
+  include_context 'integration i3s api500 context'
+
+  describe '#delete' do
+    it 'removes all deployment plans' do
+      item = klass.find_by($client_i3s_500, name: DEPLOYMENT_PLAN1_NAME).first
+      item2 = klass.find_by($client_i3s_500, name: DEPLOYMENT_PLAN2_NAME).first
+      item3 = klass.find_by($client_i3s_500, name: DEPLOYMENT_PLAN3_NAME).first
+      expect(item).to be
+      expect(item2).to be
+      expect(item3).to be
+      expect { item.delete }.not_to raise_error
+      expect(item.retrieve!).to eq(false)
+      expect { item2.delete }.not_to raise_error
+      expect(item2.retrieve!).to eq(false)
+      expect { item3.delete }.not_to raise_error
+      expect(item3.retrieve!).to eq(false)
+    end
+  end
+end

--- a/spec/integration/image-streamer/api500/deployment_plan/update_spec.rb
+++ b/spec/integration/image-streamer/api500/deployment_plan/update_spec.rb
@@ -1,0 +1,32 @@
+# (C) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API500::DeploymentPlan
+RSpec.describe klass, integration_i3s: true, type: UPDATE do
+  include_context 'integration i3s api500 context'
+
+  describe '#update' do
+    it 'updates the name of the deployment plan' do
+      item = klass.find_by($client_i3s_500, name: DEPLOYMENT_PLAN1_NAME).first
+      expect(item).to be
+      item['name'] = DEPLOYMENT_PLAN1_NAME_UPDATE
+      expect { item.update }.not_to raise_error
+      item.retrieve!
+      expect(item['name']).to eq(DEPLOYMENT_PLAN1_NAME_UPDATE)
+      item['name'] = DEPLOYMENT_PLAN1_NAME
+      expect { item.update }.not_to raise_error
+      item.retrieve!
+      expect(item['name']).to eq(DEPLOYMENT_PLAN1_NAME)
+    end
+  end
+end

--- a/spec/integration/image-streamer/api600/deployment_plan/create_spec.rb
+++ b/spec/integration/image-streamer/api600/deployment_plan/create_spec.rb
@@ -1,0 +1,111 @@
+# (C) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API600::DeploymentPlan
+RSpec.describe klass, integration_i3s: true, type: CREATE, sequence: i3s_seq(klass) do
+  include_context 'integration i3s api600 context'
+
+  before :all do
+    @build_plan = OneviewSDK::ImageStreamer::API600::BuildPlan.find_by($client_i3s_600, name: BUILD_PLAN1_NAME).first
+    @golden_image = OneviewSDK::ImageStreamer::API600::GoldenImage.find_by($client_i3s_600, name: GOLDEN_IMAGE1_NAME).first
+  end
+
+  describe '#create' do
+    it 'creates a deployment plan basic' do
+      options = {
+        name: DEPLOYMENT_PLAN1_NAME,
+        description: 'AnyDescription',
+        hpProvided: false,
+        oeBuildPlanURI: @build_plan['uri']
+      }
+
+      item = klass.new($client_i3s_600, options)
+      expect { item.create! }.not_to raise_error
+      item.retrieve!
+      expect(item['uri']).to be
+      expect(item['name']).to eq(options[:name])
+      expect(item['description']).to eq(options[:description])
+      expect(item['hpProvided']).to eq(options[:hpProvided])
+      expect(item['oeBuildPlanURI']).to eq(@build_plan['uri'])
+    end
+
+    it 'creates a deployment plan with golden image' do
+      options = {
+        name: DEPLOYMENT_PLAN2_NAME,
+        description: 'AnyDescription',
+        hpProvided: false,
+        oeBuildPlanURI: @build_plan['uri'],
+        goldenImageURI: @golden_image['uri']
+      }
+
+      item = klass.new($client_i3s_600, options)
+      expect { item.create! }.not_to raise_error
+      item.retrieve!
+      expect(item['uri']).to be
+      expect(item['name']).to eq(options[:name])
+      expect(item['description']).to eq(options[:description])
+      expect(item['hpProvided']).to eq(options[:hpProvided])
+      expect(item['oeBuildPlanURI']).to eq(@build_plan['uri'])
+      expect(item['goldenImageURI']).to eq(@golden_image['uri'])
+    end
+
+    it 'creates a deployment plan with custom attributes' do
+      build_plan = OneviewSDK::ImageStreamer::API600::BuildPlan.find_by($client_i3s_600, name: BUILD_PLAN4_NAME).first
+      options = {
+        name: DEPLOYMENT_PLAN3_NAME,
+        description: 'AnyDescription',
+        hpProvided: false,
+        oeBuildPlanURI: build_plan['uri'],
+        customAttributes: [{ 'name' => 'DomainName', 'type' => 'String', 'value' => 'fake.com' }]
+      }
+
+      item = klass.new($client_i3s_600, options)
+      expect { item.create! }.not_to raise_error
+      item.retrieve!
+      expect(item['uri']).to be
+      expect(item['name']).to eq(options[:name])
+      expect(item['description']).to eq(options[:description])
+      expect(item['hpProvided']).to eq(options[:hpProvided])
+      expect(item['oeBuildPlanURI']).to eq(build_plan['uri'])
+      expect(item['customAttributes'].first['name']).to eq(options[:customAttributes].first['name'])
+      expect(item['customAttributes'].first['type']).to eq(options[:customAttributes].first['type'])
+      expect(item['customAttributes'].first['value']).to eq(options[:customAttributes].first['value'])
+    end
+  end
+
+  describe '#get_used_by' do
+    it 'raises exception when uri is empty' do
+      item = klass.new($client_i3s_600)
+      expect { item.get_used_by }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute/)
+    end
+
+    it 'gets the details of the OS Deployment Plan' do
+      item = klass.find_by($client_i3s_600, {}).first
+      expect(item['uri']).to be
+      expect { item.get_used_by }.not_to raise_error
+    end
+  end
+
+  describe '#get_osdp' do
+    it 'raises exception when uri is empty' do
+      item = klass.new($client_i3s_600)
+      expect { item.get_osdp }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute/)
+    end
+
+    it 'gets the details of the OS Deployment Plan' do
+      item = klass.find_by($client_i3s_600, {}).first
+      expect(item['uri']).to be
+      expect { item.get_osdp }.not_to raise_error
+    end
+  end
+end

--- a/spec/integration/image-streamer/api600/deployment_plan/delete_spec.rb
+++ b/spec/integration/image-streamer/api600/deployment_plan/delete_spec.rb
@@ -1,0 +1,34 @@
+# (C) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API600::DeploymentPlan
+RSpec.describe klass, integration_i3s: true, type: DELETE, sequence: i3s_rseq(klass) do
+  include_context 'integration i3s api600 context'
+
+  describe '#delete' do
+    it 'removes all deployment plans' do
+      item = klass.find_by($client_i3s_600, name: DEPLOYMENT_PLAN1_NAME).first
+      item2 = klass.find_by($client_i3s_600, name: DEPLOYMENT_PLAN2_NAME).first
+      item3 = klass.find_by($client_i3s_600, name: DEPLOYMENT_PLAN3_NAME).first
+      expect(item).to be
+      expect(item2).to be
+      expect(item3).to be
+      expect { item.delete }.not_to raise_error
+      expect(item.retrieve!).to eq(false)
+      expect { item2.delete }.not_to raise_error
+      expect(item2.retrieve!).to eq(false)
+      expect { item3.delete }.not_to raise_error
+      expect(item3.retrieve!).to eq(false)
+    end
+  end
+end

--- a/spec/integration/image-streamer/api600/deployment_plan/update_spec.rb
+++ b/spec/integration/image-streamer/api600/deployment_plan/update_spec.rb
@@ -1,0 +1,32 @@
+# (C) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API600::DeploymentPlan
+RSpec.describe klass, integration_i3s: true, type: UPDATE do
+  include_context 'integration i3s api600 context'
+
+  describe '#update' do
+    it 'updates the name of the deployment plan' do
+      item = klass.find_by($client_i3s_600, name: DEPLOYMENT_PLAN1_NAME).first
+      expect(item).to be
+      item['name'] = DEPLOYMENT_PLAN1_NAME_UPDATE
+      expect { item.update }.not_to raise_error
+      item.retrieve!
+      expect(item['name']).to eq(DEPLOYMENT_PLAN1_NAME_UPDATE)
+      item['name'] = DEPLOYMENT_PLAN1_NAME
+      expect { item.update }.not_to raise_error
+      item.retrieve!
+      expect(item['name']).to eq(DEPLOYMENT_PLAN1_NAME)
+    end
+  end
+end

--- a/spec/unit/image-streamer/resource/api500/deployment_plan_spec.rb
+++ b/spec/unit/image-streamer/resource/api500/deployment_plan_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe klass do
     expect(described_class).to be < OneviewSDK::ImageStreamer::API300::DeploymentPlan
   end
 
+  describe '#initialize' do
+    it 'sets the defaults correctly' do
+      item = klass.new(@client_i3s_500)
+      expect(item['type']).to eq('OEDeploymentPlanV5')
+    end
+  end
+
   describe '#get_used_by' do
     it 'raises exception when uri is empty' do
       item = klass.new(@client_i3s_500)

--- a/spec/unit/image-streamer/resource/api500/deployment_plan_spec.rb
+++ b/spec/unit/image-streamer/resource/api500/deployment_plan_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API500::DeploymentPlan
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API300' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API300::DeploymentPlan
+  end
+
+  describe '#get_used_by' do
+    it 'raises exception when uri is empty' do
+      item = klass.new(@client_i3s_500)
+      expect { item.get_used_by }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute/)
+    end
+
+    it 'returns the response body from uri/usedby/' do
+      item = klass.new(@client_i3s_500, uri: '/rest/deployment-plans/fake')
+      expect(@client_i3s_500).to receive(:rest_get)
+        .with("#{item['uri']}/usedby/", { 'Content-Type' => 'none' }, 500)
+        .and_return(FakeResponse.new(response: 'fake'))
+      expect(item.get_used_by).to eq('response' => 'fake')
+    end
+  end
+end

--- a/spec/unit/image-streamer/resource/api600/deployment_plan_spec.rb
+++ b/spec/unit/image-streamer/resource/api600/deployment_plan_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API600::DeploymentPlan
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API500' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API500::DeploymentPlan
+  end
+
+  describe '#get_osdp' do
+    it 'raises exception when uri is empty' do
+      item = klass.new(@client_i3s_600)
+      expect { item.get_osdp }.to raise_error(OneviewSDK::IncompleteResource, /Please set uri attribute/)
+    end
+
+    it 'returns the response body from uri/osdp/' do
+      item = klass.new(@client_i3s_600, uri: '/rest/deployment-plans/fake')
+      expect(@client_i3s_600).to receive(:rest_get)
+        .with("#{item['uri']}/osdp/", { 'Content-Type' => 'none' }, 600)
+        .and_return(FakeResponse.new(response: 'fake'))
+      expect(item.get_osdp).to eq('response' => 'fake')
+    end
+  end
+end


### PR DESCRIPTION
### Description
Api500/600 support to OS Deployment Plans

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
