### PR TITLE
Fix for import certificate end point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v5.5.1
+
+#### Bug fixes & Enhancements
+- [#354](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/354)Input data has be to be a part of body, but not the header for import certificate method in enclosure
+
 ## v5.5.0
 
 #### Notes
@@ -12,9 +17,6 @@ Extended support to Image Streamer Rest API version 500 and 600 to the already e
    - Deployment Plan
    - Golden Image
    - OS Volume
-
-#### Bug fixes & Enhancements
-- [#354](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/354)Input data has be to be a part of body, but not the header for import certificate method in enclosure
 
 ## v5.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Extended support to Image Streamer Rest API version 500 and 600 to the already e
    - Golden Image
    - OS Volume
 
+#### Bug fixes & Enhancements
+- [#354](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/354)Input data has be to be a part of body, but not the header for import certificate method in enclosure
 
 ## v5.4.0
 

--- a/examples/shared_samples/enclosure.rb
+++ b/examples/shared_samples/enclosure.rb
@@ -117,7 +117,7 @@ if @client.api_version >= 600
   puts "Certificate Request data for Enclosure with name = '#{item2[:name]}' and uri = '#{item2[:uri]}'"
 
   certificate_data = {
-    type: certificate['type'],
+    type: 'CertificateDataV2',
     base64Data: certificate['base64Data']
   }
 

--- a/lib/oneview-sdk/resource/api600/c7000/enclosure.rb
+++ b/lib/oneview-sdk/resource/api600/c7000/enclosure.rb
@@ -62,7 +62,7 @@ module OneviewSDK
           ensure_client && ensure_uri
           uri = "#{@data['uri']}/https/certificaterequest"
           uri += "?bayNumber=#{bay_number}" if bay_number
-          response = @client.rest_put(uri, options, @api_version)
+          response = @client.rest_put(uri, { 'body' => options }, @api_version)
           @client.response_handler(response)
         end
       end

--- a/lib/oneview-sdk/resource/api600/synergy/enclosure.rb
+++ b/lib/oneview-sdk/resource/api600/synergy/enclosure.rb
@@ -62,7 +62,7 @@ module OneviewSDK
           ensure_client && ensure_uri
           uri = "#{@data['uri']}/https/certificaterequest"
           uri += "?bayNumber=#{bay_number}" if bay_number
-          response = @client.rest_put(uri, options, @api_version)
+          response = @client.rest_put(uri, { 'body' => options }, @api_version)
           @client.response_handler(response)
         end
       end

--- a/spec/unit/resource/api600/c7000/enclosure_spec.rb
+++ b/spec/unit/resource/api600/c7000/enclosure_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe OneviewSDK::API600::C7000::Enclosure do
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_put).and_return(FakeResponse.new)
       expect(@client_600).to receive(:rest_put).with('/rest/enclosures/fake/https/certificaterequest', { 'body' => 'New' },
                                                      @client_600.api_version)
-      enclosure.import_certificate('body' => 'New')
+      enclosure.import_certificate('New')
     end
   end
 end

--- a/spec/unit/resource/api600/synergy/enclosure_spec.rb
+++ b/spec/unit/resource/api600/synergy/enclosure_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe OneviewSDK::API600::Synergy::Enclosure do
       allow_any_instance_of(OneviewSDK::Client).to receive(:rest_put).and_return(FakeResponse.new)
       expect(@client_600).to receive(:rest_put).with('/rest/enclosures/fake/https/certificaterequest', { 'body' => 'New' },
                                                      @client_600.api_version)
-      enclosure.import_certificate('body' => 'New')
+      enclosure.import_certificate('New')
     end
   end
 end


### PR DESCRIPTION
### Description
Fix for the import certificate (PUT) end point of Enclosures for Api 600 version.

### Issues Resolved
#354 Issue in Header field while importing server signed certificate for an enclosure 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
