### PR TITLE
Adding query parameter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v5.6.1(Unreleased)
+
+#### Notes
+This release fixes few bugs listed below
+
+#### Bug fixes & Enhancements
+- [#366](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/366) Query parameters not working for get_attachable_volumes endpoint
+
 ## v5.6.0
 
 #### Notes

--- a/examples/shared_samples/volume.rb
+++ b/examples/shared_samples/volume.rb
@@ -150,7 +150,10 @@ item3.delete_snapshot(snapshot_name)
 puts "\nSnapshot removed successfully!"
 
 puts "\nGetting the attachable volumes managed by the appliance"
-attachables = volume_class.get_attachable_volumes(@client)
+query = {
+  connections: '<Your parameters here>'
+}
+attachables = volume_class.get_attachable_volumes(@client, query)
 puts "\nAttachable volumes found: #{attachables}"
 
 puts "\nGetting the list of extra managed storage volume paths"

--- a/lib/oneview-sdk/resource/api200/volume.rb
+++ b/lib/oneview-sdk/resource/api200/volume.rb
@@ -147,8 +147,9 @@ module OneviewSDK
       # Gets all the attachable volumes managed by the appliance
       # @param [OneviewSDK::Client] client The client object for the OneView appliance
       # @return [Array<OneviewSDK::Volume>] Array of volumes
-      def self.get_attachable_volumes(client)
-        uri = "#{BASE_URI}/attachable-volumes"
+      def self.get_attachable_volumes(client, query = nil)
+        query_uri = build_query(query) if query
+        uri = "#{BASE_URI}/attachable-volumes#{query_uri}"
         find_by(client, {}, uri)
       end
 

--- a/spec/unit/resource/api200/volume_spec.rb
+++ b/spec/unit/resource/api200/volume_spec.rb
@@ -205,8 +205,10 @@ RSpec.describe OneviewSDK::Volume do
       it 'returns an array of available volumes' do
         volumes = [@item]
         allow_any_instance_of(OneviewSDK::Client).to receive(:response_handler).and_return('members' => volumes)
-        expect(@client_200).to receive(:rest_get).with('/rest/storage-volumes/attachable-volumes', {})
-        items = OneviewSDK::Volume.get_attachable_volumes(@client_200)
+        allow(@client_200).to receive(:build_query)
+          .with(@client_200, { 'sort' => 'name:ascending' }, described_class::BASE_URI, {}).and_return('?sort=name:ascending')
+        expect(@client_200).to receive(:rest_get).with('/rest/storage-volumes/attachable-volumes?sort=name:ascending', {})
+        items = OneviewSDK::Volume.get_attachable_volumes(@client_200, 'sort' => 'name:ascending')
         expect(items.class).to eq(Array)
         expect(items.size).to eq(1)
         expect(items.first['name']).to eq('volume_name')


### PR DESCRIPTION
### Description
Adds support for `connections` query parameter for `get_attachable_volumes`

### Issues Resolved
#366 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
