### PR TITLE
Added API 1600 support to artifact bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 This release extends support of the SDK to OneView REST API version 1600 (OneView v5.20).
 
 #### Features supported
+- Artifact Bundle
+- Deployment Group
 - Deployment Plan
 - Enclosure
 - Enclosure Group

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -489,24 +489,24 @@ OneviewSDK::Datacenter.find_by(@client, width: 11000).map(&:remove)
 | Endpoints                                                                         | Verb    | V300               | V500               | V600               | V800               | V1000              | V1020               |  V1600               |
 | --------------------------------------------------------------------------------- | ------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
 |     **Artifacts Bundle**                                                                                         |
-|<sub>	/rest/artifact-bundles	</sub>                                                  | GET | :white_check_mark: |
-|<sub>	/rest/artifact-bundles	</sub>                                       |  POST(create)  | :white_check_mark: |
-|<sub>	/rest/artifact-bundles	</sub>                                       |  POST(upload)  | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/backups	</sub>                                          | GET | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/backups	</sub>                                 | POST(create) | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/backups/archive	</sub>                         | POST(upload) | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/backups/archive/{id}	</sub>                          | GET | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/backups/{id}	</sub>                                  | GET | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/backups/{id}	</sub>                                  | PUT | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/download/{id}	</sub>                                  | GET | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/{id}	</sub>                                          | GET | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/{id}	</sub>                             | PUT(extract)     | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/{id}	</sub>                             | PUT(update attr) | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/{id}	</sub>                             | DELETE           | :white_check_mark: |
-|<sub>	/rest/artifact-bundles/{id}/stopArtifactCreate	</sub>             | PUT              | :white_check_mark: |
+|<sub>	/rest/artifact-bundles	</sub>                                     | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles	</sub>                                     |  POST(create)    | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles	</sub>                                     |  POST(upload)    | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/backups	</sub>                             | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/backups	</sub>                             | POST(create)     | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/backups/archive	</sub>                     | POST(upload)     | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/backups/archive/{id}	</sub>                 | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/backups/{id}	</sub>                         | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/backups/{id}	</sub>                         | PUT              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/download/{id}	</sub>                     | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/{id}	</sub>                                 | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/{id}	</sub>                                 | PUT(extract)     | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/{id}	</sub>                                 | PUT(update attr) | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/{id}	</sub>                                 | DELETE           | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub>	/rest/artifact-bundles/{id}/stopArtifactCreate	</sub>             | PUT              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
 |     **Deployment Groups**                                                                                        |
-|<sub> /rest/deployment-groups</sub>                                       | GET              | :white_check_mark: |
-|<sub> /rest/deployment-groups/{id}</sub>                                  | GET              | :white_check_mark: |
+|<sub> /rest/deployment-groups</sub>                                       | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
+|<sub> /rest/deployment-groups/{id}</sub>                                  | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
 |     **Deployment Plans**                                                                                         |
 |<sub> /rest/deployment-plans </sub>                                       | POST             | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |
 |<sub> /rest/deployment-plans </sub>                                       | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: |

