### PR TITLE
Api600/scope fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
-## v5.5.1
+## v5.5.1(unreleased)
 
 #### Notes
-Added helper method to change request body for Server Profile for API600
+This release fixes few bugs which are listed below.
 
 #### Bug fixes & Enhancements
 - Added helper method to change request body for Server Profile for API600
 - [#354](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/354)Input data has be to be a part of body, but not the header for import certificate method in enclosure
+- [#356](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/356) Not able to add and remove scopes from a resource in a single API call.
 
 ## v5.5.0
 

--- a/examples/shared_samples/scope.rb
+++ b/examples/shared_samples/scope.rb
@@ -74,7 +74,7 @@ puts "\nscopeUris from Resources: Server Hardware scope  - #{server_hardware['sc
 
 if @client.api_version >= 600
   puts "\nGet resource scope uris"
-  resource_scope = scope.get_resource_scopes(server_hardware)
+  resource_scope = scope_class.get_resource_scopes(@client, server_hardware)
   puts "Server hardware scopes #{resource_scope}"
 
   puts "\nReplace resource scope uris with scope2"
@@ -85,7 +85,7 @@ if @client.api_version >= 600
   scope2 = scope_class.new(@client, options)
   scope2.create
   puts "Created Scope2 with uri #{scope2['uri']}"
-  scope.replace_resource_assigned_scopes(server_hardware, scopes: [scope2])
+  scope_class.replace_resource_assigned_scopes(@client, server_hardware, scopes: [scope2])
   puts 'Replaced resouce scope uris'
 
   puts '\nAdd a resource to scope3'
@@ -96,13 +96,15 @@ if @client.api_version >= 600
   scope3 = scope_class.new(@client, options)
   scope3.create
   puts 'Created scope3'
-  scope.add_resource_scope(server_hardware, scope3)
+  scope_item = scope_class.find_by(@client, name: 'scope2').first
+  scope_class.add_resource_scope(@client, enclosure, scopes: [scope3, scope_item])
   puts 'Server hardware resource added to scope3'
 
   puts '\nRemoving resource from scope3'
-  scope.remove_resource_scope(server_hardware, scope3)
+  scope_class.remove_resource_scope(@client, enclosure, scopes: [scope3, scope_item])
+  scope_class.add_resource_scope(@client, server_hardware, scopes: [scope_item])
+  scope_class.resource_patch(@client, server_hardware, add_scopes: [scope3], remove_scopes: [scope_item])
   puts 'Removed resource from scope3'
-
   # Delete all scopes created.
   scope2.delete
   scope3.delete

--- a/spec/integration/resource/api600/c7000/scope/update_spec.rb
+++ b/spec/integration/resource/api600/c7000/scope/update_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe OneviewSDK::API600::C7000::Scope, integration: true, type: UPDATE
 
   include_examples 'ScopeUpdateExample', 'integration api600 context'
 
-  describe '#replace_resource_assigned_scope' do
+  describe '::replace_resource_assigned_scope' do
     it 'should replace the resource scope' do
       options = {
         name: 'new scope',
@@ -29,20 +29,20 @@ RSpec.describe OneviewSDK::API600::C7000::Scope, integration: true, type: UPDATE
       scope = described_class.new($client_600, options)
       scope.create
       new_scopes = [scope['uri']]
-      old_scopes = scope.get_resource_scopes(server_hardware)
-      expect { scope.replace_resource_assigned_scopes(server_hardware, scopes: new_scopes) }.to_not raise_error
+      old_scopes = described_class.get_resource_scopes($client_600, server_hardware)
+      expect { described_class.replace_resource_assigned_scopes($client_600, server_hardware, scopes: new_scopes) }.to_not raise_error
       server_hardware.refresh
-      updated_resource_scopes = scope.get_resource_scopes(server_hardware)['scopeUris']
+      updated_resource_scopes = described_class.get_resource_scopes($client_600, server_hardware)['scopeUris']
       expect(new_scopes).to match_array(updated_resource_scopes)
 
       # Update the resource with old scopes
-      scope.replace_resource_assigned_scopes(server_hardware, old_scopes)
-      current_scopes = scope.get_resource_scopes(server_hardware)
+      described_class.replace_resource_assigned_scopes($client_600, server_hardware, old_scopes)
+      current_scopes = described_class.get_resource_scopes($client_600, server_hardware)
       expect(current_scopes).to match_array(old_scopes)
     end
   end
 
-  describe '#resource_patch' do
+  describe '::resource_patch' do
     it 'should update the scope of resource' do
       options = {
         name: 'test scope',
@@ -50,14 +50,14 @@ RSpec.describe OneviewSDK::API600::C7000::Scope, integration: true, type: UPDATE
       }
       scope = described_class.new($client_600, options)
       scope.create
-      old_scopes = scope.get_resource_scopes(server_hardware)
-      expect { scope.resource_patch(server_hardware['scopesUri'], 'add', '/scopeUris/-', scope['uri']) }.to_not raise_error
-      new_scopes = scope.get_resource_scopes(server_hardware)['scopeUris']
+      old_scopes = described_class.get_resource_scopes($client_600, server_hardware)
+      expect { described_class.resource_patch($client_600, server_hardware, add_scopes: [scope], remove_scopes: [item]) }.to_not raise_error
+      new_scopes = described_class.get_resource_scopes($client_600, server_hardware)['scopeUris']
       expect(new_scopes).to include(scope['uri'])
 
-      scope_index = new_scopes.find_index { |uri| uri == scope['uri'] }
-      expect { scope.resource_patch(server_hardware['scopesUri'], 'remove', "/scopeUris/#{scope_index}") }.to_not raise_error
-      new_scopes = scope.get_resource_scopes(server_hardware)
+      # scope_index = new_scopes.find_index { |uri| uri == scope['uri'] }
+      expect { described_class.resource_patch($client_600, server_hardware, add_scopes: [item], remove_scopes: [scope]) }.to_not raise_error
+      new_scopes = described_class.get_resource_scopes($client_600, server_hardware)
       expect(old_scopes).to match_array(new_scopes)
     end
   end

--- a/spec/integration/resource/api600/synergy/scope/update_spec.rb
+++ b/spec/integration/resource/api600/synergy/scope/update_spec.rb
@@ -11,16 +11,16 @@
 
 require 'spec_helper'
 
-RSpec.describe OneviewSDK::API600::Synergy::Scope, integration: true, type: UPDATE do
+RSpec.describe OneviewSDK::API600::C7000::Scope, integration: true, type: UPDATE do
   include_context 'integration api600 context'
 
-  subject(:item) { described_class.get_all($client_600_synergy).first }
-  subject(:enclosure) { OneviewSDK::API600::Synergy::Enclosure.get_all($client_600_synergy).first }
-  subject(:server_hardware) { OneviewSDK::API600::Synergy::ServerHardware.get_all($client_600_synergy).first }
+  subject(:item) { described_class.get_all($client_600).first }
+  subject(:enclosure) { OneviewSDK::API600::C7000::Enclosure.get_all($client_600).first }
+  subject(:server_hardware) { OneviewSDK::API600::C7000::ServerHardware.get_all($client_600).first }
 
   include_examples 'ScopeUpdateExample', 'integration api600 context'
 
-  describe '#replace_resource_assigned_scope' do
+  describe '::replace_resource_assigned_scope' do
     it 'should replace the resource scope' do
       options = {
         name: 'new scope',
@@ -29,20 +29,20 @@ RSpec.describe OneviewSDK::API600::Synergy::Scope, integration: true, type: UPDA
       scope = described_class.new($client_600, options)
       scope.create
       new_scopes = [scope['uri']]
-      old_scopes = scope.get_resource_scopes(server_hardware)
-      expect { scope.replace_resource_assigned_scopes(server_hardware, scopes: new_scopes) }.to_not raise_error
+      old_scopes = described_class.get_resource_scopes($client_600, server_hardware)
+      expect { described_class.replace_resource_assigned_scopes($client_600, server_hardware, scopes: new_scopes) }.to_not raise_error
       server_hardware.refresh
-      updated_resource_scopes = scope.get_resource_scopes(server_hardware)['scopeUris']
+      updated_resource_scopes = described_class.get_resource_scopes($client_600, server_hardware)['scopeUris']
       expect(new_scopes).to match_array(updated_resource_scopes)
 
       # Update the resource with old scopes
-      scope.replace_resource_assigned_scopes(server_hardware, old_scopes)
-      current_scopes = scope.get_resource_scopes(server_hardware)
+      described_class.replace_resource_assigned_scopes($client_600, server_hardware, old_scopes)
+      current_scopes = described_class.get_resource_scopes($client_600, server_hardware)
       expect(current_scopes).to match_array(old_scopes)
     end
   end
 
-  describe '#resource_patch' do
+  describe '::resource_patch' do
     it 'should update the scope of resource' do
       options = {
         name: 'test scope',
@@ -50,14 +50,14 @@ RSpec.describe OneviewSDK::API600::Synergy::Scope, integration: true, type: UPDA
       }
       scope = described_class.new($client_600, options)
       scope.create
-      old_scopes = scope.get_resource_scopes(server_hardware)
-      expect { scope.resource_patch(server_hardware['scopesUri'], 'add', '/scopeUris/-', scope['uri']) }.to_not raise_error
-      new_scopes = scope.get_resource_scopes(server_hardware)['scopeUris']
+      old_scopes = described_class.get_resource_scopes($client_600, server_hardware)
+      expect { described_class.resource_patch($client_600, server_hardware, add_scopes: [scope], remove_scopes: [item]) }.to_not raise_error
+      new_scopes = described_class.get_resource_scopes($client_600, server_hardware)['scopeUris']
       expect(new_scopes).to include(scope['uri'])
 
-      scope_index = new_scopes.find_index { |uri| uri == scope['uri'] }
-      expect { scope.resource_patch(server_hardware['scopesUri'], 'remove', "/scopeUris/#{scope_index}") }.to_not raise_error
-      new_scopes = scope.get_resource_scopes(server_hardware)
+      # scope_index = new_scopes.find_index { |uri| uri == scope['uri'] }
+      expect { described_class.resource_patch($client_600, server_hardware, add_scopes: [item], remove_scopes: [scope]) }.to_not raise_error
+      new_scopes = described_class.get_resource_scopes($client_600, server_hardware)
       expect(old_scopes).to match_array(new_scopes)
     end
   end

--- a/spec/unit/resource/api600/c7000/scope_spec.rb
+++ b/spec/unit/resource/api600/c7000/scope_spec.rb
@@ -61,16 +61,19 @@ RSpec.describe OneviewSDK::API600::C7000::Scope do
       body = [{
         'op' => 'add',
         'path' => '/scopeUris/-',
-        'value' => '/rest/scope/id'
+        'value' => '/rest/scopes/UID-222'
+      }, {
+        'op' => 'remove',
+        'path' => '/scopeUris/1'
       }]
       data = { 'Content-Type' => 'application/json-patch+json', 'If-Match' => '*', 'body' => body }
-      expect(@client_600).to receive(:rest_patch).with('/rest/scopes/resources/', data, scope.api_version)
+      expect(@client_600).to receive(:rest_patch).with('/rest/scope/resources/rest/server-hardware/UID-111', data, scope.api_version)
                                                  .and_return(fake_response)
-      expect(@client_600).to receive(:response_handler).with(fake_response).and_return('fake')
+      expect(@client_600).to receive(:response_handler).with(fake_response).and_return(resource_1)
       expect(@client_600).to receive(:rest_get).with('/rest/scope/resources/rest/server-hardware/UID-111')
-                                               .and_return('fake')
-      expect(resource_1['scopeUris']).to match_array([scope['uri'], scope1['uri']])
-      expect(described_class.resource_patch(@client_600, resource_1, add_scopes: [scope1], remove_scopes: [scope1])).to eq('fake')
+                                               .and_return(fake_response)
+      expect(@client_600).to receive(:response_handler).with(fake_response).and_return(resource_1)
+      expect(described_class.resource_patch(@client_600, resource_1, add_scopes: [scope1], remove_scopes: [scope1])).to eq(resource_1)
     end
   end
 end

--- a/spec/unit/resource/api600/c7000/scope_spec.rb
+++ b/spec/unit/resource/api600/c7000/scope_spec.rb
@@ -13,14 +13,13 @@ require 'spec_helper'
 
 RSpec.describe OneviewSDK::API600::C7000::Scope do
   include_context 'shared context'
-
   subject(:scope) { described_class.new(@client_600, uri: '/rest/scopes/UID-111') }
   let(:scope1) { described_class.new(@client_600, uri: '/rest/scopes/UID-222') }
   let(:fake_response) { FakeResponse.new({}) }
   let(:resource_1) do
     OneviewSDK::API600::C7000::ServerHardware.new(@client_600, uri: '/rest/server-hardware/UID-111',
                                                                scopesUri: '/rest/scope/resources/rest/server-hardware/UID-111',
-                                                               scopeUris: ['/rest/scope/fake1', 'resr/scope/fake2'])
+                                                               scopeUris: ['/rest/scopes/UID-111', '/rest/scopes/UID-222'])
   end
   let(:resource_2) { OneviewSDK::API600::C7000::ServerHardware.new(@client_600, uri: '/rest/server-hardware/UID-222') }
 
@@ -35,28 +34,29 @@ RSpec.describe OneviewSDK::API600::C7000::Scope do
     end
   end
 
-  describe '#get_resource_scope' do
+  describe '::get_resource_scope' do
     it 'returns the response body from rest/scope/resources/*' do
       expect(@client_600).to receive(:rest_get).with('/rest/scope/resources/rest/server-hardware/UID-111')
                                                .and_return(fake_response)
-      expect(scope.get_resource_scopes(resource_1)).to eq({})
+      expect(described_class.get_resource_scopes(@client_600, resource_1)).to eq({})
     end
   end
 
-  describe '#replace_resource_assigned_scopes' do
+  describe '::replace_resource_assigned_scopes' do
     it 'performs replace successfully' do
       options = { 'Content-Type' => 'application/json-patch+json',
                   'If-Match' => '*',
                   'body' => { 'type' => 'ScopedResource',
                               'resourceUri' => '/rest/server-hardware/UID-111',
                               'scopeUris' => ['/rest/scopes/UID-222'] } }
-      expect(@client_600).to receive(:rest_put).with('/rest/scope/resources/rest/server-hardware/UID-111', options).and_return(fake_response)
+      expect(@client_600).to receive(:rest_put).with('/rest/scope/resources/rest/server-hardware/UID-111', options)
+                                               .and_return(fake_response)
       expect(@client_600).to receive(:response_handler).with(fake_response).and_return('fake')
-      expect(scope.replace_resource_assigned_scopes(resource_1, scopes: [scope1])).to eq('fake')
+      expect(described_class.replace_resource_assigned_scopes(@client_600, resource_1, scopes: [scope1])).to eq('fake')
     end
   end
 
-  describe '#resource_patch' do
+  describe '::resource_patch' do
     it 'performs the patch successfully' do
       body = [{
         'op' => 'add',
@@ -64,9 +64,13 @@ RSpec.describe OneviewSDK::API600::C7000::Scope do
         'value' => '/rest/scope/id'
       }]
       data = { 'Content-Type' => 'application/json-patch+json', 'If-Match' => '*', 'body' => body }
-      expect(@client_600).to receive(:rest_patch).with('/rest/scopes/resources/', data, scope.api_version).and_return(fake_response)
+      expect(@client_600).to receive(:rest_patch).with('/rest/scopes/resources/', data, scope.api_version)
+                                                 .and_return(fake_response)
       expect(@client_600).to receive(:response_handler).with(fake_response).and_return('fake')
-      expect(scope.resource_patch('/rest/scopes/resources/', 'add', '/scopeUris/-', '/rest/scope/id')).to eq('fake')
+      expect(@client_600).to receive(:rest_get).with('/rest/scope/resources/rest/server-hardware/UID-111')
+                                               .and_return('fake')
+      expect(resource_1['scopeUris']).to match_array([scope['uri'], scope1['uri']])
+      expect(described_class.resource_patch(@client_600, resource_1, add_scopes: [scope1], remove_scopes: [scope1])).to eq('fake')
     end
   end
 end


### PR DESCRIPTION
### Description
Re-implemented scope: PATCH /rest/scopes/resources/** so that it can take both operations in the same call. Made other methods which were newly introduced for API600 as static instead of instance methods.

### Issues Resolved
[#356]

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
