### PR TITLE
Adding missing examples - server hardware

### DIFF
--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -425,7 +425,7 @@ OneviewSDK::Datacenter.find_by(@client, width: 11000).map(&:remove)
 |<sub>/rest/server-hardware/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware/{id}/bios</sub>                                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | PUT      | :heavy_multiplication_x:   | :heavy_multiplication_x:   | :heavy_multiplication_x:   | :heavy_multiplication_x:   |
 |<sub>/rest/server-hardware/{id}/iloSsoUrl</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware/{id}/javaRemoteConsoleUrl</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware/{id}/mpFirmwareVersion</sub>                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -252,8 +252,8 @@ OneviewSDK::Datacenter.find_by(@client, width: 11000).map(&:remove)
 |<sub>/rest/logical-interconnect-groups/{id}/settings</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnects**                                                                                                                     |
 |<sub>/rest/logical-interconnects</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
-|<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | POST     | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |  :white_check_mark:   |
-|<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | DELETE   | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |  :white_check_mark:   |
+|<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | POST     | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |  :heavy_minus_sign:   |
+|<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | DELETE   | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |  :heavy_minus_sign:   |
 |<sub>/rest/logical-interconnects/{id}</sub>                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/compliance</sub>                                   | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/ethernetSettings</sub>                             | GET      | :heavy_minus_sign:   | :heavy_multiplication_x:  |:heavy_multiplication_x:  | :heavy_multiplication_x: |
@@ -262,12 +262,12 @@ OneviewSDK::Datacenter.find_by(@client, width: 11000).map(&:remove)
 |<sub>/rest/logical-interconnects/{id}/firmware</sub>                                     | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/forwarding-information-base</sub>                  | GET      | :heavy_multiplication_x:       | :heavy_multiplication_x:       | :heavy_multiplication_x:       | :heavy_multiplication_x: |
 |<sub>/rest/logical-interconnects/{id}/forwarding-information-base</sub>                  | POST     |  :heavy_multiplication_x:      | :heavy_multiplication_x:       | :heavy_multiplication_x:       | :heavy_multiplication_x: |
-|<sub>/rest/logical-interconnects/{id}/forwarding-information-base/{dumpFileName}.{suffix}</sub>      | GET      |  :heavy_multiplication_x:  | :heavy_multiplication_x:   | :heavy_multiplication_x:   |
+|<sub>/rest/logical-interconnects/{id}/forwarding-information-base/{dumpFileName}.{suffix}</sub>      | GET      |  :heavy_multiplication_x:  | :heavy_multiplication_x:   | :heavy_multiplication_x:   | :heavy_multiplication_x: |
 |<sub>/rest/logical-interconnects/{id}/internalNetworks</sub>                             | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/internalVlans</sub>                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/qos-aggregated-configuration</sub>                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/qos-aggregated-configuration</sub>                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/settings</sub>                                     | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   || :heavy_minus_sign:   |
+|<sub>/rest/logical-interconnects/{id}/settings</sub>                                     | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :heavy_minus_sign:   |
 |<sub>/rest/logical-interconnects/{id}/snmp-configuration</sub>                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/snmp-configuration</sub>                           | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/support-dumps</sub>                                | POST     |  :heavy_multiplication_x:      | :heavy_multiplication_x:       | :heavy_multiplication_x: | :heavy_multiplication_x:  |
@@ -277,7 +277,7 @@ OneviewSDK::Datacenter.find_by(@client, width: 11000).map(&:remove)
 |<sub>/rest/logical-interconnects/{id}/port-monitor</sub>                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/telemetry-configurations/{tcId}</sub>              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/logical-interconnects/{id}/telemetry-configurations/{tcId}</sub>              | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
-|<sub>/rest/logical-interconnects/compliance</sub>                                        | POST     | :heavy_multiplication_x:       | :heavy_multiplication_x:       | :heavy_multiplication_x: | :heavy_multiplication_x: |
+|<sub>/rest/logical-interconnects/compliance</sub>                                        | PUT      | :heavy_multiplication_x:       | :heavy_multiplication_x:       | :heavy_multiplication_x: | :heavy_multiplication_x: |
 |<sub>/rest/logical-interconnects/{id}</sub>                                              | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   |
 |     **Logical Switch Groups**                                                                                                                                           |
 |<sub>/rest/logical-switch-groups</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/shared_samples/server_hardware.rb
+++ b/examples/shared_samples/server_hardware.rb
@@ -48,6 +48,22 @@ item = server_harware_class.new(@client, options)
 item.add
 puts "\nAdded #{type} '#{item[:name]}' sucessfully.\n  uri = '#{item[:uri]}'"
 
+# Setting powerstate of the server to off.
+item.set_power_state('off', 'true')
+puts "\nSet Power state to 'off' successfully"
+
+# Set refresh state
+item.set_refresh_state('RefreshPending')
+puts "\nRefresh server hardware successful"
+
+# Get physical server hardware
+physical_server_hardware = item.get_physical_server_hardware
+puts "\nPhysical hardware found :\n#{physical_server_hardware}"
+
+# Update ilo firmware
+item.update_ilo_firmware
+puts "\niLO firmware updated to minimum ILO firmware version required by OneView to manage the server"
+
 # Below Endpoint is supported only for C7000.
 puts "\nAdding multiple #{type} with hostname Range = #{@server_mpHostsAndRanges}'"
 item_multiple = server_harware_class.new(@client, options)

--- a/lib/oneview-sdk/resource/api200/server_hardware.rb
+++ b/lib/oneview-sdk/resource/api200/server_hardware.rb
@@ -204,21 +204,6 @@ module OneviewSDK
         @client.response_handler(response)
       end
 
-      private
-
-      # Converts Date, Time, or String objects to iso8601 string
-      def convert_time(t)
-        case t
-        when nil then nil
-        when Date then t.to_time.utc.iso8601(3)
-        when Time then t.utc.iso8601(3)
-        when String then Time.parse(t).utc.iso8601(3)
-        else raise InvalidResource, "Invalid time format '#{t.class}'. Valid options are Time, Date, or String"
-        end
-      rescue StandardError => e
-        raise InvalidResource, "Failed to parse time value '#{t}'. #{e.message}"
-      end
-
       # Set power state. Takes into consideration the current state and does the right thing
       def set_power_state(state, force)
         refresh
@@ -244,6 +229,21 @@ module OneviewSDK
         body = @client.response_handler(response)
         set_all(body)
         true
+      end
+
+      private
+
+      # Converts Date, Time, or String objects to iso8601 string
+      def convert_time(t)
+        case t
+        when nil then nil
+        when Date then t.to_time.utc.iso8601(3)
+        when Time then t.utc.iso8601(3)
+        when String then Time.parse(t).utc.iso8601(3)
+        else raise InvalidResource, "Invalid time format '#{t.class}'. Valid options are Time, Date, or String"
+        end
+      rescue StandardError => e
+        raise InvalidResource, "Failed to parse time value '#{t}'. #{e.message}"
       end
     end
   end


### PR DESCRIPTION
### Description
Adds examples to following endpoints:
PUT /rest/server-hardware/{id}/mpFirmwareVersion
GET /rest/server-hardware/{id}/physicalServerHardware
PUT /rest/server-hardware/{id}/powerState
PUT /rest/server-hardware/{id}/refreshState

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] New endpoints supported are updated in the endpoints-support.md file.
- [] Changes are documented in the CHANGELOG.