--- a/examples/image-streamer/artifact_bundle.rb
+++ b/examples/image-streamer/artifact_bundle.rb
@@ -1,0 +1,96 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require 'tempfile'
+require_relative '../_client_i3s' # Gives access to @client
+
+# Supported APIs:
+# - 300, 500, 600, 800, 1000, 1020, 1600
+
+# Resources that can be created according to parameters:
+# api_version = 300 & variant = Synergy to OneviewSDK::ImageStreamer::API300::ArtifactBundle
+# api_version = 500 & variant = Synergy to OneviewSDK::ImageStreamer::API500::ArtifactBundle
+# api_version = 600 & variant = Synergy to OneviewSDK::ImageStreamer::API600::ArtifactBundle
+# api_version = 800 & variant = Synergy to OneviewSDK::ImageStreamer::API800::ArtifactBundle
+# api_version = 1000 & variant = Synergy to OneviewSDK::ImageStreamer::API1000::ArtifactBundle
+# api_version = 1020 & variant = Synergy to OneviewSDK::ImageStreamer::API1020::ArtifactBundle
+# api_version = 1600 & variant = Synergy to OneviewSDK::ImageStreamer::API1600::ArtifactBundle
+
+# Example:
+# - Create, update, download, upload, extract and delete an artifact bundle for an Image Streamer
+# - Create, download, upload an backup bundle for an Image Streamer
+# NOTE: It needs a DeploymentGroup and a PlanScript created already
+
+deployment_group_class = OneviewSDK::ImageStreamer.resource_named('DeploymentGroup', @client.api_version)
+deployment_group = deployment_group_class.get_all(@client).first
+plan_script_class = OneviewSDK::ImageStreamer.resource_named('PlanScript', @client.api_version)
+plan_script = plan_script_class.get_all(@client).first
+artifact_bundle_class = OneviewSDK::ImageStreamer.resource_named('ArtifactBundle', @client.api_version)
+
+options = {
+  name: 'ArtifactBundle Name',
+  description: 'Description of ArtifactBundle'
+}
+
+puts "\nCreating an artifact bundle with plan script"
+item = artifact_bundle_class.new(@client, options)
+item.add_plan_script(plan_script, false)
+item.create
+puts "Artifact Bundle with name #{item['name']} and uri #{item['uri']} created successfully."
+puts 'Data:', item.data
+
+puts "\nUpdating the name of the artifact bundle"
+item.update_name("#{item['name']}_Updated")
+puts "Artifact Bundle with name #{item['name']} and uri #{item['uri']} updated successfully."
+
+puts "\nListing all artifact bundles"
+all_items = artifact_bundle_class.get_all(@client)
+all_items.each { |each_item| puts each_item['name'] }
+
+download_file = Tempfile.new(['artifact-bundle', '.zip'])
+download_path = download_file.path
+puts "\nDownloading artifact bundle file and saving at #{download_path}"
+item.download(download_path)
+puts 'Downloaded successfully.' if File.exist?(download_path)
+
+puts "\nCreating artifact bundle from zip file"
+item_uploaded = artifact_bundle_class.create_from_file(@client, download_path, 'ArtifactBundle Uploaded')
+puts "Artifact Bundle with name #{item_uploaded['name']} and uri #{item_uploaded['uri']} created successfully."
+
+puts "\nExtracting artifact bundle uploaded"
+puts 'Artifact Bundle extracted successfully.' if item_uploaded.extract
+
+puts "\nCreating a backup associated to deployment group with name='#{deployment_group['name']}' and uri='#{deployment_group['uri']}'"
+puts artifact_bundle_class.create_backup(@client, deployment_group)
+
+puts "\nListing backups"
+backups = artifact_bundle_class.get_backups(@client)
+backups.each { |bkp| puts bkp['name'] }
+
+backup_download_file = Tempfile.new(['backup-bundle', '.zip'])
+backup_download_path = backup_download_file.path
+puts "\nDownloading backup bundle file and saving at #{backup_download_path}"
+artifact_bundle_class.download_backup(@client, backup_download_path, backups.first)
+puts 'Downloaded successfully.' if File.exist?(backup_download_path)
+
+puts "\nUploading backup bundle"
+puts artifact_bundle_class.create_backup_from_file!(@client, deployment_group, backup_download_path, 'Backup Bundle')
+
+puts "\nExtracting backup bundle uploaded"
+backup = artifact_bundle_class.get_backups(@client).first
+puts artifact_bundle_class.extract_backup(@client, deployment_group, backup)
+puts 'Backup extracted successfully'
+
+puts "\nDeleting the artifact bundles"
+item.delete
+item_uploaded.delete
+puts "#{item['name']} deleted successfully" unless item.retrieve!
+puts "#{item_uploaded['name']} deleted successfully" unless item_uploaded.retrieve!

--- a/examples/image-streamer/deployment_group.rb
+++ b/examples/image-streamer/deployment_group.rb
@@ -1,0 +1,35 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../_client_i3s' # Gives access to @client
+
+# Supported APIs:
+# - 300, 500, 600, 800, 1000, 1020, 1600
+
+# Resources that can be created according to parameters:
+# api_version = 300 & variant = Synergy to OneviewSDK::ImageStreamer::API300::DeploymentGroup
+# api_version = 500 & variant = Synergy to OneviewSDK::ImageStreamer::API500::DeploymentGroup
+# api_version = 600 & variant = Synergy to OneviewSDK::ImageStreamer::API600::DeploymentGroup
+# api_version = 800 & variant = Synergy to OneviewSDK::ImageStreamer::API800::DeploymentGroup
+# api_version = 1000 & variant = Synergy to OneviewSDK::ImageStreamer::API1000::DeploymentGroup
+# api_version = 1020 & variant = Synergy to OneviewSDK::ImageStreamer::API1020::DeploymentGroup
+# api_version = 1600 & variant = Synergy to OneviewSDK::ImageStreamer::API1600::DeploymentGroup
+
+# Example:
+# - Gets the Deployment Groups
+# NOTE: It needs an existing DeploymentGroup
+
+deployment_group_class = OneviewSDK::ImageStreamer.resource_named('DeploymentGroup', @client.api_version)
+
+# List all deployments
+list = deployment_group_class.get_all(@client)
+puts "\n#Listing all Deployment Groups:"
+list.each { |p| puts "  #{p['name']}" }

