### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: ruby
 rvm:
-  - 2.2.6
-  - 2.3.1
-  - 2.4.1
+  - 2.2
+  - 2.4
+  - 2.6
 
 before_install: gem update bundler
 
 script:
   - rake build
   - rake test
-
-matrix:
-  allow_failures:
-    - rvm: 2.4


### PR DESCRIPTION
### Description
Updates the `.travis.yml` file to include a newer Ruby version. I replaced 2.3 with 2.6 and skipped 2.5 just to keep the matrix at only 3. I'm not opposed to doing more, but I don't think it's necessary.

This also removes the code allowing 2.4 builds to fail without marking the overall build status as a failure. I'm not sure why that was ever necessary, but it doesn't appear to be anymore.

### Issues Resolved
None

### Check List
N/A
