### PR TITLE
Api600 interconnect link topologies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
-## v5.5.1
+## v5.5.1 (Unreleased)
 
 #### Notes
-Added helper method to change request body for Server Profile for API600
+Added helper method to change request body for Server Profile for API600.
 
 #### Bug fixes & Enhancements
-- Added helper method to change request body for Server Profile for API600
-- [#354](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/354)Input data has be to be a part of body, but not the header for import certificate method in enclosure
+- Added helper method to change request body for Server Profile for API600.
+- [#354](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/354) Input data has be to be a part of body, but not the header for import certificate method in enclosure.
+- [#359](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/359) Interconnect link topologies endpoints not available for api600. Fixed by inheriting from API500.
 
 ## v5.5.0
 

--- a/lib/oneview-sdk/resource/api600/synergy/interconnect.rb
+++ b/lib/oneview-sdk/resource/api600/synergy/interconnect.rb
@@ -17,6 +17,21 @@ module OneviewSDK
     module Synergy
       # Interconnect resource implementation on API600 Synergy
       class Interconnect < OneviewSDK::API600::C7000::Interconnect
+
+         # Retrieves the interconnect link topologies
+        # @param [OneviewSDK::Client] client The client object for the OneView appliance
+        # @return [Array] All the Interconnect Link Topologies
+        def self.get_link_topologies(client)
+          OneviewSDK::API300::Synergy::Interconnect.get_link_topologies(client)
+        end
+
+        # Retrieves the interconnect link topology with the name
+        # @param [OneviewSDK::Client] client The client object for the OneView appliance
+        # @param [String] name Switch type name
+        # @return [Array] Switch type
+        def self.get_link_topology(client, name)
+          OneviewSDK::API300::Synergy::Interconnect.get_link_topology(client, name)
+        end
       end
     end
   end

--- a/lib/oneview-sdk/resource/api600/synergy/interconnect.rb
+++ b/lib/oneview-sdk/resource/api600/synergy/interconnect.rb
@@ -18,7 +18,7 @@ module OneviewSDK
       # Interconnect resource implementation on API600 Synergy
       class Interconnect < OneviewSDK::API600::C7000::Interconnect
 
-         # Retrieves the interconnect link topologies
+        # Retrieves the interconnect link topologies
         # @param [OneviewSDK::Client] client The client object for the OneView appliance
         # @return [Array] All the Interconnect Link Topologies
         def self.get_link_topologies(client)


### PR DESCRIPTION
### Description
Add missing endpoints of interconnect link topology to api600.

### Issues Resolved
Issue #359 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