--- a/examples/image-streamer/deployment_plan.rb
+++ b/examples/image-streamer/deployment_plan.rb
@@ -11,7 +11,7 @@
 
 require_relative '../_client_i3s' # Gives access to @client
 # Supported APIs:
-# - 300, 500, 600, 800, 1000, 1020
+# - 300, 500, 600, 800, 1000, 1020, 1600
 
 # Resources that can be created according to parameters:
 # api_version = 300 & variant = Synergy to OneviewSDK::ImageStreamer::API300::DeploymentPlan
@@ -20,6 +20,7 @@ require_relative '../_client_i3s' # Gives access to @client
 # api_version = 800 & variant = Synergy to OneviewSDK::ImageStreamer::API800::DeploymentPlan
 # api_version = 1000 & variant = Synergy to OneviewSDK::ImageStreamer::API1000::DeploymentPlan
 # api_version = 1020 & variant = Synergy to OneviewSDK::ImageStreamer::API1020::DeploymentPlan
+# api_version = 1600 & variant = Synergy to OneviewSDK::ImageStreamer::API1600::DeploymentPlan
 
 # Example: Create a deployment plan for an Image Streamer
 # NOTE: This will create a deployment plan named 'Deployment_Plan_1', then delete it.

--- a/lib/oneview-sdk/image-streamer/resource/api1000/artifact_bundle.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api1000/artifact_bundle.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api800/artifact_bundle'
+
+module OneviewSDK
+  module ImageStreamer
+    module API1000
+      # Artifact Bundle resource implementation for Image Streamer
+      class ArtifactBundle < OneviewSDK::ImageStreamer::API800::ArtifactBundle
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api1000/deployment_group.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api1000/deployment_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api800/deployment_group'
+
+module OneviewSDK
+  module ImageStreamer
+    module API1000
+      # Deployment Group resource implementation for Image Streamer
+      class DeploymentGroup < OneviewSDK::ImageStreamer::API800::DeploymentGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api1020/artifact_bundle.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api1020/artifact_bundle.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api1000/artifact_bundle'
+
+module OneviewSDK
+  module ImageStreamer
+    module API1020
+      # Artifact Bundle resource implementation for Image Streamer
+      class ArtifactBundle < OneviewSDK::ImageStreamer::API1000::ArtifactBundle
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api1020/deployment_group.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api1020/deployment_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api1000/deployment_group'
+
+module OneviewSDK
+  module ImageStreamer
+    module API1020
+      # Deployment Group resource implementation for Image Streamer
+      class DeploymentGroup < OneviewSDK::ImageStreamer::API1000::DeploymentGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api1600/artifact_bundle.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api1600/artifact_bundle.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api1020/artifact_bundle'
+
+module OneviewSDK
+  module ImageStreamer
+    module API1600
+      # Artifact Bundle resource implementation for Image Streamer
+      class ArtifactBundle < OneviewSDK::ImageStreamer::API020::ArtifactBundle
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api1600/artifact_bundle.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api1600/artifact_bundle.rb
@@ -15,7 +15,7 @@ module OneviewSDK
   module ImageStreamer
     module API1600
       # Artifact Bundle resource implementation for Image Streamer
-      class ArtifactBundle < OneviewSDK::ImageStreamer::API020::ArtifactBundle
+      class ArtifactBundle < OneviewSDK::ImageStreamer::API1020::ArtifactBundle
       end
     end
   end

--- a/lib/oneview-sdk/image-streamer/resource/api1600/deployment_group.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api1600/deployment_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api1020/deployment_group'
+
+module OneviewSDK
+  module ImageStreamer
+    module API1600
+      # Deployment Group resource implementation for Image Streamer
+      class DeploymentGroup < OneviewSDK::ImageStreamer::API1020::DeploymentGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api500/artifact_bundle.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api500/artifact_bundle.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api300/artifact_bundle'
+
+module OneviewSDK
+  module ImageStreamer
+    module API500
+      # Artifact Bundle resource implementation for Image Streamer
+      class ArtifactBundle < OneviewSDK::ImageStreamer::API300::ArtifactBundle
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api500/deployment_group.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api500/deployment_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api300/deployment_group'
+
+module OneviewSDK
+  module ImageStreamer
+    module API500
+      # Deployment Group resource implementation for Image Streamer
+      class DeploymentGroup < OneviewSDK::ImageStreamer::API300::DeploymentGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api600/artifact_bundle.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api600/artifact_bundle.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api500/artifact_bundle'
+
+module OneviewSDK
+  module ImageStreamer
+    module API600
+      # Artifact Bundle resource implementation for Image Streamer
+      class ArtifactBundle < OneviewSDK::ImageStreamer::API500::ArtifactBundle
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api600/deployment_group.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api600/deployment_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api500/deployment_group'
+
+module OneviewSDK
+  module ImageStreamer
+    module API600
+      # Deployment Group resource implementation for Image Streamer
+      class DeploymentGroup < OneviewSDK::ImageStreamer::API500::DeploymentGroup
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api800/artifact_bundle.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api800/artifact_bundle.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api600/artifact_bundle'
+
+module OneviewSDK
+  module ImageStreamer
+    module API800
+      # Artifact Bundle resource implementation for Image Streamer
+      class ArtifactBundle < OneviewSDK::ImageStreamer::API600::ArtifactBundle
+      end
+    end
+  end
+end

