### PR TITLE
resource to API 500 Synergy / API 300 Synergy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v5.7.1
+## v5.7.1 (Unreleased)
 
 #### Notes
 This release fixes one bug listed below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v5.7.1
+
+#### Notes
+This release fixes one bug listed below.
+
+#### Bug fixes & Enhancements
+- [#372](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/372) Failed to create logical interconnect groups for API600. Fixed by inheriting from API500 resource.
+
 ## v5.7.0
 
 #### Notes

--- a/lib/oneview-sdk/resource/api600/synergy/logical_interconnect_group.rb
+++ b/lib/oneview-sdk/resource/api600/synergy/logical_interconnect_group.rb
@@ -9,13 +9,13 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-require_relative '../c7000/logical_interconnect_group'
+require_relative '../../api500/synergy/logical_interconnect_group'
 
 module OneviewSDK
   module API600
     module Synergy
       # Logical interconnect group resource implementation for API600 Synergy
-      class LogicalInterconnectGroup < OneviewSDK::API600::C7000::LogicalInterconnectGroup
+      class LogicalInterconnectGroup < OneviewSDK::API500::Synergy::LogicalInterconnectGroup
       end
     end
   end

--- a/spec/unit/resource/api600/synergy/logical_interconnect_group.rb
+++ b/spec/unit/resource/api600/synergy/logical_interconnect_group.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe OneviewSDK::API600::Synergy::LogicalInterconnectGroup do
   include_context 'shared context'
 
-  it 'inherits from OneviewSDK::API600::C7000::LogicalInterconnectGroup' do
-    expect(described_class).to be < OneviewSDK::API600::C7000::LogicalInterconnectGroup
+  it 'inherits from OneviewSDK::API500::Synergy::LogicalInterconnectGroup' do
+    expect(described_class).to be < OneviewSDK::API500::Synergy::LogicalInterconnectGroup
   end
 end


### PR DESCRIPTION
### Description
The resource was set to C7000, but most of the Logical Interconnect Group functionality for the OneView are build in '../../api300/synergy'.
The recource for api500 is also set to api300.

### Issues Resolved
Fixes #372 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