--- a/lib/oneview-sdk/image-streamer/resource/api800/deployment_group.rb
+++ b/lib/oneview-sdk/image-streamer/resource/api800/deployment_group.rb
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative '../api600/deployment_group'
+
+module OneviewSDK
+  module ImageStreamer
+    module API800
+      # Deployment Group resource implementation for Image Streamer
+      class DeploymentGroup < OneviewSDK::ImageStreamer::API600::DeploymentGroup
+      end
+    end
+  end
+end

--- a/spec/unit/image-streamer/resource/api1000/artifact_bundle_spec.rb
+++ b/spec/unit/image-streamer/resource/api1000/artifact_bundle_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API1000::ArtifactBundle
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API800' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API800::ArtifactBundle
+  end
+end

--- a/spec/unit/image-streamer/resource/api1000/deployment_group_spec.rb
+++ b/spec/unit/image-streamer/resource/api1000/deployment_group_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API1000::DeploymentGroup
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API800' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API800::DeploymentGroup
+  end
+end

--- a/spec/unit/image-streamer/resource/api1020/artifact_bundle_spec.rb
+++ b/spec/unit/image-streamer/resource/api1020/artifact_bundle_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API1020::ArtifactBundle
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API1000' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API1000::ArtifactBundle
+  end
+end

--- a/spec/unit/image-streamer/resource/api1020/deployment_group_spec.rb
+++ b/spec/unit/image-streamer/resource/api1020/deployment_group_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API1020::DeploymentGroup
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API1000' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API1000::DeploymentGroup
+  end
+end

--- a/spec/unit/image-streamer/resource/api1600/artifact_bundle_spec.rb
+++ b/spec/unit/image-streamer/resource/api1600/artifact_bundle_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API1600::ArtifactBundle
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API1020' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API1020::ArtifactBundle
+  end
+end

--- a/spec/unit/image-streamer/resource/api1600/deployment_group_spec.rb
+++ b/spec/unit/image-streamer/resource/api1600/deployment_group_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API1600::DeploymentGroup
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API1020' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API1020::DeploymentGroup
+  end
+end

--- a/spec/unit/image-streamer/resource/api500/artifact_bundle_spec.rb
+++ b/spec/unit/image-streamer/resource/api500/artifact_bundle_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API500::ArtifactBundle
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API300' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API300::ArtifactBundle
+  end
+end

--- a/spec/unit/image-streamer/resource/api500/deployment_group_spec.rb
+++ b/spec/unit/image-streamer/resource/api500/deployment_group_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API500::DeploymentGroup
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API300' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API300::DeploymentGroup
+  end
+end

--- a/spec/unit/image-streamer/resource/api600/artifact_bundle_spec.rb
+++ b/spec/unit/image-streamer/resource/api600/artifact_bundle_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API600::ArtifactBundle
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API500' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API500::ArtifactBundle
+  end
+end

--- a/spec/unit/image-streamer/resource/api600/deployment_group_spec.rb
+++ b/spec/unit/image-streamer/resource/api600/deployment_group_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API600::DeploymentGroup
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API500' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API500::DeploymentGroup
+  end
+end

--- a/spec/unit/image-streamer/resource/api800/artifact_bundle_spec.rb
+++ b/spec/unit/image-streamer/resource/api800/artifact_bundle_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API800::ArtifactBundle
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API600' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API600::ArtifactBundle
+  end
+end

--- a/spec/unit/image-streamer/resource/api800/deployment_group_spec.rb
+++ b/spec/unit/image-streamer/resource/api800/deployment_group_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+klass = OneviewSDK::ImageStreamer::API800::DeploymentGroup
+RSpec.describe klass do
+  include_context 'shared context'
+
+  it 'inherits from API600' do
+    expect(described_class).to be < OneviewSDK::ImageStreamer::API600::DeploymentGroup
+  end
+end


### PR DESCRIPTION
### Description
Added API 1600 support to artifact bundles and added supported deployment group files.

### Issues Resolved

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
